### PR TITLE
feat: add cosmo0 untyped elaborator

### DIFF
--- a/openspec/changes/add-cosmo0-untyped-repr-elaborator/tasks.md
+++ b/openspec/changes/add-cosmo0-untyped-repr-elaborator/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Untyped Representation
 
-- [ ] 1.1 Define untyped module, declaration, statement, expression, pattern, parameter, and type representation nodes.
-- [ ] 1.2 Add stable source span attachment to every untyped node that can produce diagnostics.
-- [ ] 1.3 Represent type applications, references, paths, calls, selections, blocks, variants, and match constructs without depending on full Cosmo IR.
+- [x] 1.1 Define untyped module, declaration, statement, expression, pattern, parameter, and type representation nodes.
+- [x] 1.2 Add stable source span attachment to every untyped node that can produce diagnostics.
+- [x] 1.3 Represent type applications, references, paths, calls, selections, blocks, variants, and match constructs without depending on full Cosmo IR.
 
 ## 2. Elaboration Pipeline
 
-- [ ] 2.1 Add an elaborator entry point from shared parser syntax into the cosmo0 untyped representation.
-- [ ] 2.2 Normalize parser AST forms that are syntactic sugar into explicit cosmo0 untyped nodes.
-- [ ] 2.3 Convert compile-time apply syntax used for canonical standard generic type application into untyped type representations only in type positions.
-- [ ] 2.4 Preserve enough original source context to report unsupported constructs with useful diagnostics.
+- [x] 2.1 Add an elaborator entry point from shared parser syntax into the cosmo0 untyped representation.
+- [x] 2.2 Normalize parser AST forms that are syntactic sugar into explicit cosmo0 untyped nodes.
+- [x] 2.3 Convert compile-time apply syntax used for canonical standard generic type application into untyped type representations only in type positions.
+- [x] 2.4 Preserve enough original source context to report unsupported constructs with useful diagnostics.
 
 ## 3. Subset Boundary
 
-- [ ] 3.1 Accept non-generic classes, enum-style cases, functions, fields, locals, simple aliases, imports, blocks, calls, selections, assignments, returns, conditionals, loops, and match expressions.
-- [ ] 3.2 Reject user-defined generic classes, functions, traits, impls, explicit type parameters, host `Type`, type functions, reflection, staging, quotation, paste operations, closures, lambdas, and unsupported higher-order APIs.
-- [ ] 3.3 Reject generic type applications outside registered standard-generic syntax positions.
-- [ ] 3.4 Emit deterministic diagnostics for every rejected construct covered by the subset boundary.
+- [x] 3.1 Accept non-generic classes, enum-style cases, functions, fields, locals, simple aliases, imports, blocks, calls, selections, assignments, returns, conditionals, loops, and match expressions.
+- [x] 3.2 Reject user-defined generic classes, functions, traits, impls, explicit type parameters, host `Type`, type functions, reflection, staging, quotation, paste operations, closures, lambdas, and unsupported higher-order APIs.
+- [x] 3.3 Reject generic type applications outside registered standard-generic syntax positions.
+- [x] 3.4 Emit deterministic diagnostics for every rejected construct covered by the subset boundary.
 
 ## 4. Tests
 
-- [ ] 4.1 Add positive elaboration tests for representative accepted core declarations and expressions.
-- [ ] 4.2 Add negative elaboration tests for rejected full-language constructs.
-- [ ] 4.3 Add span-preservation tests for accepted nodes and rejection diagnostics.
+- [x] 4.1 Add positive elaboration tests for representative accepted core declarations and expressions.
+- [x] 4.2 Add negative elaboration tests for rejected full-language constructs.
+- [x] 4.3 Add span-preservation tests for accepted nodes and rejection diagnostics.

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -6,114 +6,114 @@ import fastparse.Parsed
 import fastparse.parse as fastParse
 
 final class Cosmo0:
-  def parse(sourceText: String): Cosmo0Result[Cosmo0ParsedModule] =
-    parse(Cosmo0SourceFile("<memory>", sourceText))
+  def parse(sourceText: String): Result[ParsedModule] =
+    parse(SourceFile("<memory>", sourceText))
 
-  def parse(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0ParsedModule] =
+  def parse(source: SourceFile): Result[ParsedModule] =
     try
       fastParse(source.text, Parser.root(_)) match
         case Parsed.Success(ast, _) =>
-          Cosmo0Result.success(
-            Cosmo0Phase.Parse,
-            Cosmo0ParsedModule(source, ast),
+          Result.success(
+            Phase.Parse,
+            ParsedModule(source, ast),
           )
         case failure: Parsed.Failure =>
-          Cosmo0Result.failure(
-            Cosmo0Phase.Parse,
+          Result.failure(
+            Phase.Parse,
             List(parseFailureDiagnostic(source, failure)),
           )
     catch
       case NonFatal(error) =>
-        Cosmo0Result.failure(
-          Cosmo0Phase.Parse,
+        Result.failure(
+          Phase.Parse,
           List(
-            Cosmo0Diagnostic(
-              Cosmo0Phase.Parse,
-              Cosmo0DiagnosticSeverity.Error,
+            Diagnostic(
+              Phase.Parse,
+              DiagnosticSeverity.Error,
               "cosmo0.parse.exception",
               Option(error.getMessage).getOrElse(error.getClass.getName),
             ),
           ),
         )
 
-  def check(sourceText: String): Cosmo0Result[Cosmo0CheckedModule] =
-    check(Cosmo0SourceFile("<memory>", sourceText))
+  def check(sourceText: String): Result[CheckedModule] =
+    check(SourceFile("<memory>", sourceText))
 
-  def elaborate(sourceText: String): Cosmo0Result[Cosmo0UntypedModule] =
-    elaborate(Cosmo0SourceFile("<memory>", sourceText))
+  def elaborate(sourceText: String): Result[UntypedModule] =
+    elaborate(SourceFile("<memory>", sourceText))
 
-  def elaborate(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0UntypedModule] =
+  def elaborate(source: SourceFile): Result[UntypedModule] =
     parse(source) match
       case parsed if parsed.isSuccess =>
-        Cosmo0UntypedElaborator().elaborate(parsed.value.get)
+        UntypedElaborator().elaborate(parsed.value.get)
       case failed =>
-        Cosmo0Result.failure(Cosmo0Phase.Check, failed.diagnostics)
+        Result.failure(Phase.Check, failed.diagnostics)
 
-  def check(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0CheckedModule] =
+  def check(source: SourceFile): Result[CheckedModule] =
     elaborate(source) match
       case elaborated if elaborated.isSuccess =>
-        Cosmo0Result.pending(
-          Cosmo0Phase.Check,
+        Result.pending(
+          Phase.Check,
           pendingDiagnostic(
-            Cosmo0Phase.Check,
+            Phase.Check,
             "cosmo0.check.pending",
             "cosmo0 source typing is not implemented yet",
           ),
         )
       case unsupported if unsupported.isUnsupported =>
-        Cosmo0Result(
-          Cosmo0Phase.Check,
-          Cosmo0PhaseStatus.Unsupported,
+        Result(
+          Phase.Check,
+          PhaseStatus.Unsupported,
           None,
           unsupported.diagnostics,
         )
       case failed =>
-        Cosmo0Result.failure(Cosmo0Phase.Check, failed.diagnostics)
+        Result.failure(Phase.Check, failed.diagnostics)
 
-  def compile(sourceText: String): Cosmo0Result[Cosmo0CompiledModule] =
-    compile(Cosmo0SourceFile("<memory>", sourceText))
+  def compile(sourceText: String): Result[CompiledModule] =
+    compile(SourceFile("<memory>", sourceText))
 
-  def compile(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0CompiledModule] =
+  def compile(source: SourceFile): Result[CompiledModule] =
     check(source) match
       case checked if checked.isFailure =>
-        Cosmo0Result.failure(Cosmo0Phase.Compile, checked.diagnostics)
+        Result.failure(Phase.Compile, checked.diagnostics)
       case checked if checked.isUnsupported =>
-        Cosmo0Result(
-          Cosmo0Phase.Compile,
-          Cosmo0PhaseStatus.Unsupported,
+        Result(
+          Phase.Compile,
+          PhaseStatus.Unsupported,
           None,
           checked.diagnostics,
         )
       case _ =>
-        Cosmo0Result.unsupported(
-          Cosmo0Phase.Compile,
+        Result.unsupported(
+          Phase.Compile,
           pendingDiagnostic(
-            Cosmo0Phase.Compile,
+            Phase.Compile,
             "cosmo0.compile.unsupported",
             "cosmo0 compilation is not implemented yet",
           ),
         )
 
   private def parseFailureDiagnostic(
-      source: Cosmo0SourceFile,
+      source: SourceFile,
       failure: Parsed.Failure,
-  ): Cosmo0Diagnostic =
-    Cosmo0Diagnostic(
-      Cosmo0Phase.Parse,
-      Cosmo0DiagnosticSeverity.Error,
+  ): Diagnostic =
+    Diagnostic(
+      Phase.Parse,
+      DiagnosticSeverity.Error,
       "cosmo0.parse.failed",
       failure.trace().longAggregateMsg,
       Some(source.span(failure.index, failure.index)),
     )
 
   private def pendingDiagnostic(
-      phase: Cosmo0Phase,
+      phase: Phase,
       code: String,
       message: String,
-  ): Cosmo0Diagnostic =
-    Cosmo0Diagnostic(
+  ): Diagnostic =
+    Diagnostic(
       phase,
-      Cosmo0DiagnosticSeverity.Info,
+      DiagnosticSeverity.Info,
       code,
       message,
     )

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -39,16 +39,33 @@ final class Cosmo0:
   def check(sourceText: String): Cosmo0Result[Cosmo0CheckedModule] =
     check(Cosmo0SourceFile("<memory>", sourceText))
 
-  def check(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0CheckedModule] =
+  def elaborate(sourceText: String): Cosmo0Result[Cosmo0UntypedModule] =
+    elaborate(Cosmo0SourceFile("<memory>", sourceText))
+
+  def elaborate(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0UntypedModule] =
     parse(source) match
       case parsed if parsed.isSuccess =>
+        Cosmo0UntypedElaborator().elaborate(parsed.value.get)
+      case failed =>
+        Cosmo0Result.failure(Cosmo0Phase.Check, failed.diagnostics)
+
+  def check(source: Cosmo0SourceFile): Cosmo0Result[Cosmo0CheckedModule] =
+    elaborate(source) match
+      case elaborated if elaborated.isSuccess =>
         Cosmo0Result.pending(
           Cosmo0Phase.Check,
           pendingDiagnostic(
             Cosmo0Phase.Check,
             "cosmo0.check.pending",
-            "cosmo0 subset checking is not implemented yet",
+            "cosmo0 source typing is not implemented yet",
           ),
+        )
+      case unsupported if unsupported.isUnsupported =>
+        Cosmo0Result(
+          Cosmo0Phase.Check,
+          Cosmo0PhaseStatus.Unsupported,
+          None,
+          unsupported.diagnostics,
         )
       case failed =>
         Cosmo0Result.failure(Cosmo0Phase.Check, failed.diagnostics)
@@ -60,6 +77,13 @@ final class Cosmo0:
     check(source) match
       case checked if checked.isFailure =>
         Cosmo0Result.failure(Cosmo0Phase.Compile, checked.diagnostics)
+      case checked if checked.isUnsupported =>
+        Cosmo0Result(
+          Cosmo0Phase.Compile,
+          Cosmo0PhaseStatus.Unsupported,
+          None,
+          checked.diagnostics,
+        )
       case _ =>
         Cosmo0Result.unsupported(
           Cosmo0Phase.Compile,

--- a/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
@@ -84,12 +84,14 @@ final class UntypedElaborator(
           )
 
     private def importDecl(node: Import): Option[UntypedImport] =
-      val path = pathFromNode(node.path, Some(nodeSpan(node)))
-      val dest = node.dest.map(pathFromNode(_, Some(nodeSpan(node))))
-      for
-        p <- path
-        d <- sequence(dest.toList).map(_.headOption)
-      yield UntypedImport(p, d, nodeSpan(node))
+      val span = nodeSpan(node)
+      val path = pathFromNode(node.path, Some(span))
+      val dest = node.dest.fold[Option[Option[UntypedPath]]](Some(None)) { destNode =>
+        pathFromNode(destNode, Some(span)).map(Some(_))
+      }
+      path.zip(dest).map { case (p, d) =>
+        UntypedImport(p, d, span)
+      }
 
     private def classDecl(node: Class): Option[UntypedClass] =
       if node.ab then
@@ -165,36 +167,47 @@ final class UntypedElaborator(
           "user-defined generic functions are outside the initial cosmo0 subset",
         )
       else
-        val params = node.params.getOrElse(Nil).map(param)
-        val returnType = node.ret.map(typeFromNode(_, Some(nodeSpan(node))))
-        val body = node.rhs.map(expr)
-        for
-          ps <- sequence(params)
-          rt <- sequence(returnType.toList).map(_.headOption)
-          b <- sequence(body.toList).map(_.headOption)
-        yield UntypedFunction(node.name.name, ps, rt, b, nodeSpan(node))
+        val span = nodeSpan(node)
+        val params = sequence(node.params.getOrElse(Nil).map(param))
+        val returnType = node.ret.fold[Option[Option[UntypedType]]](Some(None)) { ret =>
+          typeFromNode(ret, Some(span)).map(Some(_))
+        }
+        val body = node.rhs.fold[Option[Option[UntypedExpr]]](Some(None)) { rhs =>
+          expr(rhs).map(Some(_))
+        }
+        params.zip(returnType).zip(body).map { case ((ps, rt), b) =>
+          UntypedFunction(node.name.name, ps, rt, b, span)
+        }
 
     private def valueDecl(
         node: Val,
         kind: UntypedValueKind,
     ): Option[UntypedValueDecl] =
-      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
-      val init = node.init.map(expr)
-      for
-        t <- sequence(valueType.toList).map(_.headOption)
-        i <- sequence(init.toList).map(_.headOption)
-      yield UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
+      val span = nodeSpan(node)
+      val valueType = node.ty.fold[Option[Option[UntypedType]]](Some(None)) { ty =>
+        typeFromNode(ty, Some(span)).map(Some(_))
+      }
+      val init = node.init.fold[Option[Option[UntypedExpr]]](Some(None)) { value =>
+        expr(value).map(Some(_))
+      }
+      valueType.zip(init).map { case (t, i) =>
+        UntypedValueDecl(kind, node.name.name, t, i, span)
+      }
 
     private def valueDecl(
         node: Var,
         kind: UntypedValueKind,
     ): Option[UntypedValueDecl] =
-      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
-      val init = node.init.map(expr)
-      for
-        t <- sequence(valueType.toList).map(_.headOption)
-        i <- sequence(init.toList).map(_.headOption)
-      yield UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
+      val span = nodeSpan(node)
+      val valueType = node.ty.fold[Option[Option[UntypedType]]](Some(None)) { ty =>
+        typeFromNode(ty, Some(span)).map(Some(_))
+      }
+      val init = node.init.fold[Option[Option[UntypedExpr]]](Some(None)) { value =>
+        expr(value).map(Some(_))
+      }
+      valueType.zip(init).map { case (t, i) =>
+        UntypedValueDecl(kind, node.name.name, t, i, span)
+      }
 
     private def typeAlias(node: Typ): Option[UntypedTypeAlias] =
       node.init.orElse(node.ty) match
@@ -255,12 +268,16 @@ final class UntypedElaborator(
           "explicit compile-time parameters are outside the initial cosmo0 subset",
         )
       else
-        val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
-        val default = node.init.map(expr)
-        for
-          t <- sequence(valueType.toList).map(_.headOption)
-          d <- sequence(default.toList).map(_.headOption)
-        yield UntypedParam(node.name.name, t, d, nodeSpan(node))
+        val span = nodeSpan(node)
+        val valueType = node.ty.fold[Option[Option[UntypedType]]](Some(None)) { ty =>
+          typeFromNode(ty, Some(span)).map(Some(_))
+        }
+        val default = node.init.fold[Option[Option[UntypedExpr]]](Some(None)) { value =>
+          expr(value).map(Some(_))
+        }
+        valueType.zip(default).map { case (t, d) =>
+          UntypedParam(node.name.name, t, d, span)
+        }
 
     private def blockItem(node: syntax.Node): Option[UntypedBlockItem] =
       unwrapSemi(node) match
@@ -273,23 +290,31 @@ final class UntypedElaborator(
         node: Val,
         kind: UntypedValueKind,
     ): Option[UntypedLocal] =
-      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
-      val init = node.init.map(expr)
-      for
-        t <- sequence(valueType.toList).map(_.headOption)
-        i <- sequence(init.toList).map(_.headOption)
-      yield UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
+      val span = nodeSpan(node)
+      val valueType = node.ty.fold[Option[Option[UntypedType]]](Some(None)) { ty =>
+        typeFromNode(ty, Some(span)).map(Some(_))
+      }
+      val init = node.init.fold[Option[Option[UntypedExpr]]](Some(None)) { value =>
+        expr(value).map(Some(_))
+      }
+      valueType.zip(init).map { case (t, i) =>
+        UntypedLocal(kind, node.name.name, t, i, span)
+      }
 
     private def local(
         node: Var,
         kind: UntypedValueKind,
     ): Option[UntypedLocal] =
-      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
-      val init = node.init.map(expr)
-      for
-        t <- sequence(valueType.toList).map(_.headOption)
-        i <- sequence(init.toList).map(_.headOption)
-      yield UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
+      val span = nodeSpan(node)
+      val valueType = node.ty.fold[Option[Option[UntypedType]]](Some(None)) { ty =>
+        typeFromNode(ty, Some(span)).map(Some(_))
+      }
+      val init = node.init.fold[Option[Option[UntypedExpr]]](Some(None)) { value =>
+        expr(value).map(Some(_))
+      }
+      valueType.zip(init).map { case (t, i) =>
+        UntypedLocal(kind, node.name.name, t, i, span)
+      }
 
     private def expr(node: syntax.Node): Option[UntypedExpr] =
       unwrapSemi(node) match
@@ -352,11 +377,13 @@ final class UntypedElaborator(
         case Some(UnOp(op, lhs)) =>
           expr(lhs).map(value => UntypedUnary(op, value, nodeSpan(node)))
         case Some(If(cond, thenBranch, elseBranch)) =>
-          for
-            c <- expr(cond)
-            t <- expr(thenBranch)
-            e <- sequence(elseBranch.map(expr).toList).map(_.headOption)
-          yield UntypedIf(c, t, e, nodeSpan(node))
+          val span = nodeSpan(node)
+          val elseValue = elseBranch.fold[Option[Option[UntypedExpr]]](Some(None)) { branch =>
+            expr(branch).map(Some(_))
+          }
+          expr(cond).zip(expr(thenBranch)).zip(elseValue).map { case ((c, t), e) =>
+            UntypedIf(c, t, e, span)
+          }
         case Some(Loop(body)) =>
           expr(body).map(UntypedLoop(_, nodeSpan(node)))
         case Some(While(cond, body)) =>
@@ -461,12 +488,13 @@ final class UntypedElaborator(
           )
 
     private def matchArm(node: Case): Option[UntypedMatchArm] =
-      val p = pattern(node.cond)
-      val b = node.body.map(expr)
-      for
-        patternValue <- p
-        bodyValue <- sequence(b.toList).map(_.headOption)
-      yield UntypedMatchArm(patternValue, bodyValue, nodeSpan(node))
+      val span = nodeSpan(node)
+      val body = node.body.fold[Option[Option[UntypedExpr]]](Some(None)) { bodyNode =>
+        expr(bodyNode).map(Some(_))
+      }
+      pattern(node.cond).zip(body).map { case (patternValue, bodyValue) =>
+        UntypedMatchArm(patternValue, bodyValue, span)
+      }
 
     private def pattern(node: syntax.Node): Option[UntypedPattern] =
       node match

--- a/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
@@ -1,0 +1,612 @@
+package cosmo0
+
+import scala.collection.mutable.ListBuffer
+
+import cosmo.syntax
+import cosmo.syntax.*
+
+object Cosmo0UntypedElaborator:
+  val defaultStandardGenericNames: Set[String] =
+    Set("Arena", "Box", "Id", "Map", "Option", "Ptr", "Ref", "RefMut", "Result", "Set", "Vec")
+
+  def apply(): Cosmo0UntypedElaborator =
+    new Cosmo0UntypedElaborator(defaultStandardGenericNames)
+
+final class Cosmo0UntypedElaborator(
+    standardGenericNames: Set[String],
+):
+  def elaborate(parsed: Cosmo0ParsedModule): Cosmo0Result[Cosmo0UntypedModule] =
+    val state = State(parsed.source, standardGenericNames)
+    val declarations = parsed.ast.stmts.flatMap(state.moduleDecl)
+    val diagnostics = state.diagnostics.toList
+
+    if diagnostics.isEmpty then
+      Cosmo0Result.success(
+        Cosmo0Phase.Check,
+        Cosmo0UntypedModule(
+          parsed.source,
+          declarations,
+          state.nodeSpan(parsed.ast),
+        ),
+      )
+    else
+      Cosmo0Result(
+        Cosmo0Phase.Check,
+        Cosmo0PhaseStatus.Unsupported,
+        None,
+        diagnostics,
+      )
+
+  private final class State(
+      source: Cosmo0SourceFile,
+      standardGenericNames: Set[String],
+  ):
+    val diagnostics: ListBuffer[Cosmo0Diagnostic] = ListBuffer.empty
+
+    private val assignmentOps =
+      Set("=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=")
+
+    private val higherOrderMethodNames =
+      Set("filter", "flatMap", "fold", "forEach", "foreach", "map")
+
+    def moduleDecl(node: syntax.Node): Option[Cosmo0UntypedDecl] =
+      unwrapSemi(node) match
+        case None => None
+        case Some(importNode: Import) => importDecl(importNode)
+        case Some(classNode: Class)   => classDecl(classNode)
+        case Some(defNode: Def)       => functionDecl(defNode)
+        case Some(valueNode: Val)     => valueDecl(valueNode, Cosmo0UntypedValueKind.Val)
+        case Some(valueNode: Var)     => valueDecl(valueNode, Cosmo0UntypedValueKind.Var)
+        case Some(typeNode: Typ)      => typeAlias(typeNode)
+        case Some(implNode: Impl) =>
+          unsupported(
+            implNode,
+            "cosmo0.elaborate.unsupported.impl",
+            "impl declarations are outside the initial cosmo0 subset",
+          )
+        case Some(decorated: Decorate) =>
+          unsupported(
+            decorated,
+            "cosmo0.elaborate.unsupported.decorator",
+            "decorators and staging annotations are outside the initial cosmo0 subset",
+          )
+        case Some(caseNode: Case) =>
+          unsupported(
+            caseNode,
+            "cosmo0.elaborate.unsupported.top-level-case",
+            "case variants are only supported inside cosmo0 classes",
+          )
+        case Some(other) =>
+          unsupported(
+            other,
+            "cosmo0.elaborate.unsupported.top-level",
+            s"${constructName(other)} is not a supported top-level cosmo0 declaration",
+          )
+
+    private def importDecl(node: Import): Option[Cosmo0UntypedImport] =
+      val path = pathFromNode(node.path, Some(nodeSpan(node)))
+      val dest = node.dest.map(pathFromNode(_, Some(nodeSpan(node))))
+      for
+        p <- path
+        d <- sequence(dest.toList).map(_.headOption)
+      yield Cosmo0UntypedImport(p, d, nodeSpan(node))
+
+    private def classDecl(node: Class): Option[Cosmo0UntypedClass] =
+      if node.ab then
+        unsupported(
+          node,
+          "cosmo0.elaborate.unsupported.trait",
+          "traits are outside the initial cosmo0 subset",
+        )
+      else if hasExplicitTypeParams(node.ps) then
+        unsupported(
+          node,
+          "cosmo0.elaborate.unsupported.generic-class",
+          "user-defined generic classes are outside the initial cosmo0 subset",
+        )
+      else if node.ps.exists(_.nonEmpty) then
+        unsupported(
+          node,
+          "cosmo0.elaborate.unsupported.class-params",
+          "class parameter lists are outside the initial cosmo0 subset",
+        )
+      else
+        val members = classMembers(node.body)
+        sequence(members).map(Cosmo0UntypedClass(node.name.name, _, nodeSpan(node)))
+
+    private def classMembers(node: syntax.Node): List[Option[Cosmo0UntypedClassMember]] =
+      unwrapSemi(node) match
+        case None => Nil
+        case Some(block: Block) =>
+          block.stmts.map(classMember)
+        case Some(caseBlock: CaseBlock) =>
+          caseBlock.stmts.map(variantDecl)
+        case Some(other) =>
+          List(
+            unsupported(
+              other,
+              "cosmo0.elaborate.unsupported.class-body",
+              "cosmo0 class bodies must be blocks containing fields, methods, aliases, or case variants",
+            ),
+          )
+
+    private def classMember(node: syntax.Node): Option[Cosmo0UntypedClassMember] =
+      unwrapSemi(node) match
+        case None => None
+        case Some(valueNode: Val) => valueDecl(valueNode, Cosmo0UntypedValueKind.Val)
+        case Some(valueNode: Var) => valueDecl(valueNode, Cosmo0UntypedValueKind.Var)
+        case Some(defNode: Def)   => functionDecl(defNode)
+        case Some(typeNode: Typ)  => typeAlias(typeNode)
+        case Some(caseNode: Case) => variantDecl(caseNode)
+        case Some(decorated: Decorate) =>
+          unsupported(
+            decorated,
+            "cosmo0.elaborate.unsupported.decorator",
+            "decorators and staging annotations are outside the initial cosmo0 subset",
+          )
+        case Some(implNode: Impl) =>
+          unsupported(
+            implNode,
+            "cosmo0.elaborate.unsupported.impl",
+            "impl declarations are outside the initial cosmo0 subset",
+          )
+        case Some(other) =>
+          unsupported(
+            other,
+            "cosmo0.elaborate.unsupported.class-member",
+            s"${constructName(other)} is not a supported cosmo0 class member",
+          )
+
+    private def functionDecl(node: Def): Option[Cosmo0UntypedFunction] =
+      if hasExplicitTypeParams(node.params) then
+        unsupported(
+          node,
+          "cosmo0.elaborate.unsupported.generic-function",
+          "user-defined generic functions are outside the initial cosmo0 subset",
+        )
+      else
+        val params = node.params.getOrElse(Nil).map(param)
+        val returnType = node.ret.map(typeFromNode(_, Some(nodeSpan(node))))
+        val body = node.rhs.map(expr)
+        for
+          ps <- sequence(params)
+          rt <- sequence(returnType.toList).map(_.headOption)
+          b <- sequence(body.toList).map(_.headOption)
+        yield Cosmo0UntypedFunction(node.name.name, ps, rt, b, nodeSpan(node))
+
+    private def valueDecl(
+        node: Val,
+        kind: Cosmo0UntypedValueKind,
+    ): Option[Cosmo0UntypedValueDecl] =
+      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
+      val init = node.init.map(expr)
+      for
+        t <- sequence(valueType.toList).map(_.headOption)
+        i <- sequence(init.toList).map(_.headOption)
+      yield Cosmo0UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
+
+    private def valueDecl(
+        node: Var,
+        kind: Cosmo0UntypedValueKind,
+    ): Option[Cosmo0UntypedValueDecl] =
+      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
+      val init = node.init.map(expr)
+      for
+        t <- sequence(valueType.toList).map(_.headOption)
+        i <- sequence(init.toList).map(_.headOption)
+      yield Cosmo0UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
+
+    private def typeAlias(node: Typ): Option[Cosmo0UntypedTypeAlias] =
+      node.init.orElse(node.ty) match
+        case Some(targetNode) =>
+          typeFromNode(targetNode, Some(nodeSpan(node))).map(target =>
+            Cosmo0UntypedTypeAlias(node.name.name, target, nodeSpan(node)),
+          )
+        case None =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.type-alias-target",
+            "cosmo0 type aliases must name a concrete target type",
+          )
+
+    private def variantDecl(node: Case): Option[Cosmo0UntypedVariant] =
+      if node.body.nonEmpty then
+        unsupported(
+          node,
+          "cosmo0.elaborate.unsupported.variant-body",
+          "enum-style cosmo0 case variants cannot define branch bodies",
+        )
+      else
+        node.cond match
+          case name: Ident =>
+            Some(Cosmo0UntypedVariant(name.name, Nil, nodeSpan(node)))
+          case Apply(name: Ident, args, false) =>
+            val fields = args.map(variantField)
+            sequence(fields).map(Cosmo0UntypedVariant(name.name, _, nodeSpan(node)))
+          case other =>
+            unsupported(
+              other,
+              "cosmo0.elaborate.unsupported.variant",
+              "cosmo0 case variants must be a variant name with optional payload types",
+            )
+
+    private def variantField(node: syntax.Node): Option[Cosmo0UntypedVariantField] =
+      node match
+        case KeyedArg(name: Ident, valueType) =>
+          typeFromNode(valueType, Some(nodeSpan(node))).map(t =>
+            Cosmo0UntypedVariantField(Some(name.name), t, nodeSpan(node)),
+          )
+        case KeyedArg(_, _) =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.variant-field",
+            "named variant fields must use an identifier field name",
+          )
+        case other =>
+          typeFromNode(other, Some(nodeSpan(other))).map(t =>
+            Cosmo0UntypedVariantField(None, t, nodeSpan(other)),
+          )
+
+    private def param(node: Param): Option[Cosmo0UntypedParam] =
+      if node.ct then
+        unsupported(
+          node,
+          "cosmo0.elaborate.unsupported.type-param",
+          "explicit compile-time parameters are outside the initial cosmo0 subset",
+        )
+      else
+        val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
+        val default = node.init.map(expr)
+        for
+          t <- sequence(valueType.toList).map(_.headOption)
+          d <- sequence(default.toList).map(_.headOption)
+        yield Cosmo0UntypedParam(node.name.name, t, d, nodeSpan(node))
+
+    private def blockItem(node: syntax.Node): Option[Cosmo0UntypedBlockItem] =
+      unwrapSemi(node) match
+        case None => None
+        case Some(valueNode: Val) => local(valueNode, Cosmo0UntypedValueKind.Val)
+        case Some(valueNode: Var) => local(valueNode, Cosmo0UntypedValueKind.Var)
+        case Some(other)          => expr(other)
+
+    private def local(
+        node: Val,
+        kind: Cosmo0UntypedValueKind,
+    ): Option[Cosmo0UntypedLocal] =
+      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
+      val init = node.init.map(expr)
+      for
+        t <- sequence(valueType.toList).map(_.headOption)
+        i <- sequence(init.toList).map(_.headOption)
+      yield Cosmo0UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
+
+    private def local(
+        node: Var,
+        kind: Cosmo0UntypedValueKind,
+    ): Option[Cosmo0UntypedLocal] =
+      val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
+      val init = node.init.map(expr)
+      for
+        t <- sequence(valueType.toList).map(_.headOption)
+        i <- sequence(init.toList).map(_.headOption)
+      yield Cosmo0UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
+
+    private def expr(node: syntax.Node): Option[Cosmo0UntypedExpr] =
+      unwrapSemi(node) match
+        case None => Some(Cosmo0UntypedUnitLiteral(nodeSpan(node)))
+        case Some(block: Block) =>
+          val items = block.stmts.map(blockItem)
+          sequence(items).map(Cosmo0UntypedBlock(_, nodeSpan(block)))
+        case Some(name: Ident) =>
+          Some(Cosmo0UntypedName(Cosmo0UntypedPath(List(name.name), nodeSpan(name)), nodeSpan(name)))
+        case Some(BoolLit(value)) =>
+          Some(Cosmo0UntypedBoolLiteral(value, nodeSpan(node)))
+        case Some(IntLit(value)) =>
+          Some(Cosmo0UntypedIntLiteral(value, nodeSpan(node)))
+        case Some(FloatLit(value)) =>
+          Some(Cosmo0UntypedFloatLiteral(value, nodeSpan(node)))
+        case Some(StrLit(value)) =>
+          Some(Cosmo0UntypedStringLiteral(value, nodeSpan(node)))
+        case Some(Select(lhs, rhs, false)) =>
+          expr(lhs).map(receiver => Cosmo0UntypedSelect(receiver, rhs.name, nodeSpan(node)))
+        case Some(Select(lhs, rhs, true)) =>
+          typeFromNode(lhs, Some(nodeSpan(node))).map(owner =>
+            Cosmo0UntypedVariantConstructor(owner, rhs.name, nodeSpan(node)),
+          )
+        case Some(Apply(Select(_, rhs, false), _, false))
+            if higherOrderMethodNames.contains(rhs.name) =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.higher-order-api",
+            s"${rhs.name} is outside the initial cosmo0 higher-order API subset",
+          )
+        case Some(Apply(lhs, args, false)) =>
+          val callee = expr(lhs)
+          val callArgs = args.map(expr)
+          for
+            c <- callee
+            as <- sequence(callArgs)
+          yield Cosmo0UntypedCall(c, as, nodeSpan(node))
+        case Some(applyNode @ Apply(_, _, true)) =>
+          unsupported(
+            applyNode,
+            "cosmo0.elaborate.unsupported.compile-time-apply",
+            "compile-time type application is only supported in cosmo0 type positions",
+          )
+        case Some(BinOp(op, lhs, rhs)) if assignmentOps.contains(op) =>
+          for
+            target <- expr(lhs)
+            value <- expr(rhs)
+          yield Cosmo0UntypedAssign(target, value, op, nodeSpan(node))
+        case Some(BinOp(op, lhs, rhs)) =>
+          for
+            left <- expr(lhs)
+            right <- expr(rhs)
+          yield Cosmo0UntypedBinary(op, left, right, nodeSpan(node))
+        case Some(UnOp("mut", _)) =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.mut-expression",
+            "mut is only supported in cosmo0 reference type syntax",
+          )
+        case Some(UnOp(op, lhs)) =>
+          expr(lhs).map(value => Cosmo0UntypedUnary(op, value, nodeSpan(node)))
+        case Some(If(cond, thenBranch, elseBranch)) =>
+          for
+            c <- expr(cond)
+            t <- expr(thenBranch)
+            e <- sequence(elseBranch.map(expr).toList).map(_.headOption)
+          yield Cosmo0UntypedIf(c, t, e, nodeSpan(node))
+        case Some(Loop(body)) =>
+          expr(body).map(Cosmo0UntypedLoop(_, nodeSpan(node)))
+        case Some(While(cond, body)) =>
+          for
+            c <- expr(cond)
+            b <- expr(body)
+          yield Cosmo0UntypedWhile(c, b, nodeSpan(node))
+        case Some(For(name, iter, body)) =>
+          for
+            i <- expr(iter)
+            b <- expr(body)
+          yield Cosmo0UntypedFor(name.name, i, b, nodeSpan(node))
+        case Some(Match(lhs, rhs: CaseBlock)) =>
+          val arms = rhs.stmts.map(matchArm)
+          for
+            scrutinee <- expr(lhs)
+            as <- sequence(arms)
+          yield Cosmo0UntypedMatch(scrutinee, as, nodeSpan(node))
+        case Some(Match(_, rhs)) =>
+          unsupported(
+            rhs,
+            "cosmo0.elaborate.unsupported.match-body",
+            "cosmo0 match expressions must contain only case arms",
+          )
+        case Some(Return(value)) =>
+          expr(value).map(Cosmo0UntypedReturn(_, nodeSpan(node)))
+        case Some(Break()) =>
+          Some(Cosmo0UntypedBreak(nodeSpan(node)))
+        case Some(Continue()) =>
+          Some(Cosmo0UntypedContinue(nodeSpan(node)))
+        case Some(lambda: Lambda) =>
+          unsupported(
+            lambda,
+            "cosmo0.elaborate.unsupported.lambda",
+            "lambdas and closures are outside the initial cosmo0 subset",
+          )
+        case Some(asNode: As) =>
+          unsupported(
+            asNode,
+            "cosmo0.elaborate.unsupported.cast",
+            "as-casts are outside the initial cosmo0 subset",
+          )
+        case Some(tmpl: TmplApply) =>
+          unsupported(
+            tmpl,
+            "cosmo0.elaborate.unsupported.template-literal",
+            "template literals are outside the initial cosmo0 subset",
+          )
+        case Some(args: ArgsLit) =>
+          unsupported(
+            args,
+            "cosmo0.elaborate.unsupported.tuple",
+            "tuple and named-argument literals are outside the initial cosmo0 subset",
+          )
+        case Some(params: ParamsLit) =>
+          unsupported(
+            params,
+            "cosmo0.elaborate.unsupported.params-literal",
+            "parameter literals are outside the initial cosmo0 subset",
+          )
+        case Some(keyed: KeyedArg) =>
+          unsupported(
+            keyed,
+            "cosmo0.elaborate.unsupported.named-argument",
+            "named arguments are outside the initial cosmo0 subset",
+          )
+        case Some(TodoLit) =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.todo",
+            "??? placeholders are outside the initial cosmo0 subset",
+          )
+        case Some(decorated: Decorate) =>
+          unsupported(
+            decorated,
+            "cosmo0.elaborate.unsupported.decorator",
+            "decorators and staging annotations are outside the initial cosmo0 subset",
+          )
+        case Some(_: Val | _: Var | _: Typ | _: Def | _: Class | _: Impl | _: Import | _: Case) =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.declaration-expression",
+            s"${constructName(node)} cannot appear as a cosmo0 expression",
+          )
+        case Some(caseBlock: CaseBlock) =>
+          unsupported(
+            caseBlock,
+            "cosmo0.elaborate.unsupported.case-block",
+            "case blocks are only supported as match bodies",
+          )
+        case Some(err: Err) =>
+          unsupported(
+            err,
+            "cosmo0.elaborate.unsupported.parser-error",
+            err.msg,
+          )
+        case Some(other) =>
+          unsupported(
+            other,
+            "cosmo0.elaborate.unsupported.expression",
+            s"${constructName(other)} is outside the initial cosmo0 expression subset",
+          )
+
+    private def matchArm(node: Case): Option[Cosmo0UntypedMatchArm] =
+      val p = pattern(node.cond)
+      val b = node.body.map(expr)
+      for
+        patternValue <- p
+        bodyValue <- sequence(b.toList).map(_.headOption)
+      yield Cosmo0UntypedMatchArm(patternValue, bodyValue, nodeSpan(node))
+
+    private def pattern(node: syntax.Node): Option[Cosmo0UntypedPattern] =
+      node match
+        case Ident("_") =>
+          Some(Cosmo0UntypedWildcardPattern(nodeSpan(node)))
+        case Ident(name) =>
+          Some(Cosmo0UntypedBindingPattern(name, nodeSpan(node)))
+        case BoolLit(value) =>
+          Some(Cosmo0UntypedBoolLiteral(value, nodeSpan(node)))
+        case IntLit(value) =>
+          Some(Cosmo0UntypedIntLiteral(value, nodeSpan(node)))
+        case FloatLit(value) =>
+          Some(Cosmo0UntypedFloatLiteral(value, nodeSpan(node)))
+        case StrLit(value) =>
+          Some(Cosmo0UntypedStringLiteral(value, nodeSpan(node)))
+        case Apply(callee, args, false) =>
+          val constructor = expr(callee)
+          val argPatterns = args.map(pattern)
+          for
+            c <- constructor
+            as <- sequence(argPatterns)
+          yield Cosmo0UntypedVariantPattern(c, as, nodeSpan(node))
+        case select: Select =>
+          expr(select).map(constructor => Cosmo0UntypedVariantPattern(constructor, Nil, nodeSpan(node)))
+        case other =>
+          unsupported(
+            other,
+            "cosmo0.elaborate.unsupported.pattern",
+            s"${constructName(other)} is not a supported cosmo0 pattern",
+          )
+
+    private def typeFromNode(
+        node: syntax.Node,
+        fallbackSpan: Option[Cosmo0SourceSpan] = None,
+    ): Option[Cosmo0UntypedType] =
+      node match
+        case Ident("Type") =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.host-type",
+            "host Type and type-level programming are outside the initial cosmo0 subset",
+          )
+        case UnOp("&", UnOp("mut", target)) =>
+          typeFromNode(target, fallbackSpan).map(t =>
+            Cosmo0UntypedRefType(t, mutable = true, nodeSpan(node, fallbackSpan)),
+          )
+        case UnOp("&", target) =>
+          typeFromNode(target, fallbackSpan).map(t =>
+            Cosmo0UntypedRefType(t, mutable = false, nodeSpan(node, fallbackSpan)),
+          )
+        case Apply(lhs, args, true) =>
+          pathFromNode(lhs, fallbackSpan) match
+            case Some(base) if standardGenericNames.contains(base.parts.lastOption.getOrElse("")) =>
+              val typeArgs = args.map(typeFromNode(_, Some(nodeSpan(node, fallbackSpan))))
+              sequence(typeArgs).map { values =>
+                base.parts.lastOption match
+                  case Some("Ref") if values.size == 1 =>
+                    Cosmo0UntypedRefType(values.head, mutable = false, nodeSpan(node, fallbackSpan))
+                  case Some("RefMut") if values.size == 1 =>
+                    Cosmo0UntypedRefType(values.head, mutable = true, nodeSpan(node, fallbackSpan))
+                  case _ =>
+                    Cosmo0UntypedAppliedType(base, values, nodeSpan(node, fallbackSpan))
+              }
+            case Some(base) =>
+              unsupported(
+                node,
+                "cosmo0.elaborate.unsupported.generic-type",
+                s"${base.text} is not a registered cosmo0 standard generic type",
+              )
+            case None => None
+        case Apply(_, _, false) =>
+          unsupported(
+            node,
+            "cosmo0.elaborate.unsupported.runtime-type-apply",
+            "cosmo0 type applications must use compile-time square-bracket syntax",
+          )
+        case pathNode =>
+          pathFromNode(pathNode, fallbackSpan).map(path =>
+            Cosmo0UntypedNamedType(path, nodeSpan(pathNode, fallbackSpan)),
+          )
+
+    private def pathFromNode(
+        node: syntax.Node,
+        fallbackSpan: Option[Cosmo0SourceSpan] = None,
+    ): Option[Cosmo0UntypedPath] =
+      node match
+        case Ident(name) =>
+          Some(Cosmo0UntypedPath(List(name), nodeSpan(node, fallbackSpan)))
+        case Select(lhs, rhs, _) =>
+          pathFromNode(lhs, fallbackSpan).map(path =>
+            Cosmo0UntypedPath(path.parts :+ rhs.name, nodeSpan(node, fallbackSpan)),
+          )
+        case other =>
+          unsupported(
+            other,
+            "cosmo0.elaborate.unsupported.path",
+            s"${constructName(other)} cannot be used as a cosmo0 path",
+          )
+
+    def nodeSpan(node: syntax.Node): Cosmo0SourceSpan =
+      nodeSpan(node, None)
+
+    private def nodeSpan(
+        node: syntax.Node,
+        fallbackSpan: Option[Cosmo0SourceSpan],
+    ): Cosmo0SourceSpan =
+      if node.offset >= 0 && node.end >= node.offset then source.span(node.offset, node.end)
+      else fallbackSpan.getOrElse(source.span(0, 0))
+
+    private def unwrapSemi(node: syntax.Node): Option[syntax.Node] =
+      node match
+        case Semi(None)        => None
+        case Semi(Some(inner)) => unwrapSemi(inner)
+        case other             => Some(other)
+
+    private def hasExplicitTypeParams(params: Option[List[Param]]): Boolean =
+      params.exists(_.exists(_.ct))
+
+    private def sequence[A](items: List[Option[A]]): Option[List[A]] =
+      val values = ListBuffer.empty[A]
+      var ok = true
+      items.foreach {
+        case Some(value) => values += value
+        case None        => ok = false
+      }
+      if ok then Some(values.toList) else None
+
+    private def unsupported[A](
+        node: syntax.Node,
+        code: String,
+        message: String,
+    ): Option[A] =
+      diagnostics += Cosmo0Diagnostic(
+        Cosmo0Phase.Check,
+        Cosmo0DiagnosticSeverity.Error,
+        code,
+        message,
+        Some(nodeSpan(node)),
+      )
+      None
+
+    private def constructName(node: syntax.Node): String =
+      node.getClass.getSimpleName.stripSuffix("$")

--- a/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
@@ -5,43 +5,43 @@ import scala.collection.mutable.ListBuffer
 import cosmo.syntax
 import cosmo.syntax.*
 
-object Cosmo0UntypedElaborator:
+object UntypedElaborator:
   val defaultStandardGenericNames: Set[String] =
     Set("Arena", "Box", "Id", "Map", "Option", "Ptr", "Ref", "RefMut", "Result", "Set", "Vec")
 
-  def apply(): Cosmo0UntypedElaborator =
-    new Cosmo0UntypedElaborator(defaultStandardGenericNames)
+  def apply(): UntypedElaborator =
+    new UntypedElaborator(defaultStandardGenericNames)
 
-final class Cosmo0UntypedElaborator(
+final class UntypedElaborator(
     standardGenericNames: Set[String],
 ):
-  def elaborate(parsed: Cosmo0ParsedModule): Cosmo0Result[Cosmo0UntypedModule] =
+  def elaborate(parsed: ParsedModule): Result[UntypedModule] =
     val state = State(parsed.source, standardGenericNames)
     val declarations = parsed.ast.stmts.flatMap(state.moduleDecl)
     val diagnostics = state.diagnostics.toList
 
     if diagnostics.isEmpty then
-      Cosmo0Result.success(
-        Cosmo0Phase.Check,
-        Cosmo0UntypedModule(
+      Result.success(
+        Phase.Check,
+        UntypedModule(
           parsed.source,
           declarations,
           state.nodeSpan(parsed.ast),
         ),
       )
     else
-      Cosmo0Result(
-        Cosmo0Phase.Check,
-        Cosmo0PhaseStatus.Unsupported,
+      Result(
+        Phase.Check,
+        PhaseStatus.Unsupported,
         None,
         diagnostics,
       )
 
   private final class State(
-      source: Cosmo0SourceFile,
+      source: SourceFile,
       standardGenericNames: Set[String],
   ):
-    val diagnostics: ListBuffer[Cosmo0Diagnostic] = ListBuffer.empty
+    val diagnostics: ListBuffer[Diagnostic] = ListBuffer.empty
 
     private val assignmentOps =
       Set("=", "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=")
@@ -49,14 +49,14 @@ final class Cosmo0UntypedElaborator(
     private val higherOrderMethodNames =
       Set("filter", "flatMap", "fold", "forEach", "foreach", "map")
 
-    def moduleDecl(node: syntax.Node): Option[Cosmo0UntypedDecl] =
+    def moduleDecl(node: syntax.Node): Option[UntypedDecl] =
       unwrapSemi(node) match
         case None => None
         case Some(importNode: Import) => importDecl(importNode)
         case Some(classNode: Class)   => classDecl(classNode)
         case Some(defNode: Def)       => functionDecl(defNode)
-        case Some(valueNode: Val)     => valueDecl(valueNode, Cosmo0UntypedValueKind.Val)
-        case Some(valueNode: Var)     => valueDecl(valueNode, Cosmo0UntypedValueKind.Var)
+        case Some(valueNode: Val)     => valueDecl(valueNode, UntypedValueKind.Val)
+        case Some(valueNode: Var)     => valueDecl(valueNode, UntypedValueKind.Var)
         case Some(typeNode: Typ)      => typeAlias(typeNode)
         case Some(implNode: Impl) =>
           unsupported(
@@ -83,15 +83,15 @@ final class Cosmo0UntypedElaborator(
             s"${constructName(other)} is not a supported top-level cosmo0 declaration",
           )
 
-    private def importDecl(node: Import): Option[Cosmo0UntypedImport] =
+    private def importDecl(node: Import): Option[UntypedImport] =
       val path = pathFromNode(node.path, Some(nodeSpan(node)))
       val dest = node.dest.map(pathFromNode(_, Some(nodeSpan(node))))
       for
         p <- path
         d <- sequence(dest.toList).map(_.headOption)
-      yield Cosmo0UntypedImport(p, d, nodeSpan(node))
+      yield UntypedImport(p, d, nodeSpan(node))
 
-    private def classDecl(node: Class): Option[Cosmo0UntypedClass] =
+    private def classDecl(node: Class): Option[UntypedClass] =
       if node.ab then
         unsupported(
           node,
@@ -112,9 +112,9 @@ final class Cosmo0UntypedElaborator(
         )
       else
         val members = classMembers(node.body)
-        sequence(members).map(Cosmo0UntypedClass(node.name.name, _, nodeSpan(node)))
+        sequence(members).map(UntypedClass(node.name.name, _, nodeSpan(node)))
 
-    private def classMembers(node: syntax.Node): List[Option[Cosmo0UntypedClassMember]] =
+    private def classMembers(node: syntax.Node): List[Option[UntypedClassMember]] =
       unwrapSemi(node) match
         case None => Nil
         case Some(block: Block) =>
@@ -130,11 +130,11 @@ final class Cosmo0UntypedElaborator(
             ),
           )
 
-    private def classMember(node: syntax.Node): Option[Cosmo0UntypedClassMember] =
+    private def classMember(node: syntax.Node): Option[UntypedClassMember] =
       unwrapSemi(node) match
         case None => None
-        case Some(valueNode: Val) => valueDecl(valueNode, Cosmo0UntypedValueKind.Val)
-        case Some(valueNode: Var) => valueDecl(valueNode, Cosmo0UntypedValueKind.Var)
+        case Some(valueNode: Val) => valueDecl(valueNode, UntypedValueKind.Val)
+        case Some(valueNode: Var) => valueDecl(valueNode, UntypedValueKind.Var)
         case Some(defNode: Def)   => functionDecl(defNode)
         case Some(typeNode: Typ)  => typeAlias(typeNode)
         case Some(caseNode: Case) => variantDecl(caseNode)
@@ -157,7 +157,7 @@ final class Cosmo0UntypedElaborator(
             s"${constructName(other)} is not a supported cosmo0 class member",
           )
 
-    private def functionDecl(node: Def): Option[Cosmo0UntypedFunction] =
+    private def functionDecl(node: Def): Option[UntypedFunction] =
       if hasExplicitTypeParams(node.params) then
         unsupported(
           node,
@@ -172,35 +172,35 @@ final class Cosmo0UntypedElaborator(
           ps <- sequence(params)
           rt <- sequence(returnType.toList).map(_.headOption)
           b <- sequence(body.toList).map(_.headOption)
-        yield Cosmo0UntypedFunction(node.name.name, ps, rt, b, nodeSpan(node))
+        yield UntypedFunction(node.name.name, ps, rt, b, nodeSpan(node))
 
     private def valueDecl(
         node: Val,
-        kind: Cosmo0UntypedValueKind,
-    ): Option[Cosmo0UntypedValueDecl] =
+        kind: UntypedValueKind,
+    ): Option[UntypedValueDecl] =
       val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
       val init = node.init.map(expr)
       for
         t <- sequence(valueType.toList).map(_.headOption)
         i <- sequence(init.toList).map(_.headOption)
-      yield Cosmo0UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
+      yield UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
 
     private def valueDecl(
         node: Var,
-        kind: Cosmo0UntypedValueKind,
-    ): Option[Cosmo0UntypedValueDecl] =
+        kind: UntypedValueKind,
+    ): Option[UntypedValueDecl] =
       val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
       val init = node.init.map(expr)
       for
         t <- sequence(valueType.toList).map(_.headOption)
         i <- sequence(init.toList).map(_.headOption)
-      yield Cosmo0UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
+      yield UntypedValueDecl(kind, node.name.name, t, i, nodeSpan(node))
 
-    private def typeAlias(node: Typ): Option[Cosmo0UntypedTypeAlias] =
+    private def typeAlias(node: Typ): Option[UntypedTypeAlias] =
       node.init.orElse(node.ty) match
         case Some(targetNode) =>
           typeFromNode(targetNode, Some(nodeSpan(node))).map(target =>
-            Cosmo0UntypedTypeAlias(node.name.name, target, nodeSpan(node)),
+            UntypedTypeAlias(node.name.name, target, nodeSpan(node)),
           )
         case None =>
           unsupported(
@@ -209,7 +209,7 @@ final class Cosmo0UntypedElaborator(
             "cosmo0 type aliases must name a concrete target type",
           )
 
-    private def variantDecl(node: Case): Option[Cosmo0UntypedVariant] =
+    private def variantDecl(node: Case): Option[UntypedVariant] =
       if node.body.nonEmpty then
         unsupported(
           node,
@@ -219,10 +219,10 @@ final class Cosmo0UntypedElaborator(
       else
         node.cond match
           case name: Ident =>
-            Some(Cosmo0UntypedVariant(name.name, Nil, nodeSpan(node)))
+            Some(UntypedVariant(name.name, Nil, nodeSpan(node)))
           case Apply(name: Ident, args, false) =>
             val fields = args.map(variantField)
-            sequence(fields).map(Cosmo0UntypedVariant(name.name, _, nodeSpan(node)))
+            sequence(fields).map(UntypedVariant(name.name, _, nodeSpan(node)))
           case other =>
             unsupported(
               other,
@@ -230,11 +230,11 @@ final class Cosmo0UntypedElaborator(
               "cosmo0 case variants must be a variant name with optional payload types",
             )
 
-    private def variantField(node: syntax.Node): Option[Cosmo0UntypedVariantField] =
+    private def variantField(node: syntax.Node): Option[UntypedVariantField] =
       node match
         case KeyedArg(name: Ident, valueType) =>
           typeFromNode(valueType, Some(nodeSpan(node))).map(t =>
-            Cosmo0UntypedVariantField(Some(name.name), t, nodeSpan(node)),
+            UntypedVariantField(Some(name.name), t, nodeSpan(node)),
           )
         case KeyedArg(_, _) =>
           unsupported(
@@ -244,10 +244,10 @@ final class Cosmo0UntypedElaborator(
           )
         case other =>
           typeFromNode(other, Some(nodeSpan(other))).map(t =>
-            Cosmo0UntypedVariantField(None, t, nodeSpan(other)),
+            UntypedVariantField(None, t, nodeSpan(other)),
           )
 
-    private def param(node: Param): Option[Cosmo0UntypedParam] =
+    private def param(node: Param): Option[UntypedParam] =
       if node.ct then
         unsupported(
           node,
@@ -260,58 +260,58 @@ final class Cosmo0UntypedElaborator(
         for
           t <- sequence(valueType.toList).map(_.headOption)
           d <- sequence(default.toList).map(_.headOption)
-        yield Cosmo0UntypedParam(node.name.name, t, d, nodeSpan(node))
+        yield UntypedParam(node.name.name, t, d, nodeSpan(node))
 
-    private def blockItem(node: syntax.Node): Option[Cosmo0UntypedBlockItem] =
+    private def blockItem(node: syntax.Node): Option[UntypedBlockItem] =
       unwrapSemi(node) match
         case None => None
-        case Some(valueNode: Val) => local(valueNode, Cosmo0UntypedValueKind.Val)
-        case Some(valueNode: Var) => local(valueNode, Cosmo0UntypedValueKind.Var)
+        case Some(valueNode: Val) => local(valueNode, UntypedValueKind.Val)
+        case Some(valueNode: Var) => local(valueNode, UntypedValueKind.Var)
         case Some(other)          => expr(other)
 
     private def local(
         node: Val,
-        kind: Cosmo0UntypedValueKind,
-    ): Option[Cosmo0UntypedLocal] =
+        kind: UntypedValueKind,
+    ): Option[UntypedLocal] =
       val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
       val init = node.init.map(expr)
       for
         t <- sequence(valueType.toList).map(_.headOption)
         i <- sequence(init.toList).map(_.headOption)
-      yield Cosmo0UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
+      yield UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
 
     private def local(
         node: Var,
-        kind: Cosmo0UntypedValueKind,
-    ): Option[Cosmo0UntypedLocal] =
+        kind: UntypedValueKind,
+    ): Option[UntypedLocal] =
       val valueType = node.ty.map(typeFromNode(_, Some(nodeSpan(node))))
       val init = node.init.map(expr)
       for
         t <- sequence(valueType.toList).map(_.headOption)
         i <- sequence(init.toList).map(_.headOption)
-      yield Cosmo0UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
+      yield UntypedLocal(kind, node.name.name, t, i, nodeSpan(node))
 
-    private def expr(node: syntax.Node): Option[Cosmo0UntypedExpr] =
+    private def expr(node: syntax.Node): Option[UntypedExpr] =
       unwrapSemi(node) match
-        case None => Some(Cosmo0UntypedUnitLiteral(nodeSpan(node)))
+        case None => Some(UntypedUnitLiteral(nodeSpan(node)))
         case Some(block: Block) =>
           val items = block.stmts.map(blockItem)
-          sequence(items).map(Cosmo0UntypedBlock(_, nodeSpan(block)))
+          sequence(items).map(UntypedBlock(_, nodeSpan(block)))
         case Some(name: Ident) =>
-          Some(Cosmo0UntypedName(Cosmo0UntypedPath(List(name.name), nodeSpan(name)), nodeSpan(name)))
+          Some(UntypedName(UntypedPath(List(name.name), nodeSpan(name)), nodeSpan(name)))
         case Some(BoolLit(value)) =>
-          Some(Cosmo0UntypedBoolLiteral(value, nodeSpan(node)))
+          Some(UntypedBoolLiteral(value, nodeSpan(node)))
         case Some(IntLit(value)) =>
-          Some(Cosmo0UntypedIntLiteral(value, nodeSpan(node)))
+          Some(UntypedIntLiteral(value, nodeSpan(node)))
         case Some(FloatLit(value)) =>
-          Some(Cosmo0UntypedFloatLiteral(value, nodeSpan(node)))
+          Some(UntypedFloatLiteral(value, nodeSpan(node)))
         case Some(StrLit(value)) =>
-          Some(Cosmo0UntypedStringLiteral(value, nodeSpan(node)))
+          Some(UntypedStringLiteral(value, nodeSpan(node)))
         case Some(Select(lhs, rhs, false)) =>
-          expr(lhs).map(receiver => Cosmo0UntypedSelect(receiver, rhs.name, nodeSpan(node)))
+          expr(lhs).map(receiver => UntypedSelect(receiver, rhs.name, nodeSpan(node)))
         case Some(Select(lhs, rhs, true)) =>
           typeFromNode(lhs, Some(nodeSpan(node))).map(owner =>
-            Cosmo0UntypedVariantConstructor(owner, rhs.name, nodeSpan(node)),
+            UntypedVariantConstructor(owner, rhs.name, nodeSpan(node)),
           )
         case Some(Apply(Select(_, rhs, false), _, false))
             if higherOrderMethodNames.contains(rhs.name) =>
@@ -326,7 +326,7 @@ final class Cosmo0UntypedElaborator(
           for
             c <- callee
             as <- sequence(callArgs)
-          yield Cosmo0UntypedCall(c, as, nodeSpan(node))
+          yield UntypedCall(c, as, nodeSpan(node))
         case Some(applyNode @ Apply(_, _, true)) =>
           unsupported(
             applyNode,
@@ -337,12 +337,12 @@ final class Cosmo0UntypedElaborator(
           for
             target <- expr(lhs)
             value <- expr(rhs)
-          yield Cosmo0UntypedAssign(target, value, op, nodeSpan(node))
+          yield UntypedAssign(target, value, op, nodeSpan(node))
         case Some(BinOp(op, lhs, rhs)) =>
           for
             left <- expr(lhs)
             right <- expr(rhs)
-          yield Cosmo0UntypedBinary(op, left, right, nodeSpan(node))
+          yield UntypedBinary(op, left, right, nodeSpan(node))
         case Some(UnOp("mut", _)) =>
           unsupported(
             node,
@@ -350,31 +350,31 @@ final class Cosmo0UntypedElaborator(
             "mut is only supported in cosmo0 reference type syntax",
           )
         case Some(UnOp(op, lhs)) =>
-          expr(lhs).map(value => Cosmo0UntypedUnary(op, value, nodeSpan(node)))
+          expr(lhs).map(value => UntypedUnary(op, value, nodeSpan(node)))
         case Some(If(cond, thenBranch, elseBranch)) =>
           for
             c <- expr(cond)
             t <- expr(thenBranch)
             e <- sequence(elseBranch.map(expr).toList).map(_.headOption)
-          yield Cosmo0UntypedIf(c, t, e, nodeSpan(node))
+          yield UntypedIf(c, t, e, nodeSpan(node))
         case Some(Loop(body)) =>
-          expr(body).map(Cosmo0UntypedLoop(_, nodeSpan(node)))
+          expr(body).map(UntypedLoop(_, nodeSpan(node)))
         case Some(While(cond, body)) =>
           for
             c <- expr(cond)
             b <- expr(body)
-          yield Cosmo0UntypedWhile(c, b, nodeSpan(node))
+          yield UntypedWhile(c, b, nodeSpan(node))
         case Some(For(name, iter, body)) =>
           for
             i <- expr(iter)
             b <- expr(body)
-          yield Cosmo0UntypedFor(name.name, i, b, nodeSpan(node))
+          yield UntypedFor(name.name, i, b, nodeSpan(node))
         case Some(Match(lhs, rhs: CaseBlock)) =>
           val arms = rhs.stmts.map(matchArm)
           for
             scrutinee <- expr(lhs)
             as <- sequence(arms)
-          yield Cosmo0UntypedMatch(scrutinee, as, nodeSpan(node))
+          yield UntypedMatch(scrutinee, as, nodeSpan(node))
         case Some(Match(_, rhs)) =>
           unsupported(
             rhs,
@@ -382,11 +382,11 @@ final class Cosmo0UntypedElaborator(
             "cosmo0 match expressions must contain only case arms",
           )
         case Some(Return(value)) =>
-          expr(value).map(Cosmo0UntypedReturn(_, nodeSpan(node)))
+          expr(value).map(UntypedReturn(_, nodeSpan(node)))
         case Some(Break()) =>
-          Some(Cosmo0UntypedBreak(nodeSpan(node)))
+          Some(UntypedBreak(nodeSpan(node)))
         case Some(Continue()) =>
-          Some(Cosmo0UntypedContinue(nodeSpan(node)))
+          Some(UntypedContinue(nodeSpan(node)))
         case Some(lambda: Lambda) =>
           unsupported(
             lambda,
@@ -460,37 +460,37 @@ final class Cosmo0UntypedElaborator(
             s"${constructName(other)} is outside the initial cosmo0 expression subset",
           )
 
-    private def matchArm(node: Case): Option[Cosmo0UntypedMatchArm] =
+    private def matchArm(node: Case): Option[UntypedMatchArm] =
       val p = pattern(node.cond)
       val b = node.body.map(expr)
       for
         patternValue <- p
         bodyValue <- sequence(b.toList).map(_.headOption)
-      yield Cosmo0UntypedMatchArm(patternValue, bodyValue, nodeSpan(node))
+      yield UntypedMatchArm(patternValue, bodyValue, nodeSpan(node))
 
-    private def pattern(node: syntax.Node): Option[Cosmo0UntypedPattern] =
+    private def pattern(node: syntax.Node): Option[UntypedPattern] =
       node match
         case Ident("_") =>
-          Some(Cosmo0UntypedWildcardPattern(nodeSpan(node)))
+          Some(UntypedWildcardPattern(nodeSpan(node)))
         case Ident(name) =>
-          Some(Cosmo0UntypedBindingPattern(name, nodeSpan(node)))
+          Some(UntypedBindingPattern(name, nodeSpan(node)))
         case BoolLit(value) =>
-          Some(Cosmo0UntypedBoolLiteral(value, nodeSpan(node)))
+          Some(UntypedBoolLiteral(value, nodeSpan(node)))
         case IntLit(value) =>
-          Some(Cosmo0UntypedIntLiteral(value, nodeSpan(node)))
+          Some(UntypedIntLiteral(value, nodeSpan(node)))
         case FloatLit(value) =>
-          Some(Cosmo0UntypedFloatLiteral(value, nodeSpan(node)))
+          Some(UntypedFloatLiteral(value, nodeSpan(node)))
         case StrLit(value) =>
-          Some(Cosmo0UntypedStringLiteral(value, nodeSpan(node)))
+          Some(UntypedStringLiteral(value, nodeSpan(node)))
         case Apply(callee, args, false) =>
           val constructor = expr(callee)
           val argPatterns = args.map(pattern)
           for
             c <- constructor
             as <- sequence(argPatterns)
-          yield Cosmo0UntypedVariantPattern(c, as, nodeSpan(node))
+          yield UntypedVariantPattern(c, as, nodeSpan(node))
         case select: Select =>
-          expr(select).map(constructor => Cosmo0UntypedVariantPattern(constructor, Nil, nodeSpan(node)))
+          expr(select).map(constructor => UntypedVariantPattern(constructor, Nil, nodeSpan(node)))
         case other =>
           unsupported(
             other,
@@ -500,8 +500,8 @@ final class Cosmo0UntypedElaborator(
 
     private def typeFromNode(
         node: syntax.Node,
-        fallbackSpan: Option[Cosmo0SourceSpan] = None,
-    ): Option[Cosmo0UntypedType] =
+        fallbackSpan: Option[SourceSpan] = None,
+    ): Option[UntypedType] =
       node match
         case Ident("Type") =>
           unsupported(
@@ -511,11 +511,11 @@ final class Cosmo0UntypedElaborator(
           )
         case UnOp("&", UnOp("mut", target)) =>
           typeFromNode(target, fallbackSpan).map(t =>
-            Cosmo0UntypedRefType(t, mutable = true, nodeSpan(node, fallbackSpan)),
+            UntypedRefType(t, mutable = true, nodeSpan(node, fallbackSpan)),
           )
         case UnOp("&", target) =>
           typeFromNode(target, fallbackSpan).map(t =>
-            Cosmo0UntypedRefType(t, mutable = false, nodeSpan(node, fallbackSpan)),
+            UntypedRefType(t, mutable = false, nodeSpan(node, fallbackSpan)),
           )
         case Apply(lhs, args, true) =>
           pathFromNode(lhs, fallbackSpan) match
@@ -524,11 +524,11 @@ final class Cosmo0UntypedElaborator(
               sequence(typeArgs).map { values =>
                 base.parts.lastOption match
                   case Some("Ref") if values.size == 1 =>
-                    Cosmo0UntypedRefType(values.head, mutable = false, nodeSpan(node, fallbackSpan))
+                    UntypedRefType(values.head, mutable = false, nodeSpan(node, fallbackSpan))
                   case Some("RefMut") if values.size == 1 =>
-                    Cosmo0UntypedRefType(values.head, mutable = true, nodeSpan(node, fallbackSpan))
+                    UntypedRefType(values.head, mutable = true, nodeSpan(node, fallbackSpan))
                   case _ =>
-                    Cosmo0UntypedAppliedType(base, values, nodeSpan(node, fallbackSpan))
+                    UntypedAppliedType(base, values, nodeSpan(node, fallbackSpan))
               }
             case Some(base) =>
               unsupported(
@@ -545,19 +545,19 @@ final class Cosmo0UntypedElaborator(
           )
         case pathNode =>
           pathFromNode(pathNode, fallbackSpan).map(path =>
-            Cosmo0UntypedNamedType(path, nodeSpan(pathNode, fallbackSpan)),
+            UntypedNamedType(path, nodeSpan(pathNode, fallbackSpan)),
           )
 
     private def pathFromNode(
         node: syntax.Node,
-        fallbackSpan: Option[Cosmo0SourceSpan] = None,
-    ): Option[Cosmo0UntypedPath] =
+        fallbackSpan: Option[SourceSpan] = None,
+    ): Option[UntypedPath] =
       node match
         case Ident(name) =>
-          Some(Cosmo0UntypedPath(List(name), nodeSpan(node, fallbackSpan)))
+          Some(UntypedPath(List(name), nodeSpan(node, fallbackSpan)))
         case Select(lhs, rhs, _) =>
           pathFromNode(lhs, fallbackSpan).map(path =>
-            Cosmo0UntypedPath(path.parts :+ rhs.name, nodeSpan(node, fallbackSpan)),
+            UntypedPath(path.parts :+ rhs.name, nodeSpan(node, fallbackSpan)),
           )
         case other =>
           unsupported(
@@ -566,13 +566,13 @@ final class Cosmo0UntypedElaborator(
             s"${constructName(other)} cannot be used as a cosmo0 path",
           )
 
-    def nodeSpan(node: syntax.Node): Cosmo0SourceSpan =
+    def nodeSpan(node: syntax.Node): SourceSpan =
       nodeSpan(node, None)
 
     private def nodeSpan(
         node: syntax.Node,
-        fallbackSpan: Option[Cosmo0SourceSpan],
-    ): Cosmo0SourceSpan =
+        fallbackSpan: Option[SourceSpan],
+    ): SourceSpan =
       if node.offset >= 0 && node.end >= node.offset then source.span(node.offset, node.end)
       else fallbackSpan.getOrElse(source.span(0, 0))
 
@@ -599,9 +599,9 @@ final class Cosmo0UntypedElaborator(
         code: String,
         message: String,
     ): Option[A] =
-      diagnostics += Cosmo0Diagnostic(
-        Cosmo0Phase.Check,
-        Cosmo0DiagnosticSeverity.Error,
+      diagnostics += Diagnostic(
+        Phase.Check,
+        DiagnosticSeverity.Error,
         code,
         message,
         Some(nodeSpan(node)),

--- a/packages/cosmo0/src/main/scala/cosmo0/Model.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Model.scala
@@ -2,28 +2,28 @@ package cosmo0
 
 import cosmo.syntax
 
-enum Cosmo0Phase:
+enum Phase:
   case Parse, Check, Compile
 
-enum Cosmo0PhaseStatus:
+enum PhaseStatus:
   case Succeeded, Pending, Unsupported, Failed
 
-enum Cosmo0DiagnosticSeverity:
+enum DiagnosticSeverity:
   case Info, Warning, Error
 
-final case class Cosmo0SourcePosition(
+final case class SourcePosition(
     offset: Int,
     line: Int,
     column: Int,
 )
 
-final case class Cosmo0SourceSpan(
+final case class SourceSpan(
     fileName: String,
-    start: Cosmo0SourcePosition,
-    end: Cosmo0SourcePosition,
+    start: SourcePosition,
+    end: SourcePosition,
 )
 
-final case class Cosmo0SourceFile(
+final case class SourceFile(
     name: String,
     text: String,
 ):
@@ -35,17 +35,17 @@ final case class Cosmo0SourceFile(
       i += 1
     starts.toArray
 
-  def positionAt(offset: Int): Cosmo0SourcePosition =
+  def positionAt(offset: Int): SourcePosition =
     val boundedOffset = offset.max(0).min(text.length)
     val lineIndex = bestLineStartIndex(boundedOffset)
-    Cosmo0SourcePosition(
+    SourcePosition(
       boundedOffset,
       lineIndex + 1,
       boundedOffset - lineStarts(lineIndex) + 1,
     )
 
-  def span(startOffset: Int, endOffset: Int): Cosmo0SourceSpan =
-    Cosmo0SourceSpan(
+  def span(startOffset: Int, endOffset: Int): SourceSpan =
+    SourceSpan(
       name,
       positionAt(startOffset),
       positionAt(endOffset.max(startOffset)),
@@ -63,59 +63,59 @@ final case class Cosmo0SourceFile(
       else high = mid - 1
     best
 
-final case class Cosmo0Diagnostic(
-    phase: Cosmo0Phase,
-    severity: Cosmo0DiagnosticSeverity,
+final case class Diagnostic(
+    phase: Phase,
+    severity: DiagnosticSeverity,
     code: String,
     message: String,
-    span: Option[Cosmo0SourceSpan] = None,
+    span: Option[SourceSpan] = None,
 )
 
-final case class Cosmo0Result[+A](
-    phase: Cosmo0Phase,
-    status: Cosmo0PhaseStatus,
+final case class Result[+A](
+    phase: Phase,
+    status: PhaseStatus,
     value: Option[A],
-    diagnostics: List[Cosmo0Diagnostic] = Nil,
+    diagnostics: List[Diagnostic] = Nil,
 ):
-  def isSuccess: Boolean = status == Cosmo0PhaseStatus.Succeeded
-  def isPending: Boolean = status == Cosmo0PhaseStatus.Pending
-  def isUnsupported: Boolean = status == Cosmo0PhaseStatus.Unsupported
-  def isFailure: Boolean = status == Cosmo0PhaseStatus.Failed
+  def isSuccess: Boolean = status == PhaseStatus.Succeeded
+  def isPending: Boolean = status == PhaseStatus.Pending
+  def isUnsupported: Boolean = status == PhaseStatus.Unsupported
+  def isFailure: Boolean = status == PhaseStatus.Failed
 
-object Cosmo0Result:
-  def success[A](phase: Cosmo0Phase, value: A): Cosmo0Result[A] =
-    Cosmo0Result(phase, Cosmo0PhaseStatus.Succeeded, Some(value))
+object Result:
+  def success[A](phase: Phase, value: A): Result[A] =
+    Result(phase, PhaseStatus.Succeeded, Some(value))
 
   def pending[A](
-      phase: Cosmo0Phase,
-      diagnostic: Cosmo0Diagnostic,
+      phase: Phase,
+      diagnostic: Diagnostic,
       value: Option[A] = None,
-  ): Cosmo0Result[A] =
-    Cosmo0Result(phase, Cosmo0PhaseStatus.Pending, value, List(diagnostic))
+  ): Result[A] =
+    Result(phase, PhaseStatus.Pending, value, List(diagnostic))
 
   def unsupported[A](
-      phase: Cosmo0Phase,
-      diagnostic: Cosmo0Diagnostic,
+      phase: Phase,
+      diagnostic: Diagnostic,
       value: Option[A] = None,
-  ): Cosmo0Result[A] =
-    Cosmo0Result(phase, Cosmo0PhaseStatus.Unsupported, value, List(diagnostic))
+  ): Result[A] =
+    Result(phase, PhaseStatus.Unsupported, value, List(diagnostic))
 
   def failure[A](
-      phase: Cosmo0Phase,
-      diagnostics: List[Cosmo0Diagnostic],
-  ): Cosmo0Result[A] =
-    Cosmo0Result(phase, Cosmo0PhaseStatus.Failed, None, diagnostics)
+      phase: Phase,
+      diagnostics: List[Diagnostic],
+  ): Result[A] =
+    Result(phase, PhaseStatus.Failed, None, diagnostics)
 
-final case class Cosmo0ParsedModule(
-    source: Cosmo0SourceFile,
+final case class ParsedModule(
+    source: SourceFile,
     ast: syntax.Block,
 )
 
-final case class Cosmo0CheckedModule(
-    parsed: Cosmo0ParsedModule,
+final case class CheckedModule(
+    parsed: ParsedModule,
 )
 
-final case class Cosmo0CompiledModule(
-    checked: Cosmo0CheckedModule,
+final case class CompiledModule(
+    checked: CheckedModule,
     output: String,
 )

--- a/packages/cosmo0/src/main/scala/cosmo0/Untyped.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Untyped.scala
@@ -1,262 +1,262 @@
 package cosmo0
 
-sealed trait Cosmo0UntypedNode:
-  def span: Cosmo0SourceSpan
+sealed trait UntypedNode:
+  def span: SourceSpan
 
-final case class Cosmo0UntypedModule(
-    source: Cosmo0SourceFile,
-    declarations: List[Cosmo0UntypedDecl],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedNode
+final case class UntypedModule(
+    source: SourceFile,
+    declarations: List[UntypedDecl],
+    span: SourceSpan,
+) extends UntypedNode
 
-sealed trait Cosmo0UntypedDecl extends Cosmo0UntypedNode:
+sealed trait UntypedDecl extends UntypedNode:
   def name: String
 
-sealed trait Cosmo0UntypedClassMember extends Cosmo0UntypedNode
+sealed trait UntypedClassMember extends UntypedNode
 
-sealed trait Cosmo0UntypedBlockItem extends Cosmo0UntypedNode
+sealed trait UntypedBlockItem extends UntypedNode
 
-sealed trait Cosmo0UntypedStmt extends Cosmo0UntypedBlockItem
+sealed trait UntypedStmt extends UntypedBlockItem
 
-sealed trait Cosmo0UntypedExpr extends Cosmo0UntypedBlockItem
+sealed trait UntypedExpr extends UntypedBlockItem
 
-sealed trait Cosmo0UntypedPattern extends Cosmo0UntypedNode
+sealed trait UntypedPattern extends UntypedNode
 
-sealed trait Cosmo0UntypedType extends Cosmo0UntypedNode
+sealed trait UntypedType extends UntypedNode
 
-enum Cosmo0UntypedValueKind:
+enum UntypedValueKind:
   case Val, Var
 
-final case class Cosmo0UntypedPath(
+final case class UntypedPath(
     parts: List[String],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedNode:
+    span: SourceSpan,
+) extends UntypedNode:
   def text: String = parts.mkString("::")
 
-final case class Cosmo0UntypedImport(
-    path: Cosmo0UntypedPath,
-    dest: Option[Cosmo0UntypedPath],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedDecl:
+final case class UntypedImport(
+    path: UntypedPath,
+    dest: Option[UntypedPath],
+    span: SourceSpan,
+) extends UntypedDecl:
   def name: String = dest.orElse(Some(path)).fold("<import>")(_.text)
 
-final case class Cosmo0UntypedClass(
+final case class UntypedClass(
     name: String,
-    members: List[Cosmo0UntypedClassMember],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedDecl
+    members: List[UntypedClassMember],
+    span: SourceSpan,
+) extends UntypedDecl
 
-final case class Cosmo0UntypedFunction(
+final case class UntypedFunction(
     name: String,
-    params: List[Cosmo0UntypedParam],
-    returnType: Option[Cosmo0UntypedType],
-    body: Option[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedDecl
-    with Cosmo0UntypedClassMember
+    params: List[UntypedParam],
+    returnType: Option[UntypedType],
+    body: Option[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedDecl
+    with UntypedClassMember
 
-final case class Cosmo0UntypedValueDecl(
-    kind: Cosmo0UntypedValueKind,
+final case class UntypedValueDecl(
+    kind: UntypedValueKind,
     name: String,
-    valueType: Option[Cosmo0UntypedType],
-    init: Option[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedDecl
-    with Cosmo0UntypedClassMember
+    valueType: Option[UntypedType],
+    init: Option[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedDecl
+    with UntypedClassMember
 
-final case class Cosmo0UntypedTypeAlias(
+final case class UntypedTypeAlias(
     name: String,
-    target: Cosmo0UntypedType,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedDecl
-    with Cosmo0UntypedClassMember
+    target: UntypedType,
+    span: SourceSpan,
+) extends UntypedDecl
+    with UntypedClassMember
 
-final case class Cosmo0UntypedVariant(
+final case class UntypedVariant(
     name: String,
-    fields: List[Cosmo0UntypedVariantField],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedClassMember
+    fields: List[UntypedVariantField],
+    span: SourceSpan,
+) extends UntypedClassMember
 
-final case class Cosmo0UntypedVariantField(
+final case class UntypedVariantField(
     name: Option[String],
-    valueType: Cosmo0UntypedType,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedNode
+    valueType: UntypedType,
+    span: SourceSpan,
+) extends UntypedNode
 
-final case class Cosmo0UntypedParam(
+final case class UntypedParam(
     name: String,
-    valueType: Option[Cosmo0UntypedType],
-    default: Option[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedNode
+    valueType: Option[UntypedType],
+    default: Option[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedNode
 
-final case class Cosmo0UntypedNamedType(
-    path: Cosmo0UntypedPath,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedType
+final case class UntypedNamedType(
+    path: UntypedPath,
+    span: SourceSpan,
+) extends UntypedType
 
-final case class Cosmo0UntypedAppliedType(
-    base: Cosmo0UntypedPath,
-    args: List[Cosmo0UntypedType],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedType
+final case class UntypedAppliedType(
+    base: UntypedPath,
+    args: List[UntypedType],
+    span: SourceSpan,
+) extends UntypedType
 
-final case class Cosmo0UntypedRefType(
-    target: Cosmo0UntypedType,
+final case class UntypedRefType(
+    target: UntypedType,
     mutable: Boolean,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedType
+    span: SourceSpan,
+) extends UntypedType
 
-final case class Cosmo0UntypedLocal(
-    kind: Cosmo0UntypedValueKind,
+final case class UntypedLocal(
+    kind: UntypedValueKind,
     name: String,
-    valueType: Option[Cosmo0UntypedType],
-    init: Option[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedStmt
+    valueType: Option[UntypedType],
+    init: Option[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedStmt
 
-final case class Cosmo0UntypedExprStmt(
-    expr: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedStmt
+final case class UntypedExprStmt(
+    expr: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedStmt
 
-final case class Cosmo0UntypedBlock(
-    items: List[Cosmo0UntypedBlockItem],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedBlock(
+    items: List[UntypedBlockItem],
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedName(
-    path: Cosmo0UntypedPath,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedName(
+    path: UntypedPath,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedSelect(
-    receiver: Cosmo0UntypedExpr,
+final case class UntypedSelect(
+    receiver: UntypedExpr,
     field: String,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedVariantConstructor(
-    owner: Cosmo0UntypedType,
+final case class UntypedVariantConstructor(
+    owner: UntypedType,
     variant: String,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedCall(
-    callee: Cosmo0UntypedExpr,
-    args: List[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedCall(
+    callee: UntypedExpr,
+    args: List[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedAssign(
-    target: Cosmo0UntypedExpr,
-    value: Cosmo0UntypedExpr,
+final case class UntypedAssign(
+    target: UntypedExpr,
+    value: UntypedExpr,
     op: String,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedUnary(
+final case class UntypedUnary(
     op: String,
-    expr: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+    expr: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedBinary(
+final case class UntypedBinary(
     op: String,
-    left: Cosmo0UntypedExpr,
-    right: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+    left: UntypedExpr,
+    right: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedIf(
-    cond: Cosmo0UntypedExpr,
-    thenBranch: Cosmo0UntypedExpr,
-    elseBranch: Option[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedIf(
+    cond: UntypedExpr,
+    thenBranch: UntypedExpr,
+    elseBranch: Option[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedLoop(
-    body: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedLoop(
+    body: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedWhile(
-    cond: Cosmo0UntypedExpr,
-    body: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedWhile(
+    cond: UntypedExpr,
+    body: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedFor(
+final case class UntypedFor(
     name: String,
-    iter: Cosmo0UntypedExpr,
-    body: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+    iter: UntypedExpr,
+    body: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedMatch(
-    scrutinee: Cosmo0UntypedExpr,
-    arms: List[Cosmo0UntypedMatchArm],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedMatch(
+    scrutinee: UntypedExpr,
+    arms: List[UntypedMatchArm],
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedMatchArm(
-    pattern: Cosmo0UntypedPattern,
-    body: Option[Cosmo0UntypedExpr],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedNode
+final case class UntypedMatchArm(
+    pattern: UntypedPattern,
+    body: Option[UntypedExpr],
+    span: SourceSpan,
+) extends UntypedNode
 
-final case class Cosmo0UntypedReturn(
-    value: Cosmo0UntypedExpr,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedReturn(
+    value: UntypedExpr,
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedBreak(
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedBreak(
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedContinue(
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedContinue(
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedBoolLiteral(
+final case class UntypedBoolLiteral(
     value: Boolean,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
-    with Cosmo0UntypedPattern
+    span: SourceSpan,
+) extends UntypedExpr
+    with UntypedPattern
 
-final case class Cosmo0UntypedIntLiteral(
+final case class UntypedIntLiteral(
     value: BigInt,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
-    with Cosmo0UntypedPattern
+    span: SourceSpan,
+) extends UntypedExpr
+    with UntypedPattern
 
-final case class Cosmo0UntypedFloatLiteral(
+final case class UntypedFloatLiteral(
     value: BigDecimal,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
-    with Cosmo0UntypedPattern
+    span: SourceSpan,
+) extends UntypedExpr
+    with UntypedPattern
 
-final case class Cosmo0UntypedStringLiteral(
+final case class UntypedStringLiteral(
     value: String,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
-    with Cosmo0UntypedPattern
+    span: SourceSpan,
+) extends UntypedExpr
+    with UntypedPattern
 
-final case class Cosmo0UntypedUnitLiteral(
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedExpr
+final case class UntypedUnitLiteral(
+    span: SourceSpan,
+) extends UntypedExpr
 
-final case class Cosmo0UntypedWildcardPattern(
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedPattern
+final case class UntypedWildcardPattern(
+    span: SourceSpan,
+) extends UntypedPattern
 
-final case class Cosmo0UntypedBindingPattern(
+final case class UntypedBindingPattern(
     name: String,
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedPattern
+    span: SourceSpan,
+) extends UntypedPattern
 
-final case class Cosmo0UntypedVariantPattern(
-    constructor: Cosmo0UntypedExpr,
-    args: List[Cosmo0UntypedPattern],
-    span: Cosmo0SourceSpan,
-) extends Cosmo0UntypedPattern
+final case class UntypedVariantPattern(
+    constructor: UntypedExpr,
+    args: List[UntypedPattern],
+    span: SourceSpan,
+) extends UntypedPattern

--- a/packages/cosmo0/src/main/scala/cosmo0/Untyped.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Untyped.scala
@@ -1,0 +1,262 @@
+package cosmo0
+
+sealed trait Cosmo0UntypedNode:
+  def span: Cosmo0SourceSpan
+
+final case class Cosmo0UntypedModule(
+    source: Cosmo0SourceFile,
+    declarations: List[Cosmo0UntypedDecl],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedNode
+
+sealed trait Cosmo0UntypedDecl extends Cosmo0UntypedNode:
+  def name: String
+
+sealed trait Cosmo0UntypedClassMember extends Cosmo0UntypedNode
+
+sealed trait Cosmo0UntypedBlockItem extends Cosmo0UntypedNode
+
+sealed trait Cosmo0UntypedStmt extends Cosmo0UntypedBlockItem
+
+sealed trait Cosmo0UntypedExpr extends Cosmo0UntypedBlockItem
+
+sealed trait Cosmo0UntypedPattern extends Cosmo0UntypedNode
+
+sealed trait Cosmo0UntypedType extends Cosmo0UntypedNode
+
+enum Cosmo0UntypedValueKind:
+  case Val, Var
+
+final case class Cosmo0UntypedPath(
+    parts: List[String],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedNode:
+  def text: String = parts.mkString("::")
+
+final case class Cosmo0UntypedImport(
+    path: Cosmo0UntypedPath,
+    dest: Option[Cosmo0UntypedPath],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedDecl:
+  def name: String = dest.orElse(Some(path)).fold("<import>")(_.text)
+
+final case class Cosmo0UntypedClass(
+    name: String,
+    members: List[Cosmo0UntypedClassMember],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedDecl
+
+final case class Cosmo0UntypedFunction(
+    name: String,
+    params: List[Cosmo0UntypedParam],
+    returnType: Option[Cosmo0UntypedType],
+    body: Option[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedDecl
+    with Cosmo0UntypedClassMember
+
+final case class Cosmo0UntypedValueDecl(
+    kind: Cosmo0UntypedValueKind,
+    name: String,
+    valueType: Option[Cosmo0UntypedType],
+    init: Option[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedDecl
+    with Cosmo0UntypedClassMember
+
+final case class Cosmo0UntypedTypeAlias(
+    name: String,
+    target: Cosmo0UntypedType,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedDecl
+    with Cosmo0UntypedClassMember
+
+final case class Cosmo0UntypedVariant(
+    name: String,
+    fields: List[Cosmo0UntypedVariantField],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedClassMember
+
+final case class Cosmo0UntypedVariantField(
+    name: Option[String],
+    valueType: Cosmo0UntypedType,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedNode
+
+final case class Cosmo0UntypedParam(
+    name: String,
+    valueType: Option[Cosmo0UntypedType],
+    default: Option[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedNode
+
+final case class Cosmo0UntypedNamedType(
+    path: Cosmo0UntypedPath,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedType
+
+final case class Cosmo0UntypedAppliedType(
+    base: Cosmo0UntypedPath,
+    args: List[Cosmo0UntypedType],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedType
+
+final case class Cosmo0UntypedRefType(
+    target: Cosmo0UntypedType,
+    mutable: Boolean,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedType
+
+final case class Cosmo0UntypedLocal(
+    kind: Cosmo0UntypedValueKind,
+    name: String,
+    valueType: Option[Cosmo0UntypedType],
+    init: Option[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedStmt
+
+final case class Cosmo0UntypedExprStmt(
+    expr: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedStmt
+
+final case class Cosmo0UntypedBlock(
+    items: List[Cosmo0UntypedBlockItem],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedName(
+    path: Cosmo0UntypedPath,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedSelect(
+    receiver: Cosmo0UntypedExpr,
+    field: String,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedVariantConstructor(
+    owner: Cosmo0UntypedType,
+    variant: String,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedCall(
+    callee: Cosmo0UntypedExpr,
+    args: List[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedAssign(
+    target: Cosmo0UntypedExpr,
+    value: Cosmo0UntypedExpr,
+    op: String,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedUnary(
+    op: String,
+    expr: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedBinary(
+    op: String,
+    left: Cosmo0UntypedExpr,
+    right: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedIf(
+    cond: Cosmo0UntypedExpr,
+    thenBranch: Cosmo0UntypedExpr,
+    elseBranch: Option[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedLoop(
+    body: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedWhile(
+    cond: Cosmo0UntypedExpr,
+    body: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedFor(
+    name: String,
+    iter: Cosmo0UntypedExpr,
+    body: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedMatch(
+    scrutinee: Cosmo0UntypedExpr,
+    arms: List[Cosmo0UntypedMatchArm],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedMatchArm(
+    pattern: Cosmo0UntypedPattern,
+    body: Option[Cosmo0UntypedExpr],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedNode
+
+final case class Cosmo0UntypedReturn(
+    value: Cosmo0UntypedExpr,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedBreak(
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedContinue(
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedBoolLiteral(
+    value: Boolean,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+    with Cosmo0UntypedPattern
+
+final case class Cosmo0UntypedIntLiteral(
+    value: BigInt,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+    with Cosmo0UntypedPattern
+
+final case class Cosmo0UntypedFloatLiteral(
+    value: BigDecimal,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+    with Cosmo0UntypedPattern
+
+final case class Cosmo0UntypedStringLiteral(
+    value: String,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+    with Cosmo0UntypedPattern
+
+final case class Cosmo0UntypedUnitLiteral(
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedExpr
+
+final case class Cosmo0UntypedWildcardPattern(
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedPattern
+
+final case class Cosmo0UntypedBindingPattern(
+    name: String,
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedPattern
+
+final case class Cosmo0UntypedVariantPattern(
+    constructor: Cosmo0UntypedExpr,
+    args: List[Cosmo0UntypedPattern],
+    span: Cosmo0SourceSpan,
+) extends Cosmo0UntypedPattern

--- a/packages/cosmo0/src/test/scala/cosmo0/Cosmo0Tests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/Cosmo0Tests.scala
@@ -31,6 +31,134 @@ class Cosmo0Tests extends munit.FunSuite:
     assert(result.value.isEmpty)
     assertEquals(result.diagnostics.head.code, "cosmo0.check.pending")
 
+  test("elaborate builds untyped representation for accepted core declarations"):
+    val result = Cosmo0().elaborate(
+      """type SourceId = Id[SourceFile]
+        |
+        |class Severity {
+        |  case Note
+        |  case Error(String)
+        |}
+        |
+        |class Diagnostic {
+        |  val labels: Vec[DiagnosticLabel]
+        |  var count: usize = 0
+        |
+        |  def push(&mut self, label: DiagnosticLabel): Unit = {
+        |    val previous = self.count;
+        |    self.labels.push(label);
+        |    if (previous == 0) {
+        |      return previous
+        |    } else {
+        |      self.count = previous + 1
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Cosmo0Phase.Check)
+    assertEquals(result.status, Cosmo0PhaseStatus.Succeeded)
+    assert(result.diagnostics.isEmpty)
+
+    val module = result.value.get
+    assertEquals(module.declarations.map(_.name), List("SourceId", "Severity", "Diagnostic"))
+
+    val alias = module.declarations.head.asInstanceOf[Cosmo0UntypedTypeAlias]
+    assert(alias.target.isInstanceOf[Cosmo0UntypedAppliedType])
+
+    val severity = module.declarations(1).asInstanceOf[Cosmo0UntypedClass]
+    assertEquals(
+      severity.members.collect { case variant: Cosmo0UntypedVariant => variant.name },
+      List("Note", "Error"),
+    )
+
+    val diagnostic = module.declarations(2).asInstanceOf[Cosmo0UntypedClass]
+    val push = diagnostic.members.collectFirst { case fn: Cosmo0UntypedFunction => fn }.get
+    val selfType = push.params.head.valueType.get.asInstanceOf[Cosmo0UntypedRefType]
+    assert(selfType.mutable)
+    assert(push.body.exists(_.isInstanceOf[Cosmo0UntypedBlock]))
+
+  test("elaborate represents match arms and standard-generic variant constructors"):
+    val result = Cosmo0().elaborate(
+      """def current(&self): Option[Token] = {
+        |  val current = self.advance();
+        |  current match {
+        |    case Option[Token]::Some(token) => {
+        |      token
+        |    }
+        |    case Option[Token]::None => {
+        |      return token
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.status, Cosmo0PhaseStatus.Succeeded)
+    val fn = result.value.get.declarations.head.asInstanceOf[Cosmo0UntypedFunction]
+    val body = fn.body.get.asInstanceOf[Cosmo0UntypedBlock]
+    val matchExpr = body.items.collectFirst { case m: Cosmo0UntypedMatch => m }.get
+
+    assertEquals(matchExpr.arms.length, 2)
+    val somePattern = matchExpr.arms.head.pattern.asInstanceOf[Cosmo0UntypedVariantPattern]
+    assert(somePattern.constructor.isInstanceOf[Cosmo0UntypedVariantConstructor])
+    assertEquals(somePattern.args.length, 1)
+
+  test("elaborate rejects unsupported full-language constructs deterministically"):
+    val cases = List(
+      "trait Display {}" -> "cosmo0.elaborate.unsupported.trait",
+      "class Arena[T] {}" -> "cosmo0.elaborate.unsupported.generic-class",
+      "def id[T](x: T): T = x" -> "cosmo0.elaborate.unsupported.generic-function",
+      "impl Display {}" -> "cosmo0.elaborate.unsupported.impl",
+      "def f(T: Type): Unit = {}" -> "cosmo0.elaborate.unsupported.host-type",
+      "type X = User[T]" -> "cosmo0.elaborate.unsupported.generic-type",
+      "def f(): Unit = { val x = Vec[i32] }" ->
+        "cosmo0.elaborate.unsupported.compile-time-apply",
+      "def f(): Unit = { val f = x => x }" ->
+        "cosmo0.elaborate.unsupported.lambda",
+      "def f(items: Vec[i32]): Unit = { items.map(process) }" ->
+        "cosmo0.elaborate.unsupported.higher-order-api",
+    )
+
+    cases.foreach { case (source, code) =>
+      val result = Cosmo0().elaborate(source)
+
+      assertEquals(result.phase, Cosmo0Phase.Check)
+      assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+      assert(result.value.isEmpty)
+      assert(
+        result.diagnostics.exists(_.code == code),
+        s"missing diagnostic $code in ${result.diagnostics.map(_.code)}",
+      )
+    }
+
+  test("check stops on unsupported subset constructs"):
+    val result = Cosmo0().check("trait Display {}")
+
+    assertEquals(result.phase, Cosmo0Phase.Check)
+    assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+    assertEquals(result.diagnostics.head.code, "cosmo0.elaborate.unsupported.trait")
+
+  test("elaboration preserves spans for accepted nodes and diagnostics"):
+    val accepted = Cosmo0().elaborate("\nval answer = 42")
+    val declarationSpan = accepted.value.get.declarations.head.span
+
+    assertEquals(declarationSpan.start.line, 2)
+    assertEquals(declarationSpan.start.column, 1)
+    assert(declarationSpan.end.offset > declarationSpan.start.offset)
+
+    val rejected = Cosmo0().elaborate(
+      """def f(): Unit = {
+        |  val f = x => x
+        |}
+        |""".stripMargin,
+    )
+    val diagnosticSpan = rejected.diagnostics.head.span.get
+
+    assertEquals(diagnosticSpan.start.line, 2)
+    assert(diagnosticSpan.end.offset >= diagnosticSpan.start.offset)
+
   test("compile returns a structured unsupported result"):
     val result = Cosmo0().compile("val answer = 42")
 
@@ -38,3 +166,11 @@ class Cosmo0Tests extends munit.FunSuite:
     assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
     assert(result.value.isEmpty)
     assertEquals(result.diagnostics.head.code, "cosmo0.compile.unsupported")
+
+  test("compile stops on unsupported subset constructs"):
+    val result = Cosmo0().compile("trait Display {}")
+
+    assertEquals(result.phase, Cosmo0Phase.Compile)
+    assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+    assert(result.value.isEmpty)
+    assertEquals(result.diagnostics.head.code, "cosmo0.elaborate.unsupported.trait")

--- a/packages/cosmo0/src/test/scala/cosmo0/FacadeTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/FacadeTests.scala
@@ -1,6 +1,6 @@
 package cosmo0
 
-class Cosmo0Tests extends munit.FunSuite:
+class FacadeTests extends munit.FunSuite:
   test("facade can be instantiated independently"):
     val compiler = Cosmo0()
     assertNotEquals(compiler, null)
@@ -8,8 +8,8 @@ class Cosmo0Tests extends munit.FunSuite:
   test("parse accepts source text and returns a parsed module"):
     val result = Cosmo0().parse("val answer = 42")
 
-    assertEquals(result.phase, Cosmo0Phase.Parse)
-    assertEquals(result.status, Cosmo0PhaseStatus.Succeeded)
+    assertEquals(result.phase, Phase.Parse)
+    assertEquals(result.status, PhaseStatus.Succeeded)
     assert(result.value.nonEmpty)
     assertEquals(result.value.get.source.name, "<memory>")
     assert(result.diagnostics.isEmpty)
@@ -17,8 +17,8 @@ class Cosmo0Tests extends munit.FunSuite:
   test("parse failures return structured diagnostics"):
     val result = Cosmo0().parse("val =")
 
-    assertEquals(result.phase, Cosmo0Phase.Parse)
-    assertEquals(result.status, Cosmo0PhaseStatus.Failed)
+    assertEquals(result.phase, Phase.Parse)
+    assertEquals(result.status, PhaseStatus.Failed)
     assert(result.value.isEmpty)
     assertEquals(result.diagnostics.head.code, "cosmo0.parse.failed")
     assert(result.diagnostics.head.span.nonEmpty)
@@ -26,8 +26,8 @@ class Cosmo0Tests extends munit.FunSuite:
   test("check returns a structured pending result"):
     val result = Cosmo0().check("val answer = 42")
 
-    assertEquals(result.phase, Cosmo0Phase.Check)
-    assertEquals(result.status, Cosmo0PhaseStatus.Pending)
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Pending)
     assert(result.value.isEmpty)
     assertEquals(result.diagnostics.head.code, "cosmo0.check.pending")
 
@@ -57,27 +57,27 @@ class Cosmo0Tests extends munit.FunSuite:
         |""".stripMargin,
     )
 
-    assertEquals(result.phase, Cosmo0Phase.Check)
-    assertEquals(result.status, Cosmo0PhaseStatus.Succeeded)
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Succeeded)
     assert(result.diagnostics.isEmpty)
 
     val module = result.value.get
     assertEquals(module.declarations.map(_.name), List("SourceId", "Severity", "Diagnostic"))
 
-    val alias = module.declarations.head.asInstanceOf[Cosmo0UntypedTypeAlias]
-    assert(alias.target.isInstanceOf[Cosmo0UntypedAppliedType])
+    val alias = module.declarations.head.asInstanceOf[UntypedTypeAlias]
+    assert(alias.target.isInstanceOf[UntypedAppliedType])
 
-    val severity = module.declarations(1).asInstanceOf[Cosmo0UntypedClass]
+    val severity = module.declarations(1).asInstanceOf[UntypedClass]
     assertEquals(
-      severity.members.collect { case variant: Cosmo0UntypedVariant => variant.name },
+      severity.members.collect { case variant: UntypedVariant => variant.name },
       List("Note", "Error"),
     )
 
-    val diagnostic = module.declarations(2).asInstanceOf[Cosmo0UntypedClass]
-    val push = diagnostic.members.collectFirst { case fn: Cosmo0UntypedFunction => fn }.get
-    val selfType = push.params.head.valueType.get.asInstanceOf[Cosmo0UntypedRefType]
+    val diagnostic = module.declarations(2).asInstanceOf[UntypedClass]
+    val push = diagnostic.members.collectFirst { case fn: UntypedFunction => fn }.get
+    val selfType = push.params.head.valueType.get.asInstanceOf[UntypedRefType]
     assert(selfType.mutable)
-    assert(push.body.exists(_.isInstanceOf[Cosmo0UntypedBlock]))
+    assert(push.body.exists(_.isInstanceOf[UntypedBlock]))
 
   test("elaborate represents match arms and standard-generic variant constructors"):
     val result = Cosmo0().elaborate(
@@ -95,14 +95,14 @@ class Cosmo0Tests extends munit.FunSuite:
         |""".stripMargin,
     )
 
-    assertEquals(result.status, Cosmo0PhaseStatus.Succeeded)
-    val fn = result.value.get.declarations.head.asInstanceOf[Cosmo0UntypedFunction]
-    val body = fn.body.get.asInstanceOf[Cosmo0UntypedBlock]
-    val matchExpr = body.items.collectFirst { case m: Cosmo0UntypedMatch => m }.get
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    val fn = result.value.get.declarations.head.asInstanceOf[UntypedFunction]
+    val body = fn.body.get.asInstanceOf[UntypedBlock]
+    val matchExpr = body.items.collectFirst { case m: UntypedMatch => m }.get
 
     assertEquals(matchExpr.arms.length, 2)
-    val somePattern = matchExpr.arms.head.pattern.asInstanceOf[Cosmo0UntypedVariantPattern]
-    assert(somePattern.constructor.isInstanceOf[Cosmo0UntypedVariantConstructor])
+    val somePattern = matchExpr.arms.head.pattern.asInstanceOf[UntypedVariantPattern]
+    assert(somePattern.constructor.isInstanceOf[UntypedVariantConstructor])
     assertEquals(somePattern.args.length, 1)
 
   test("elaborate rejects unsupported full-language constructs deterministically"):
@@ -124,8 +124,8 @@ class Cosmo0Tests extends munit.FunSuite:
     cases.foreach { case (source, code) =>
       val result = Cosmo0().elaborate(source)
 
-      assertEquals(result.phase, Cosmo0Phase.Check)
-      assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+      assertEquals(result.phase, Phase.Check)
+      assertEquals(result.status, PhaseStatus.Unsupported)
       assert(result.value.isEmpty)
       assert(
         result.diagnostics.exists(_.code == code),
@@ -136,8 +136,8 @@ class Cosmo0Tests extends munit.FunSuite:
   test("check stops on unsupported subset constructs"):
     val result = Cosmo0().check("trait Display {}")
 
-    assertEquals(result.phase, Cosmo0Phase.Check)
-    assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Unsupported)
     assertEquals(result.diagnostics.head.code, "cosmo0.elaborate.unsupported.trait")
 
   test("elaboration preserves spans for accepted nodes and diagnostics"):
@@ -162,15 +162,15 @@ class Cosmo0Tests extends munit.FunSuite:
   test("compile returns a structured unsupported result"):
     val result = Cosmo0().compile("val answer = 42")
 
-    assertEquals(result.phase, Cosmo0Phase.Compile)
-    assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+    assertEquals(result.phase, Phase.Compile)
+    assertEquals(result.status, PhaseStatus.Unsupported)
     assert(result.value.isEmpty)
     assertEquals(result.diagnostics.head.code, "cosmo0.compile.unsupported")
 
   test("compile stops on unsupported subset constructs"):
     val result = Cosmo0().compile("trait Display {}")
 
-    assertEquals(result.phase, Cosmo0Phase.Compile)
-    assertEquals(result.status, Cosmo0PhaseStatus.Unsupported)
+    assertEquals(result.phase, Phase.Compile)
+    assertEquals(result.status, PhaseStatus.Unsupported)
     assert(result.value.isEmpty)
     assertEquals(result.diagnostics.head.code, "cosmo0.elaborate.unsupported.trait")


### PR DESCRIPTION
Implement the initial cosmo0 elaboration pipeline from parsed syntax into a dedicated untyped IR.

- add `UntypedElaborator` and the full untyped model for modules, declarations, types, expressions, patterns, and spans
- normalize supported parser forms into explicit untyped nodes
- reject unsupported language features with deterministic diagnostics
- wire `Cosmo0` facade methods through the new elaboration flow and rename shared phase/result model types
- replace the old facade tests with elaboration-focused coverage for accepted constructs, rejected constructs, and span preservation