### PR TITLE
feat: add cosmo1 core acceptance corpus

### DIFF
--- a/fixtures/cosmo0/cosmo1/core-acceptance/README.md
+++ b/fixtures/cosmo0/cosmo1/core-acceptance/README.md
@@ -1,0 +1,45 @@
+# cosmo1 Core Acceptance Corpus
+
+This directory contains the first cosmo1-shaped source corpus for the future
+cosmo0 pipeline. The corpus is a design and acceptance target, not a working
+compiler implementation.
+
+## Path
+
+The corpus lives under `fixtures/cosmo0/cosmo1/core-acceptance/` because it is
+cosmo1-style source that will be validated by cosmo0 phases as they become
+available.
+
+## Conventions
+
+- Standard generic application uses the parser-supported compile-time spelling:
+  `Vec[Token]`, `Option[Span]`, `Result[ExprId, Diagnostic]`, `Map[Symbol, DefId]`,
+  `Set[Symbol]`, `Arena[Expr]`, and `Id[Expr]`.
+- Descriptor-backed standard values use the same application as constructor
+  targets, for example `Vec[DiagnosticLabel]()` and `Option[Token]::Some(token)`.
+- References are written as `&T` and `&mut T` in parameter positions, with
+  `&self` and `&mut self` for receiver methods.
+- Mutable state is modeled with `var` fields or locals and ordinary assignment.
+- Descriptor-backed standard types are used but not declared in this fixture.
+- The fixture avoids user-defined generic declarations, traits, reflection,
+  staging, closures, and full cosmo1 implementation logic.
+
+## Exercised Forms
+
+The corpus intentionally includes compiler-shaped declarations for source files,
+spans, diagnostics, symbols, tokens, AST nodes, arenas, typed identifiers, scopes,
+maps, sets, and parser state.
+
+It also includes representative expression forms: class fields, enum-style cases,
+methods, receiver references, mutation, field access, calls, assignments,
+conditionals, `while`/`loop`, descriptor-backed variant construction, and `match`.
+
+## Validation
+
+Current repository validation is lightweight:
+
+- The manifest lists the corpus path and phase intent.
+- The existing shared parser parses the corpus.
+
+Later cosmo0 work should consume this same file in order: subset elaboration,
+typed checking, LIR lowering, backend emission, and package-level validation.

--- a/fixtures/cosmo0/cosmo1/core-acceptance/cosmo1_core_acceptance.cos
+++ b/fixtures/cosmo0/cosmo1/core-acceptance/cosmo1_core_acceptance.cos
@@ -1,0 +1,323 @@
+// cosmo1 core acceptance corpus.
+// This is representative compiler-shaped source for future cosmo0 phases.
+// It is not a complete compiler implementation.
+
+class SourceFile {
+  val path: String
+  val text: String
+}
+
+type SourceId = Id[SourceFile]
+
+class Span {
+  val source: SourceId
+  val start: usize
+  val end: usize
+
+  def is_empty(&self): Bool = {
+    self.start == self.end
+  }
+
+  def contains(&self, offset: usize): Bool = {
+    self.start <= offset and offset < self.end
+  }
+}
+
+class Severity {
+  case Note
+  case Warning
+  case Error
+}
+
+class LabelStyle {
+  case Primary
+  case Secondary
+}
+
+class DiagnosticLabel {
+  val style: LabelStyle
+  val span: Span
+  val message: String
+}
+
+class FixIt {
+  val span: Span
+  val replacement: String
+}
+
+class Diagnostic {
+  val severity: Severity
+  val message: String
+  val labels: Vec[DiagnosticLabel]
+  val fix: Option[FixIt]
+
+  def primary_span(&self): Option[Span] = {
+    if (self.labels.size() == 0) {
+      Option[Span]::None
+    } else {
+      Option[Span]::Some(self.labels.get(0).span)
+    }
+  }
+}
+
+class DiagnosticSink {
+  var items: Vec[Diagnostic]
+
+  def push(&mut self, diagnostic: Diagnostic): Unit = {
+    self.items.push(diagnostic)
+  }
+
+  def append_from(&mut self, other: &DiagnosticSink): Unit = {
+    var index: usize = 0;
+    while (index < other.items.size()) {
+      self.items.push(other.items.get(index));
+      index = index + 1;
+    }
+  }
+}
+
+class Symbol {
+  val text: String
+}
+
+type SymbolId = Id[Symbol]
+
+class TokenKind {
+  case Identifier
+  case Number
+  case StringLiteral
+  case KeywordClass
+  case KeywordDef
+  case LeftParen
+  case RightParen
+  case Comma
+  case Equal
+  case EndOfFile
+}
+
+class Token {
+  val kind: TokenKind
+  val span: Span
+  val text: String
+}
+
+type TokenId = Id[Token]
+
+class Pattern {
+  case Wildcard(Span)
+  case Binding(Symbol, Span)
+  case Token(TokenKind, Span)
+}
+
+class MatchArm {
+  val pattern: Pattern
+  val body: Id[Expr]
+  val span: Span
+}
+
+class Expr {
+  case Missing(Span)
+  case Name(Symbol, Span)
+  case Literal(TokenId, Span)
+  case Call(Id[Expr], Vec[Id[Expr]], Span)
+  case Select(Id[Expr], Symbol, Span)
+  case Assign(Id[Expr], Id[Expr], Span)
+  case Match(Id[Expr], Vec[MatchArm], Span)
+  case Block(Vec[Id[Expr]], Span)
+}
+
+type ExprId = Id[Expr]
+
+class Ty {
+  case Error
+  case Unit
+  case Bool
+  case Int
+  case String
+  case Named(Symbol)
+  case Applied(Symbol, Vec[TyId])
+}
+
+type TyId = Id[Ty]
+
+class DefKind {
+  case Function
+  case Class
+  case Variant
+  case Field
+  case Local
+}
+
+class DefInfo {
+  val name: Symbol
+  val kind: DefKind
+  val span: Span
+}
+
+type DefId = Id[DefInfo]
+
+class Scope {
+  val parent: Option[ScopeId]
+  var values: Map[Symbol, DefId]
+
+  def define(&mut self, symbol: Symbol, def_id: DefId): Option[DefId] = {
+    val previous = self.values.get(symbol);
+    self.values.insert(symbol, def_id);
+    previous
+  }
+
+  def resolve(&self, symbol: Symbol): Option[DefId] = {
+    self.values.get(symbol)
+  }
+}
+
+type ScopeId = Id[Scope]
+
+class ModuleGraph {
+  var visited: Set[Symbol]
+  var imports: Map[Symbol, Vec[Symbol]]
+
+  def mark_seen(&mut self, module_name: Symbol): Bool = {
+    if (self.visited.contains(module_name)) {
+      false
+    } else {
+      self.visited.insert(module_name);
+      true
+    }
+  }
+
+  def add_import(&mut self, module_name: Symbol, dependency: Symbol): Unit = {
+    val current = self.imports.get(module_name);
+    current match {
+      case Option[Vec[Symbol]]::Some(list) => {
+        list.push(dependency)
+      }
+      case Option[Vec[Symbol]]::None => {
+        val list = Vec[Symbol]();
+        list.push(dependency);
+        self.imports.insert(module_name, list);
+      }
+    }
+  }
+}
+
+class ModuleArenas {
+  var sources: Arena[SourceFile]
+  var tokens: Arena[Token]
+  var expressions: Arena[Expr]
+  var types: Arena[Ty]
+  var definitions: Arena[DefInfo]
+  var scopes: Arena[Scope]
+
+  def add_expr(&mut self, expr: Expr): ExprId = {
+    self.expressions.alloc(expr)
+  }
+
+  def get_expr(&self, id: ExprId): &Expr = {
+    self.expressions.get(id)
+  }
+}
+
+class ParserState {
+  var tokens: Vec[Token]
+  var cursor: usize
+  var diagnostics: DiagnosticSink
+  var exprs: Arena[Expr]
+  val eof_span: Span
+
+  def at_end(&self): Bool = {
+    self.cursor >= self.tokens.size()
+  }
+
+  def current(&self): Option[Token] = {
+    if (self.at_end()) {
+      Option[Token]::None
+    } else {
+      Option[Token]::Some(self.tokens.get(self.cursor))
+    }
+  }
+
+  def advance(&mut self): Option[Token] = {
+    val token = self.current();
+    if (!self.at_end()) {
+      self.cursor = self.cursor + 1;
+    }
+    token
+  }
+
+  def recover_until(&mut self, stop: TokenKind): Unit = {
+    while (!self.at_end()) {
+      val current = self.current();
+      current match {
+        case Option[Token]::Some(token) => {
+          if (token.kind == stop) {
+            break
+          } else {
+            self.cursor = self.cursor + 1
+          }
+        }
+        case Option[Token]::None => {
+          break
+        }
+      }
+    }
+  }
+
+  def parse_name(&mut self): Result[ExprId, Diagnostic] = {
+    val current = self.advance();
+    current match {
+      case Option[Token]::Some(token) => {
+        token.kind match {
+          case TokenKind.Identifier => {
+            val symbol = Symbol(token.text);
+            val expr = Expr.Name(symbol, token.span);
+            val id = self.exprs.alloc(expr);
+            Result[ExprId, Diagnostic]::Ok(id)
+          }
+          case _ => {
+            val labels = Vec[DiagnosticLabel]();
+            labels.push(DiagnosticLabel(LabelStyle.Primary, token.span, "expected identifier"));
+            val diagnostic = Diagnostic(
+              Severity.Error,
+              "parser expected a name",
+              labels,
+              Option[FixIt]::None
+            );
+            self.diagnostics.push(diagnostic);
+            Result[ExprId, Diagnostic]::Err(diagnostic)
+          }
+        }
+      }
+      case Option[Token]::None => {
+        val labels = Vec[DiagnosticLabel]();
+        labels.push(DiagnosticLabel(LabelStyle.Primary, self.eof_span, "reached end of file"));
+        val diagnostic = Diagnostic(
+          Severity.Error,
+          "parser expected a name",
+          labels,
+          Option[FixIt]::None
+        );
+        self.diagnostics.push(diagnostic);
+        Result[ExprId, Diagnostic]::Err(diagnostic)
+      }
+    }
+  }
+
+  def scan_until_name(&mut self): Unit = {
+    loop {
+      val current = self.current();
+      current match {
+        case Option[Token]::Some(token) => {
+          if (token.kind == TokenKind.Identifier) {
+            break
+          } else {
+            self.cursor = self.cursor + 1
+          }
+        }
+        case Option[Token]::None => {
+          break
+        }
+      }
+    }
+  }
+}

--- a/fixtures/cosmo0/cosmo1/core-acceptance/manifest.json
+++ b/fixtures/cosmo0/cosmo1/core-acceptance/manifest.json
@@ -1,0 +1,49 @@
+{
+  "schema": "cosmo.acceptance-corpus.v1",
+  "name": "cosmo1-core-acceptance-corpus",
+  "status": "acceptance-target",
+  "description": "Representative cosmo1-shaped source forms for future cosmo0 parse, elaboration, typing, LIR, backend, and package validation.",
+  "files": [
+    {
+      "path": "fixtures/cosmo0/cosmo1/core-acceptance/cosmo1_core_acceptance.cos",
+      "role": "core-source",
+      "currentValidation": [
+        "discoverable",
+        "shared-parser"
+      ],
+      "futurePhases": [
+        "cosmo0-subset-elaboration",
+        "cosmo0-typing",
+        "cosmo0-lir-lowering",
+        "cosmo0-backend",
+        "cosmo0-package-validation"
+      ]
+    }
+  ],
+  "conventions": {
+    "standardGenericTypeApplication": "Name[Arg]",
+    "referenceTypes": [
+      "&T",
+      "&mut T",
+      "&self",
+      "&mut self"
+    ],
+    "descriptorBackedStandardTypes": [
+      "Vec[T]",
+      "Option[T]",
+      "Result[T, E]",
+      "Arena[T]",
+      "Id[T]",
+      "Map[K, V]",
+      "Set[T]"
+    ],
+    "excludedSourceFeatures": [
+      "user-defined generic declarations",
+      "traits",
+      "reflection",
+      "staging",
+      "closures",
+      "full compiler implementation logic"
+    ]
+  }
+}

--- a/openspec/changes/add-cosmo1-core-acceptance-corpus/design.md
+++ b/openspec/changes/add-cosmo1-core-acceptance-corpus/design.md
@@ -1,0 +1,85 @@
+## Context
+
+cosmo0 does not exist in this repository as an implemented compiler package yet,
+but its scope is already defined by the surrounding proposals: it should validate
+compiler-shaped cosmo1 source without growing into full Cosmo. The acceptance
+corpus provides one concrete source file that later cosmo0 phases can reuse as
+the pipeline matures.
+
+The corpus must therefore be representative enough to exercise the future subset
+boundary while remaining additive and harmless to the current full compiler path.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add one cosmo1-shaped source fixture under a cosmo0/cosmo1 validation path.
+- Capture the canonical source conventions used by the fixture.
+- Cover compiler-oriented data for spans, diagnostics, symbols, tokens, AST
+  nodes, typed IDs, arenas, scopes, maps, sets, and parser state.
+- Ensure the repository can discover the fixture and parse it with the shared
+  parser today.
+- Mark later cosmo0 phases as future consumers without requiring those phases in
+  this change.
+
+**Non-Goals:**
+
+- Implement cosmo0 phases.
+- Compile or type-check the corpus through the current full compiler.
+- Implement cosmo1 behavior.
+- Introduce user-defined generic declarations, traits, reflection, staging,
+  closures, or full compiler logic in the corpus.
+
+## Decisions
+
+### Store the corpus under fixtures/cosmo0/cosmo1
+
+The fixture lives at:
+
+```text
+fixtures/cosmo0/cosmo1/core-acceptance/cosmo1_core_acceptance.cos
+```
+
+This keeps it separate from existing full-compiler samples while making its role
+explicit: cosmo1-shaped source validated by future cosmo0 phases.
+
+Alternative considered: place it under `samples/`. That would make it look like a
+full compiler sample and invite current compilation expectations that this change
+intentionally avoids.
+
+### Use a manifest and README for phase intent
+
+The manifest records the file path, current validation level, future validation
+phases, and source conventions. The README explains the same decisions for
+humans.
+
+Alternative considered: rely only on comments in the source file. That would make
+test discovery and future phase ownership less explicit.
+
+### Validate parser compatibility only
+
+The current executable check ensures the manifest and source file exist and that
+the shared parser accepts the corpus. It does not run type checking or
+compilation.
+
+Alternative considered: add the corpus to full compiler sample tests. That would
+incorrectly require descriptor-backed cosmo0 standard types to exist in the full
+compiler path.
+
+## Risks / Trade-offs
+
+- Corpus drifts from future cosmo0 syntax -> Mitigation: the parser test pins the
+  current grammar, and later cosmo0 phases should update this file deliberately.
+- Fixture is mistaken for working cosmo1 code -> Mitigation: manifest, README,
+  and source header all mark it as an acceptance target.
+- Future phases need multiple files instead of one corpus -> Mitigation: keep this
+  file as the broad core target and let stage-specific changes add narrower
+  package fixtures later.
+
+## Migration Plan
+
+1. Add the corpus, manifest, README, and parser/discovery test.
+2. Reuse the corpus in cosmo0 subset elaboration once that phase exists.
+3. Promote the same file through typing, LIR lowering, backend, and package
+   validation as the corresponding cosmo0 features are implemented.
+4. Keep current validation at parser/discovery level until those phases exist.

--- a/openspec/changes/add-cosmo1-core-acceptance-corpus/specs/cosmo1-core-acceptance-corpus/spec.md
+++ b/openspec/changes/add-cosmo1-core-acceptance-corpus/specs/cosmo1-core-acceptance-corpus/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Core Acceptance Corpus Location
+
+The repository SHALL provide a cosmo1 core acceptance corpus under a cosmo0/cosmo1
+validation fixture area.
+
+#### Scenario: Corpus path is discoverable
+
+- **WHEN** repository tests or future cosmo0 tooling need the corpus path
+- **THEN** the corpus is available at
+  `fixtures/cosmo0/cosmo1/core-acceptance/cosmo1_core_acceptance.cos`
+- **AND** a manifest in the same directory lists the corpus path
+
+### Requirement: Corpus Source Conventions
+
+The corpus SHALL document the source conventions it uses for standard generic
+application, references, mutability, and descriptor-backed standard types.
+
+#### Scenario: Standard generic spelling is canonicalized
+
+- **WHEN** the corpus references descriptor-backed standard generic types
+- **THEN** it uses `Name[Arg]` syntax such as `Vec[Token]`, `Option[Span]`,
+  `Result[ExprId, Diagnostic]`, `Arena[Expr]`, `Id[Expr]`, `Map[Symbol, DefId]`,
+  and `Set[Symbol]`
+
+#### Scenario: References and mutability are represented
+
+- **WHEN** the corpus declares receiver or parameter references
+- **THEN** it uses `&self`, `&mut self`, `&T`, and `&mut T`
+- **AND** mutable state is represented with `var` fields or locals and assignment
+
+### Requirement: Compiler-Shaped Data Coverage
+
+The corpus SHALL include representative cosmo1 compiler data declarations without
+implementing compiler behavior.
+
+#### Scenario: Core compiler records are present
+
+- **WHEN** a later cosmo0 phase consumes the corpus
+- **THEN** it encounters source files, spans, diagnostics, symbols, tokens, AST
+  nodes, arenas, typed identifiers, scopes, maps, sets, and parser state
+
+#### Scenario: Standard containers are exercised
+
+- **WHEN** a later cosmo0 phase consumes the corpus
+- **THEN** it encounters relevant uses of `Vec`, `Option`, `Result`, `Arena`,
+  `Id`, `Map`, and `Set`
+
+### Requirement: Expression Form Coverage
+
+The corpus SHALL exercise the ordinary expression forms needed by compiler-shaped
+cosmo1 code.
+
+#### Scenario: Core expression forms are present
+
+- **WHEN** a later cosmo0 phase consumes the corpus
+- **THEN** it encounters methods, receiver references, mutation, field access,
+  calls, assignments, conditionals, loops, variant construction, and `match`
+
+### Requirement: Corpus Is Not a Full Compiler
+
+The corpus SHALL remain an acceptance target rather than a working cosmo1
+implementation.
+
+#### Scenario: Full-language features are excluded
+
+- **WHEN** the corpus source is reviewed or consumed by future cosmo0 tooling
+- **THEN** it does not declare user-defined generics, traits, reflection, staging,
+  closures, or full cosmo1 implementation logic
+
+#### Scenario: Current validation remains lightweight
+
+- **WHEN** the current repository test suite validates the corpus
+- **THEN** it verifies manifest discoverability and shared-parser acceptance
+- **AND** it does not require cosmo0 typing, LIR lowering, backend compilation, or
+  package validation until those phases exist

--- a/openspec/changes/add-cosmo1-core-acceptance-corpus/tasks.md
+++ b/openspec/changes/add-cosmo1-core-acceptance-corpus/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Corpus Scope
 
-- [ ] 1.1 Choose the acceptance corpus path under the cosmo0/cosmo1 validation area.
-- [ ] 1.2 Define the corpus conventions for canonical cosmo0 type application, references, mutability, and descriptor-backed standard types.
-- [ ] 1.3 List the cosmo1-style source forms the corpus is intended to exercise without implementing compiler behavior.
+- [x] 1.1 Choose the acceptance corpus path under the cosmo0/cosmo1 validation area.
+- [x] 1.2 Define the corpus conventions for canonical cosmo0 type application, references, mutability, and descriptor-backed standard types.
+- [x] 1.3 List the cosmo1-style source forms the corpus is intended to exercise without implementing compiler behavior.
 
 ## 2. Corpus Source
 
-- [ ] 2.1 Add one Cosmo source file containing representative span, symbol, diagnostic, token, AST, arena, and parser-state declarations.
-- [ ] 2.2 Include standard generic uses for `Vec`, `Option`, `Result`, `Arena`, `Id`, `Map`, and `Set` where they are relevant to compiler-shaped data.
-- [ ] 2.3 Include expression examples for methods, `&self`, `&mut self`, mutation, field access, calls, assignments, conditionals, loops, variant construction, and match.
-- [ ] 2.4 Keep the file free of user-defined generics, host `Type`, traits, reflection, staging, closures, and full cosmo1 implementation logic.
+- [x] 2.1 Add one Cosmo source file containing representative span, symbol, diagnostic, token, AST, arena, and parser-state declarations.
+- [x] 2.2 Include standard generic uses for `Vec`, `Option`, `Result`, `Arena`, `Id`, `Map`, and `Set` where they are relevant to compiler-shaped data.
+- [x] 2.3 Include expression examples for methods, `&self`, `&mut self`, mutation, field access, calls, assignments, conditionals, loops, variant construction, and match.
+- [x] 2.4 Keep the file free of user-defined generics, host `Type`, traits, reflection, staging, closures, and full cosmo1 implementation logic.
 
 ## 3. Corpus Validation
 
-- [ ] 3.1 Add a lightweight test or manifest entry that ensures the corpus file is discoverable by the repository test infrastructure.
-- [ ] 3.2 Mark the corpus as an acceptance target for later cosmo0 phases rather than requiring full cosmo0 compilation immediately.
-- [ ] 3.3 Document which later phases are expected to consume the corpus as parse, elaboration, typing, LIR, backend, and package validation mature.
+- [x] 3.1 Add a lightweight test or manifest entry that ensures the corpus file is discoverable by the repository test infrastructure.
+- [x] 3.2 Mark the corpus as an acceptance target for later cosmo0 phases rather than requiring full cosmo0 compilation immediately.
+- [x] 3.3 Document which later phases are expected to consume the corpus as parse, elaboration, typing, LIR, backend, and package validation mature.

--- a/packages/cosmo/src/test/scala/cosmo/Cosmo1CoreAcceptanceCorpusTests.scala
+++ b/packages/cosmo/src/test/scala/cosmo/Cosmo1CoreAcceptanceCorpusTests.scala
@@ -1,0 +1,32 @@
+package cosmo
+
+class Cosmo1CoreAcceptanceCorpusTest extends TestBase:
+  private val corpusPath =
+    "fixtures/cosmo0/cosmo1/core-acceptance/cosmo1_core_acceptance.cos"
+  private val manifestPath =
+    "fixtures/cosmo0/cosmo1/core-acceptance/manifest.json"
+
+  test("manifest lists core acceptance corpus") {
+    assert(NodeFs.existsSync(manifestPath), s"missing manifest: $manifestPath")
+    assert(NodeFs.existsSync(corpusPath), s"missing corpus: $corpusPath")
+
+    val manifest =
+      NodeFs.readFileSync(manifestPath, "utf8").asInstanceOf[String]
+    assert(
+      manifest.contains(corpusPath),
+      s"manifest does not list corpus path: $corpusPath",
+    )
+    assert(
+      manifest.contains("\"status\": \"acceptance-target\""),
+      "manifest must mark the corpus as a future acceptance target",
+    )
+  }
+
+  test("core acceptance corpus parses through shared parser") {
+    val source = NodeFs.readFileSync(corpusPath, "utf8").asInstanceOf[String]
+    val parsed = compiler.parse(source)
+
+    assert(parsed.isDefined, s"failed to parse corpus: $corpusPath")
+    assert(parsed.get.stmts.nonEmpty, s"corpus has no top-level forms: $corpusPath")
+  }
+end Cosmo1CoreAcceptanceCorpusTest


### PR DESCRIPTION
## Summary
- add a cosmo1-shaped core acceptance corpus under `fixtures/cosmo0/cosmo1/core-acceptance`
- document corpus conventions, scope, and future cosmo0 phase intent in OpenSpec
- add a shared-parser test that verifies the manifest discovers the corpus and the source parses successfully

## Notes
- the corpus is an acceptance target, not a full cosmo1 implementation
- current validation stays lightweight and does not require cosmo0 typing, lowering, backend, or package validation