### PR TITLE
feat: add cosmo0 typed expressions

### DIFF
--- a/openspec/changes/add-cosmo0-typed-expressions/tasks.md
+++ b/openspec/changes/add-cosmo0-typed-expressions/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Type Model
 
-- [ ] 1.1 Define cosmo0 source-level types for unit, booleans, integers, `usize`, bytes, chars, strings, user declarations, aliases, references, and never/error placeholders.
-- [ ] 1.2 Define sealed standard generic type applications for descriptor-backed types such as `Vec`, `Option`, `Result`, `Arena`, `Id`, `Map`, `Set`, `Ptr`, and `Box`.
-- [ ] 1.3 Add alias expansion and type equality rules for the cosmo0 source type model.
-- [ ] 1.4 Add descriptor signature metadata needed for source-level method checking.
+- [x] 1.1 Define cosmo0 source-level types for unit, booleans, integers, `usize`, bytes, chars, strings, user declarations, aliases, references, and never/error placeholders.
+- [x] 1.2 Define sealed standard generic type applications for descriptor-backed types such as `Vec`, `Option`, `Result`, `Arena`, `Id`, `Map`, `Set`, `Ptr`, and `Box`.
+- [x] 1.3 Add alias expansion and type equality rules for the cosmo0 source type model.
+- [x] 1.4 Add descriptor signature metadata needed for source-level method checking.
 
 ## 2. Typed Expression Representation
 
-- [ ] 2.1 Define typed modules, declarations, statements, expressions, patterns, and callable signatures.
-- [ ] 2.2 Attach resolved type information and source spans to each typed expression node.
-- [ ] 2.3 Represent mutable and immutable references explicitly in typed expression nodes.
+- [x] 2.1 Define typed modules, declarations, statements, expressions, patterns, and callable signatures.
+- [x] 2.2 Attach resolved type information and source spans to each typed expression node.
+- [x] 2.3 Represent mutable and immutable references explicitly in typed expression nodes.
 
 ## 3. Front-End Typer
 
-- [ ] 3.1 Add declaration collection for classes, fields, variants, methods, functions, aliases, and imports accepted by the untyped elaborator.
-- [ ] 3.2 Add scoped name resolution for parameters, locals, fields, functions, methods, aliases, and descriptor-defined names.
-- [ ] 3.3 Type-check literals, locals, assignments, field access, direct calls, method calls, returns, blocks, conditionals, loops, variant construction, and match expressions.
-- [ ] 3.4 Type-check source-level reference and mutability rules for `&T`, `&mut T`, `&self`, and `&mut self`.
-- [ ] 3.5 Type-check descriptor method surfaces for the early standard generics needed by compiler-shaped code.
+- [x] 3.1 Add declaration collection for classes, fields, variants, methods, functions, aliases, and imports accepted by the untyped elaborator.
+- [x] 3.2 Add scoped name resolution for parameters, locals, fields, functions, methods, aliases, and descriptor-defined names.
+- [x] 3.3 Type-check literals, locals, assignments, field access, direct calls, method calls, returns, blocks, conditionals, loops, variant construction, and match expressions.
+- [x] 3.4 Type-check source-level reference and mutability rules for `&T`, `&mut T`, `&self`, and `&mut self`.
+- [x] 3.5 Type-check descriptor method surfaces for the early standard generics needed by compiler-shaped code.
 
 ## 4. Diagnostics And Tests
 
-- [ ] 4.1 Emit source diagnostics for unresolved names, wrong arity, invalid fields, invalid calls, assignment mismatch, return mismatch, invalid match payloads, and invalid mutability.
-- [ ] 4.2 Add positive tests that produce typed expressions for accepted source snippets.
-- [ ] 4.3 Add negative tests for representative type errors and invalid descriptor usage.
-- [ ] 4.4 Confirm the typed-expression typer does not call the existing full Cosmo `Typer`.
+- [x] 4.1 Emit source diagnostics for unresolved names, wrong arity, invalid fields, invalid calls, assignment mismatch, return mismatch, invalid match payloads, and invalid mutability.
+- [x] 4.2 Add positive tests that produce typed expressions for accepted source snippets.
+- [x] 4.3 Add negative tests for representative type errors and invalid descriptor usage.
+- [x] 4.4 Confirm the typed-expression typer does not call the existing full Cosmo `Typer`.

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -52,14 +52,11 @@ final class Cosmo0:
   def check(source: SourceFile): Result[CheckedModule] =
     elaborate(source) match
       case elaborated if elaborated.isSuccess =>
-        Result.pending(
-          Phase.Check,
-          pendingDiagnostic(
-            Phase.Check,
-            "cosmo0.check.pending",
-            "cosmo0 source typing is not implemented yet",
-          ),
-        )
+        SourceTyper().check(elaborated.value.get) match
+          case checked if checked.isSuccess =>
+            Result.success(Phase.Check, CheckedModule(checked.value.get))
+          case failed =>
+            Result.failure(Phase.Check, failed.diagnostics)
       case unsupported if unsupported.isUnsupported =>
         Result(
           Phase.Check,

--- a/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Elaborator.scala
@@ -280,11 +280,21 @@ final class UntypedElaborator(
         }
 
     private def blockItem(node: syntax.Node): Option[UntypedBlockItem] =
-      unwrapSemi(node) match
-        case None => None
-        case Some(valueNode: Val) => local(valueNode, UntypedValueKind.Val)
-        case Some(valueNode: Var) => local(valueNode, UntypedValueKind.Var)
-        case Some(other)          => expr(other)
+      node match
+        case Semi(None) => None
+        case Semi(Some(inner)) =>
+          unwrapSemi(inner) match
+            case None => None
+            case Some(valueNode: Val) => local(valueNode, UntypedValueKind.Val)
+            case Some(valueNode: Var) => local(valueNode, UntypedValueKind.Var)
+            case Some(other) =>
+              expr(other).map(value => UntypedExprStmt(value, nodeSpan(node)))
+        case other =>
+          unwrapSemi(other) match
+            case None => None
+            case Some(valueNode: Val) => local(valueNode, UntypedValueKind.Val)
+            case Some(valueNode: Var) => local(valueNode, UntypedValueKind.Var)
+            case Some(value)          => expr(value)
 
     private def local(
         node: Val,
@@ -345,6 +355,15 @@ final class UntypedElaborator(
             "cosmo0.elaborate.unsupported.higher-order-api",
             s"${rhs.name} is outside the initial cosmo0 higher-order API subset",
           )
+        case Some(Apply(typeApply @ Apply(_, _, true), args, false)) =>
+          val callee = typeFromNode(typeApply, Some(nodeSpan(typeApply))).map(t =>
+            UntypedTypeConstructor(t, nodeSpan(typeApply)),
+          )
+          val callArgs = args.map(expr)
+          for
+            c <- callee
+            as <- sequence(callArgs)
+          yield UntypedCall(c, as, nodeSpan(node))
         case Some(Apply(lhs, args, false)) =>
           val callee = expr(lhs)
           val callArgs = args.map(expr)

--- a/packages/cosmo0/src/main/scala/cosmo0/Model.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Model.scala
@@ -112,7 +112,7 @@ final case class ParsedModule(
 )
 
 final case class CheckedModule(
-    parsed: ParsedModule,
+    typed: TypedModule,
 )
 
 final case class CompiledModule(

--- a/packages/cosmo0/src/main/scala/cosmo0/SourceTyper.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/SourceTyper.scala
@@ -1,0 +1,1393 @@
+package cosmo0
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+object SourceTyper:
+  def apply(): SourceTyper =
+    new SourceTyper(StandardGenericDescriptors.all)
+
+final class SourceTyper(
+    standardGenerics: Map[String, StandardGenericDescriptor],
+):
+  def check(module: UntypedModule): Result[TypedModule] =
+    val state = State(module)
+    state.check()
+
+  private final case class ValueSymbol(
+      name: String,
+      valueType: SourceType,
+      mutableBinding: Boolean,
+      mutationAllowed: Boolean,
+      span: SourceSpan,
+  )
+
+  private final class Scope(parent: Option[Scope]):
+    private val values = mutable.LinkedHashMap.empty[String, ValueSymbol]
+
+    def define(symbol: ValueSymbol): Unit =
+      values.update(symbol.name, symbol)
+
+    def resolve(name: String): Option[ValueSymbol] =
+      values.get(name).orElse(parent.flatMap(_.resolve(name)))
+
+    def child: Scope =
+      new Scope(Some(this))
+
+  private final case class ExprInfo(
+      expr: TypedExpr,
+      mutableBinding: Boolean,
+      mutationAllowed: Boolean,
+  )
+
+  private final case class FieldInfo(
+      name: String,
+      kind: UntypedValueKind,
+      valueType: SourceType,
+      init: Option[UntypedExpr],
+      span: SourceSpan,
+  )
+
+  private final case class VariantInfo(
+      name: String,
+      fields: List[TypedVariantField],
+      span: SourceSpan,
+  ):
+    def signature(owner: String): CallableSignature =
+      CallableSignature(
+        name,
+        fields.zipWithIndex.map { case (field, index) =>
+          CallableParam(field.name.getOrElse(s"field$index"), field.valueType, field.span)
+        },
+        SourceType.User(owner),
+      )
+
+  private final case class ParamInfo(
+      name: String,
+      valueType: SourceType,
+      default: Option[UntypedExpr],
+      span: SourceSpan,
+  )
+
+  private final case class FunctionInfo(
+      name: String,
+      params: List[ParamInfo],
+      returnType: SourceType,
+      body: Option[UntypedExpr],
+      signature: CallableSignature,
+      owner: Option[String],
+      span: SourceSpan,
+  )
+
+  private final case class ClassInfo(
+      name: String,
+      fields: List[FieldInfo],
+      aliases: List[TypedTypeAlias],
+      variants: Map[String, VariantInfo],
+      methods: Map[String, FunctionInfo],
+      span: SourceSpan,
+  ):
+    def constructorSignature: CallableSignature =
+      CallableSignature(
+        name,
+        fields.map(field => CallableParam(field.name, field.valueType, field.span)),
+        SourceType.User(name),
+      )
+
+  private final class State(module: UntypedModule):
+    private val diagnostics = ListBuffer.empty[Diagnostic]
+    private val classNames =
+      module.declarations.collect { case decl: UntypedClass => decl.name }.toSet
+    private val rawAliases = mutable.LinkedHashMap.empty[String, UntypedType]
+    private val aliasTypes = mutable.LinkedHashMap.empty[String, SourceType]
+    private val classes = mutable.LinkedHashMap.empty[String, ClassInfo]
+    private val functions = mutable.LinkedHashMap.empty[String, FunctionInfo]
+
+    def check(): Result[TypedModule] =
+      collectAliases()
+      rawAliases.keys.foreach(resolveAlias)
+      collectClasses()
+      collectFunctions()
+
+      val globalScope = new Scope(None)
+      functions.values.foreach(info =>
+        globalScope.define(
+          ValueSymbol(
+            info.name,
+            info.signature.functionType,
+            mutableBinding = false,
+            mutationAllowed = false,
+            info.span,
+          ),
+        ),
+      )
+
+      val declarations = module.declarations.flatMap(decl =>
+        typedDecl(decl, globalScope),
+      )
+
+      val result = TypedModule(module.source, declarations, module.span)
+      if diagnostics.isEmpty then Result.success(Phase.Check, result)
+      else Result.failure(Phase.Check, diagnostics.toList)
+
+    private def collectAliases(): Unit =
+      module.declarations.foreach {
+        case alias: UntypedTypeAlias =>
+          rawAliases.update(alias.name, alias.target)
+        case cls: UntypedClass =>
+          cls.members.foreach {
+            case alias: UntypedTypeAlias =>
+              rawAliases.update(alias.name, alias.target)
+            case _ =>
+          }
+        case _ =>
+      }
+
+    private def collectClasses(): Unit =
+      module.declarations.collect { case cls: UntypedClass => cls }.foreach { cls =>
+        val fields = cls.members.collect { case field: UntypedValueDecl =>
+          FieldInfo(
+            field.name,
+            field.kind,
+            field.valueType.map(resolveType(_, Some(cls.name))).getOrElse {
+              error(
+                "cosmo0.type.missing-annotation",
+                s"field ${field.name} requires an explicit type",
+                field.span,
+              )
+              SourceType.Error
+            },
+            field.init,
+            field.span,
+          )
+        }
+        val aliases = cls.members.collect { case alias: UntypedTypeAlias =>
+          TypedTypeAlias(alias.name, resolveAlias(alias.name), alias.span)
+        }
+        val variants = cls.members.collect { case variant: UntypedVariant =>
+          val fields = variant.fields.map(field =>
+            TypedVariantField(
+              field.name,
+              resolveType(field.valueType, Some(cls.name)),
+              field.span,
+            ),
+          )
+          variant.name -> VariantInfo(variant.name, fields, variant.span)
+        }.toMap
+        val methods = cls.members.collect { case fn: UntypedFunction =>
+          functionInfo(fn, Some(cls.name))
+        }.map(info => info.name -> info).toMap
+
+        classes.update(
+          cls.name,
+          ClassInfo(cls.name, fields, aliases, variants, methods, cls.span),
+        )
+      }
+
+    private def collectFunctions(): Unit =
+      module.declarations.collect { case fn: UntypedFunction => fn }.foreach { fn =>
+        val info = functionInfo(fn, None)
+        functions.update(info.name, info)
+      }
+
+    private def typedDecl(decl: UntypedDecl, scope: Scope): Option[TypedDecl] =
+      decl match
+        case importDecl: UntypedImport =>
+          Some(TypedImport(importDecl.path, importDecl.dest, importDecl.span))
+        case alias: UntypedTypeAlias =>
+          Some(TypedTypeAlias(alias.name, resolveAlias(alias.name), alias.span))
+        case value: UntypedValueDecl =>
+          val typed = typedValueDecl(value, scope)
+          typed.foreach(valueDecl =>
+            scope.define(valueSymbol(valueDecl.name, valueDecl.valueType, valueDecl.kind, valueDecl.span)),
+          )
+          typed
+        case fn: UntypedFunction =>
+          functions.get(fn.name).map(info => typedFunction(info, scope))
+        case cls: UntypedClass =>
+          classes.get(cls.name).map(info => typedClass(info, scope))
+
+    private def typedClass(info: ClassInfo, globalScope: Scope): TypedClass =
+      val classScope = globalScope.child
+      info.methods.values.foreach(method =>
+        classScope.define(
+          ValueSymbol(
+            method.name,
+            method.signature.functionType,
+            mutableBinding = false,
+            mutationAllowed = false,
+            method.span,
+          ),
+        ),
+      )
+
+      val fields = info.fields.map { field =>
+        val init = field.init.map(expr(_, classScope, Some(field.valueType), FunctionContext.None))
+        init.foreach(checkAssignable(_, field.valueType, field.span, "cosmo0.type.assignment-mismatch"))
+        TypedValueDecl(field.kind, field.name, field.valueType, init.map(_.expr), field.span)
+      }
+      val methods = info.methods.values.toList.map(method => typedFunction(method, globalScope))
+      TypedClass(
+        info.name,
+        fields,
+        info.aliases,
+        info.variants.values.toList.map(variant =>
+          TypedVariant(variant.name, variant.fields, variant.span),
+        ),
+        methods,
+        info.span,
+      )
+
+    private def typedFunction(info: FunctionInfo, outerScope: Scope): TypedFunction =
+      val fnScope = outerScope.child
+      info.params.foreach(param =>
+        fnScope.define(
+          ValueSymbol(
+            param.name,
+            param.valueType,
+            mutableBinding = false,
+            mutationAllowed = mutationCapability(param.valueType),
+            param.span,
+          ),
+        ),
+      )
+      val context = FunctionContext.Some(info.returnType, info.owner)
+      val defaults = info.params.map { param =>
+        param.default.map(expr(_, fnScope, Some(param.valueType), context)).map { typed =>
+          checkAssignable(typed, param.valueType, param.span, "cosmo0.type.assignment-mismatch")
+          typed.expr
+        }
+      }
+      val typedParams = info.params.zip(defaults).map { case (param, default) =>
+        TypedParam(param.name, param.valueType, default, param.span)
+      }
+      val body = info.body.map(expr(_, fnScope, Some(info.returnType), context))
+      body.foreach(checkAssignable(_, info.returnType, info.span, "cosmo0.type.return-mismatch"))
+      TypedFunction(
+        info.name,
+        typedParams,
+        info.returnType,
+        body.map(_.expr),
+        info.signature,
+        info.owner,
+        info.span,
+      )
+
+    private def typedValueDecl(value: UntypedValueDecl, scope: Scope): Option[TypedValueDecl] =
+      val explicitType = value.valueType.map(resolveType(_, None))
+      val init = value.init.map(expr(_, scope, explicitType, FunctionContext.None))
+      val valueType =
+        explicitType.orElse(init.map(_.expr.valueType)).getOrElse {
+          error(
+            "cosmo0.type.missing-annotation",
+            s"value ${value.name} requires a type annotation or initializer",
+            value.span,
+          )
+          SourceType.Error
+        }
+      init.foreach(checkAssignable(_, valueType, value.span, "cosmo0.type.assignment-mismatch"))
+      Some(TypedValueDecl(value.kind, value.name, valueType, init.map(_.expr), value.span))
+
+    private def functionInfo(fn: UntypedFunction, owner: Option[String]): FunctionInfo =
+      val params = fn.params.map(param =>
+        val valueType = param.valueType.map(resolveType(_, owner)).getOrElse {
+          error(
+            "cosmo0.type.missing-annotation",
+            s"parameter ${param.name} requires an explicit type",
+            param.span,
+          )
+          SourceType.Error
+        }
+        ParamInfo(param.name, valueType, param.default, param.span)
+      )
+      val returnType = fn.returnType.map(resolveType(_, owner)).getOrElse(SourceType.Unit)
+      val receiver = owner.flatMap: ownerName =>
+        params.headOption.filter(_.name == "self").flatMap: self =>
+          SourceType.dealias(self.valueType) match
+            case SourceType.Ref(SourceType.User(name), mutable) if name == ownerName =>
+              Some(CallableReceiver(SourceType.User(ownerName), mutable))
+            case SourceType.User(name) if name == ownerName =>
+              Some(CallableReceiver(SourceType.User(ownerName), mutable = true))
+            case _ =>
+              error(
+                "cosmo0.type.invalid-self",
+                s"method ${fn.name} has a self parameter that does not refer to $ownerName",
+                self.span,
+              )
+              None
+      val callableParams =
+        if receiver.nonEmpty && params.headOption.exists(_.name == "self") then params.tail
+        else params
+      val signature = CallableSignature(
+        fn.name,
+        callableParams.map(param => CallableParam(param.name, param.valueType, param.span)),
+        returnType,
+        receiver,
+      )
+      FunctionInfo(fn.name, params, returnType, fn.body, signature, owner, fn.span)
+
+    private def expr(
+        node: UntypedExpr,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      node match
+        case value: UntypedBlock =>
+          blockExpr(value, scope, expected, context)
+        case value: UntypedName =>
+          nameExpr(value, scope)
+        case value: UntypedTypeConstructor =>
+          typeConstructorExpr(value)
+        case value: UntypedSelect =>
+          selectExpr(value, scope, context)
+        case value: UntypedVariantConstructor =>
+          variantConstructorExpr(value)
+        case value: UntypedCall =>
+          callExpr(value, scope, expected, context)
+        case value: UntypedAssign =>
+          assignExpr(value, scope, context)
+        case value: UntypedUnary =>
+          unaryExpr(value, scope, expected, context)
+        case value: UntypedBinary =>
+          binaryExpr(value, scope, expected, context)
+        case value: UntypedIf =>
+          ifExpr(value, scope, expected, context)
+        case value: UntypedLoop =>
+          val body = expr(value.body, scope.child, Some(SourceType.Unit), context)
+          ExprInfo(TypedLoop(body.expr, SourceType.Unit, value.span), mutableBinding = false, mutationAllowed = true)
+        case value: UntypedWhile =>
+          val cond = expr(value.cond, scope, Some(SourceType.Bool), context)
+          requireBool(cond, value.cond.span)
+          val body = expr(value.body, scope.child, Some(SourceType.Unit), context)
+          ExprInfo(TypedWhile(cond.expr, body.expr, SourceType.Unit, value.span), false, true)
+        case value: UntypedFor =>
+          forExpr(value, scope, context)
+        case value: UntypedMatch =>
+          matchExpr(value, scope, expected, context)
+        case value: UntypedReturn =>
+          returnExpr(value, scope, context)
+        case value: UntypedBreak =>
+          ExprInfo(TypedBreak(SourceType.Never, value.span), false, false)
+        case value: UntypedContinue =>
+          ExprInfo(TypedContinue(SourceType.Never, value.span), false, false)
+        case value: UntypedBoolLiteral =>
+          ExprInfo(TypedBoolLiteral(value.value, SourceType.Bool, value.span), false, false)
+        case value: UntypedIntLiteral =>
+          val valueType = expected.filter(SourceType.isInteger).getOrElse(SourceType.I32)
+          ExprInfo(TypedIntLiteral(value.value, valueType, value.span), false, false)
+        case value: UntypedFloatLiteral =>
+          val valueType = expected.filter(SourceType.isFloat).getOrElse(SourceType.F64)
+          ExprInfo(TypedFloatLiteral(value.value, valueType, value.span), false, false)
+        case value: UntypedStringLiteral =>
+          ExprInfo(TypedStringLiteral(value.value, SourceType.String, value.span), false, false)
+        case value: UntypedUnitLiteral =>
+          ExprInfo(TypedUnitLiteral(SourceType.Unit, value.span), false, false)
+
+    private def blockExpr(
+        node: UntypedBlock,
+        outerScope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      val scope = outerScope.child
+      val items = node.items.zipWithIndex.map { case (item, index) =>
+        val itemExpected =
+          if index == node.items.length - 1 then expected else None
+        blockItem(item, scope, itemExpected, context)
+      }
+      val valueType = items.lastOption match
+        case Some(expr: TypedExpr) => expr.valueType
+        case _                     => SourceType.Unit
+      ExprInfo(TypedBlock(items, valueType, node.span), mutableBinding = false, mutationAllowed = true)
+
+    private def blockItem(
+        item: UntypedBlockItem,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): TypedBlockItem =
+      item match
+        case local: UntypedLocal =>
+          val explicitType = local.valueType.map(resolveType(_, context.ownerName))
+          val init = local.init.map(expr(_, scope, explicitType, context))
+          val valueType =
+            explicitType.orElse(init.map(_.expr.valueType)).getOrElse {
+              error(
+                "cosmo0.type.missing-annotation",
+                s"local ${local.name} requires a type annotation or initializer",
+                local.span,
+              )
+              SourceType.Error
+            }
+          init.foreach(checkAssignable(_, valueType, local.span, "cosmo0.type.assignment-mismatch"))
+          scope.define(valueSymbol(local.name, valueType, local.kind, local.span))
+          TypedLocal(local.kind, local.name, valueType, init.map(_.expr), local.span)
+        case stmt: UntypedExprStmt =>
+          val typed = expr(stmt.expr, scope, expected, context)
+          TypedExprStmt(typed.expr, stmt.span)
+        case expression: UntypedExpr =>
+          val typed = expr(expression, scope, expected, context)
+          typed.expr
+
+    private def nameExpr(node: UntypedName, scope: Scope): ExprInfo =
+      node.path.parts match
+        case name :: Nil =>
+          scope.resolve(name) match
+            case Some(symbol) =>
+              ExprInfo(
+                TypedName(node.path, symbol.valueType, symbol.mutableBinding, symbol.mutationAllowed, node.span),
+                symbol.mutableBinding,
+                symbol.mutationAllowed,
+              )
+            case None =>
+              classConstructor(name, node.span) match
+                case Some(signature) =>
+                  val valueType = signature.functionType
+                  ExprInfo(TypedName(node.path, valueType, false, false, node.span), false, false)
+                case None =>
+                  error(
+                    "cosmo0.type.unresolved-name",
+                    s"unresolved name ${node.path.text}",
+                    node.span,
+                  )
+                  ExprInfo(TypedName(node.path, SourceType.Error, false, false, node.span), false, false)
+        case _ =>
+          error(
+            "cosmo0.type.unresolved-name",
+            s"unresolved name ${node.path.text}",
+            node.span,
+          )
+          ExprInfo(TypedName(node.path, SourceType.Error, false, false, node.span), false, false)
+
+    private def typeConstructorExpr(node: UntypedTypeConstructor): ExprInfo =
+      val constructedType = resolveType(node.valueType, None)
+      val valueType = SourceType.dealias(constructedType) match
+        case owner @ SourceType.Standard(name, _) =>
+          standardGenerics
+            .get(name)
+            .flatMap(_.constructor("<init>"))
+            .map(_.instantiate(owner, node.span).functionType)
+            .getOrElse(SourceType.Error)
+        case _ => SourceType.Error
+      ExprInfo(TypedTypeConstructorExpr(constructedType, valueType, node.span), false, false)
+
+    private def selectExpr(
+        node: UntypedSelect,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      node.receiver match
+        case UntypedName(path, _) if path.parts.length == 1 =>
+          val ownerName = path.parts.head
+          classes.get(ownerName).flatMap(_.variants.get(node.field)) match
+            case Some(variant) =>
+              val signature = variant.signature(ownerName)
+              val valueType =
+                if signature.params.isEmpty then signature.returnType else signature.functionType
+              return ExprInfo(
+                TypedVariantConstructorExpr(SourceType.User(ownerName), node.field, valueType, node.span),
+                mutableBinding = false,
+                mutationAllowed = false,
+              )
+            case None =>
+        case _ =>
+
+      val receiver = expr(node.receiver, scope, None, context)
+      SourceType.dealias(receiver.expr.valueType) match
+        case owner @ SourceType.Standard(name, _) =>
+          standardGenerics.get(name).flatMap(_.method(node.field)) match
+            case Some(method) =>
+              val signature = method.instantiate(owner, node.span)
+              ExprInfo(
+                TypedSelect(
+                  receiver.expr,
+                  node.field,
+                  signature.functionType,
+                  mutableBinding = false,
+                  mutationAllowed = false,
+                  node.span,
+                ),
+                mutableBinding = false,
+                mutationAllowed = false,
+              )
+            case None =>
+              invalidField(node.field, receiver.expr.valueType, node.span)
+        case SourceType.Ref(owner @ SourceType.Standard(name, _), _) =>
+          standardGenerics.get(name).flatMap(_.method(node.field)) match
+            case Some(method) =>
+              val signature = method.instantiate(owner, node.span)
+              ExprInfo(
+                TypedSelect(receiver.expr, node.field, signature.functionType, false, false, node.span),
+                false,
+                false,
+              )
+            case None =>
+              invalidField(node.field, receiver.expr.valueType, node.span)
+        case ty =>
+          classInfoFor(ty) match
+            case Some(cls) =>
+              cls.fields.find(_.name == node.field) match
+                case Some(field) =>
+                  val fieldMutationAllowed = receiver.mutationAllowed && mutationCapability(field.valueType)
+                  val mutableBinding =
+                    field.kind == UntypedValueKind.Var && receiver.mutationAllowed
+                  ExprInfo(
+                    TypedSelect(
+                      receiver.expr,
+                      node.field,
+                      field.valueType,
+                      mutableBinding,
+                      fieldMutationAllowed,
+                      node.span,
+                    ),
+                    mutableBinding,
+                    fieldMutationAllowed,
+                  )
+                case None =>
+                  cls.methods.get(node.field) match
+                    case Some(method) =>
+                      ExprInfo(
+                        TypedSelect(
+                          receiver.expr,
+                          node.field,
+                          method.signature.functionType,
+                          mutableBinding = false,
+                          mutationAllowed = false,
+                          node.span,
+                        ),
+                        false,
+                        false,
+                      )
+                    case None =>
+                      invalidField(node.field, receiver.expr.valueType, node.span)
+            case None =>
+              invalidField(node.field, receiver.expr.valueType, node.span)
+
+    private def invalidField(field: String, receiverType: SourceType, span: SourceSpan): ExprInfo =
+      error(
+        "cosmo0.type.invalid-field",
+        s"type ${receiverType.display} has no field or method $field",
+        span,
+      )
+      ExprInfo(
+        TypedSelect(
+          TypedUnitLiteral(SourceType.Unit, span),
+          field,
+          SourceType.Error,
+          mutableBinding = false,
+          mutationAllowed = false,
+          span,
+        ),
+        mutableBinding = false,
+        mutationAllowed = false,
+      )
+
+    private def variantConstructorExpr(node: UntypedVariantConstructor): ExprInfo =
+      val ownerType = resolveType(node.owner, None)
+      constructorSignature(ownerType, node.variant, node.span) match
+        case Some(signature) =>
+          val valueType =
+            if signature.params.isEmpty then signature.returnType else signature.functionType
+          ExprInfo(
+            TypedVariantConstructorExpr(ownerType, node.variant, valueType, node.span),
+            mutableBinding = false,
+            mutationAllowed = false,
+          )
+        case None =>
+          error(
+            "cosmo0.type.invalid-field",
+            s"type ${ownerType.display} has no variant constructor ${node.variant}",
+            node.span,
+          )
+          ExprInfo(
+            TypedVariantConstructorExpr(ownerType, node.variant, SourceType.Error, node.span),
+            false,
+            false,
+          )
+
+    private def callExpr(
+        node: UntypedCall,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      node.callee match
+        case select: UntypedSelect =>
+          methodOrVariantCall(select, node.args, node.span, scope, expected, context)
+        case constructor: UntypedVariantConstructor =>
+          val ownerType = resolveType(constructor.owner, context.ownerName)
+          constructorSignature(ownerType, constructor.variant, constructor.span) match
+            case Some(signature) =>
+              callWithSignature(
+                TypedVariantConstructorExpr(ownerType, constructor.variant, signature.functionType, constructor.span),
+                signature,
+                node.args,
+                node.span,
+                scope,
+                context,
+              )
+            case None =>
+              error(
+                "cosmo0.type.invalid-call",
+                s"type ${ownerType.display} has no variant constructor ${constructor.variant}",
+                constructor.span,
+              )
+              errorCall(node, scope, context)
+        case constructor: UntypedTypeConstructor =>
+          val constructedType = resolveType(constructor.valueType, context.ownerName)
+          SourceType.dealias(constructedType) match
+            case owner @ SourceType.Standard(name, _) =>
+              standardGenerics.get(name).flatMap(_.constructor("<init>")) match
+                case Some(descriptor) =>
+                  val signature = descriptor.instantiate(owner, constructor.span)
+                  callWithSignature(
+                    TypedTypeConstructorExpr(constructedType, signature.functionType, constructor.span),
+                    signature,
+                    node.args,
+                    node.span,
+                    scope,
+                    context,
+                  )
+                case None =>
+                  error(
+                    "cosmo0.type.invalid-call",
+                    s"type ${constructedType.display} is not directly constructible",
+                    constructor.span,
+                  )
+                  errorCall(node, scope, context)
+            case _ =>
+              error(
+                "cosmo0.type.invalid-call",
+                s"type ${constructedType.display} is not directly constructible",
+                constructor.span,
+              )
+              errorCall(node, scope, context)
+        case name: UntypedName if name.path.parts.length == 1 =>
+          val calleeName = name.path.parts.head
+          functions.get(calleeName) match
+            case Some(info) =>
+              callWithSignature(
+                TypedName(name.path, info.signature.functionType, false, false, name.span),
+                info.signature,
+                node.args,
+                node.span,
+                scope,
+                context,
+              )
+            case None =>
+              classConstructor(calleeName, name.span) match
+                case Some(signature) =>
+                  callWithSignature(
+                    TypedName(name.path, signature.functionType, false, false, name.span),
+                    signature,
+                    node.args,
+                    node.span,
+                    scope,
+                    context,
+                  )
+                case None =>
+                  val callee = expr(node.callee, scope, None, context)
+                  callFunctionValue(callee, node.args, node.span, scope, context)
+        case _ =>
+          val callee = expr(node.callee, scope, None, context)
+          callFunctionValue(callee, node.args, node.span, scope, context)
+
+    private def methodOrVariantCall(
+        select: UntypedSelect,
+        args: List[UntypedExpr],
+        span: SourceSpan,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      select.receiver match
+        case UntypedName(path, _) if path.parts.length == 1 =>
+          val ownerName = path.parts.head
+          classes.get(ownerName).flatMap(_.variants.get(select.field)) match
+            case Some(variant) =>
+              val signature = variant.signature(ownerName)
+              return callWithSignature(
+                TypedVariantConstructorExpr(SourceType.User(ownerName), select.field, signature.functionType, select.span),
+                signature,
+                args,
+                span,
+                scope,
+                context,
+              )
+            case None =>
+        case _ =>
+
+      val receiver = expr(select.receiver, scope, None, context)
+      SourceType.dealias(receiver.expr.valueType) match
+        case owner @ SourceType.Standard(name, _) =>
+          standardGenerics.get(name).flatMap(_.method(select.field)) match
+            case Some(method) =>
+              val signature = method.instantiate(owner, select.span)
+              checkReceiverMutation(receiver, signature, select.span)
+              callWithSignature(
+                TypedSelect(receiver.expr, select.field, signature.functionType, false, false, select.span),
+                signature,
+                args,
+                span,
+                scope,
+                context,
+              )
+            case None =>
+              val selected = selectExpr(select, scope, context)
+              callFunctionValue(selected, args, span, scope, context)
+        case SourceType.Ref(owner @ SourceType.Standard(name, _), _) =>
+          standardGenerics.get(name).flatMap(_.method(select.field)) match
+            case Some(method) =>
+              val signature = method.instantiate(owner, select.span)
+              checkReceiverMutation(receiver, signature, select.span)
+              callWithSignature(
+                TypedSelect(receiver.expr, select.field, signature.functionType, false, false, select.span),
+                signature,
+                args,
+                span,
+                scope,
+                context,
+              )
+            case None =>
+              val selected = selectExpr(select, scope, context)
+              callFunctionValue(selected, args, span, scope, context)
+        case ty =>
+          classInfoFor(ty) match
+            case Some(cls) =>
+              cls.methods.get(select.field) match
+                case Some(method) =>
+                  checkReceiverMutation(receiver, method.signature, select.span)
+                  callWithSignature(
+                    TypedSelect(receiver.expr, select.field, method.signature.functionType, false, false, select.span),
+                    method.signature,
+                    args,
+                    span,
+                    scope,
+                    context,
+                  )
+                case None =>
+                  val selected = selectExpr(select, scope, context)
+                  callFunctionValue(selected, args, span, scope, context)
+            case None =>
+              val selected = selectExpr(select, scope, context)
+              callFunctionValue(selected, args, span, scope, context)
+
+    private def callFunctionValue(
+        callee: ExprInfo,
+        args: List[UntypedExpr],
+        span: SourceSpan,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      SourceType.dealias(callee.expr.valueType) match
+        case SourceType.Function(params, returnType) =>
+          val signature = CallableSignature(
+            "<function>",
+            params.zipWithIndex.map { case (paramType, index) =>
+              CallableParam(s"arg$index", paramType, span)
+            },
+            returnType,
+          )
+          callWithSignature(callee.expr, signature, args, span, scope, context)
+        case other =>
+          error(
+            "cosmo0.type.invalid-call",
+            s"type ${other.display} is not callable",
+            span,
+          )
+          val typedArgs = args.map(expr(_, scope, None, context).expr)
+          ExprInfo(
+            TypedCall(callee.expr, typedArgs, SourceType.Error, CallableSignature("<error>", Nil, SourceType.Error), span),
+            false,
+            false,
+          )
+
+    private def callWithSignature(
+        callee: TypedExpr,
+        signature: CallableSignature,
+        args: List[UntypedExpr],
+        span: SourceSpan,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      if args.length != signature.params.length then
+        error(
+          "cosmo0.type.wrong-arity",
+          s"${signature.name} expects ${signature.params.length} argument(s), got ${args.length}",
+          span,
+        )
+      val typedArgs = args.zipWithIndex.map { case (arg, index) =>
+        val expectedType = signature.params.lift(index).map(_.valueType)
+        val typed = expr(arg, scope, expectedType, context)
+        expectedType.foreach(paramType =>
+          if !canPass(typed, paramType) then
+            error(
+              "cosmo0.type.invalid-call",
+              s"argument ${index + 1} has type ${typed.expr.valueType.display}, expected ${paramType.display}",
+              arg.span,
+            ),
+        )
+        typed.expr
+      }
+      ExprInfo(
+        TypedCall(callee, typedArgs, signature.returnType, signature, span),
+        mutableBinding = false,
+        mutationAllowed = mutationCapability(signature.returnType),
+      )
+
+    private def errorCall(
+        node: UntypedCall,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      val callee = expr(node.callee, scope, None, context)
+      val args = node.args.map(expr(_, scope, None, context).expr)
+      ExprInfo(
+        TypedCall(
+          callee.expr,
+          args,
+          SourceType.Error,
+          CallableSignature("<error>", Nil, SourceType.Error),
+          node.span,
+        ),
+        false,
+        false,
+      )
+
+    private def assignExpr(
+        node: UntypedAssign,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      val target = expr(node.target, scope, None, context)
+      if !target.mutableBinding then
+        error(
+          "cosmo0.type.invalid-mutability",
+          "assignment target is not mutable",
+          node.target.span,
+        )
+      val valueExpected =
+        if node.op == "=" then Some(target.expr.valueType) else Some(target.expr.valueType)
+      val value = expr(node.value, scope, valueExpected, context)
+      if !SourceType.assignable(value.expr.valueType, target.expr.valueType) then
+        error(
+          "cosmo0.type.assignment-mismatch",
+          s"cannot assign ${value.expr.valueType.display} to ${target.expr.valueType.display}",
+          node.span,
+        )
+      if node.op != "=" && !SourceType.isNumeric(target.expr.valueType) then
+        error(
+          "cosmo0.type.assignment-mismatch",
+          s"operator ${node.op} requires a numeric target",
+          node.span,
+        )
+      ExprInfo(TypedAssign(target.expr, value.expr, node.op, SourceType.Unit, node.span), false, true)
+
+    private def unaryExpr(
+        node: UntypedUnary,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      node.op match
+        case "!" =>
+          val value = expr(node.expr, scope, Some(SourceType.Bool), context)
+          requireBool(value, node.expr.span)
+          ExprInfo(TypedUnary(node.op, value.expr, SourceType.Bool, node.span), false, false)
+        case "-" =>
+          val value = expr(node.expr, scope, expected.filter(SourceType.isNumeric), context)
+          if !SourceType.isNumeric(value.expr.valueType) then
+            error(
+              "cosmo0.type.invalid-unary",
+              s"operator - requires a numeric operand, got ${value.expr.valueType.display}",
+              node.span,
+            )
+          ExprInfo(TypedUnary(node.op, value.expr, value.expr.valueType, node.span), false, false)
+        case "&" =>
+          val value = expr(node.expr, scope, None, context)
+          ExprInfo(
+            TypedUnary(node.op, value.expr, SourceType.Ref(value.expr.valueType, mutable = false), node.span),
+            false,
+            false,
+          )
+        case "*" =>
+          val value = expr(node.expr, scope, None, context)
+          SourceType.dealias(value.expr.valueType) match
+            case SourceType.Ref(target, mutable) =>
+              ExprInfo(TypedUnary(node.op, value.expr, target, node.span), mutable, mutable)
+            case other =>
+              error(
+                "cosmo0.type.invalid-unary",
+                s"operator * requires a reference, got ${other.display}",
+                node.span,
+              )
+              ExprInfo(TypedUnary(node.op, value.expr, SourceType.Error, node.span), false, false)
+        case other =>
+          val value = expr(node.expr, scope, None, context)
+          error(
+            "cosmo0.type.invalid-unary",
+            s"unsupported unary operator $other",
+            node.span,
+          )
+          ExprInfo(TypedUnary(other, value.expr, SourceType.Error, node.span), false, false)
+
+    private def binaryExpr(
+        node: UntypedBinary,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      node.op match
+        case "and" | "or" | "&&" | "||" =>
+          val left = expr(node.left, scope, Some(SourceType.Bool), context)
+          val right = expr(node.right, scope, Some(SourceType.Bool), context)
+          requireBool(left, node.left.span)
+          requireBool(right, node.right.span)
+          ExprInfo(TypedBinary(node.op, left.expr, right.expr, SourceType.Bool, node.span), false, false)
+        case "==" | "!=" =>
+          val left = expr(node.left, scope, None, context)
+          val right = expr(node.right, scope, Some(left.expr.valueType), context)
+          if !SourceType.same(left.expr.valueType, right.expr.valueType) then
+            error(
+              "cosmo0.type.invalid-binary",
+              s"operator ${node.op} requires comparable operands, got ${left.expr.valueType.display} and ${right.expr.valueType.display}",
+              node.span,
+            )
+          ExprInfo(TypedBinary(node.op, left.expr, right.expr, SourceType.Bool, node.span), false, false)
+        case "<" | "<=" | ">" | ">=" =>
+          val left = expr(node.left, scope, expected.filter(SourceType.isNumeric), context)
+          val right = expr(node.right, scope, Some(left.expr.valueType), context)
+          if !SourceType.isNumeric(left.expr.valueType) || !SourceType.same(left.expr.valueType, right.expr.valueType) then
+            error(
+              "cosmo0.type.invalid-binary",
+              s"operator ${node.op} requires matching numeric operands",
+              node.span,
+            )
+          ExprInfo(TypedBinary(node.op, left.expr, right.expr, SourceType.Bool, node.span), false, false)
+        case "+" | "-" | "*" | "/" | "%" =>
+          val left = expr(node.left, scope, expected.filter(SourceType.isNumeric), context)
+          val right = expr(node.right, scope, Some(left.expr.valueType), context)
+          if !SourceType.isNumeric(left.expr.valueType) || !SourceType.same(left.expr.valueType, right.expr.valueType) then
+            error(
+              "cosmo0.type.invalid-binary",
+              s"operator ${node.op} requires matching numeric operands",
+              node.span,
+            )
+          ExprInfo(TypedBinary(node.op, left.expr, right.expr, left.expr.valueType, node.span), false, false)
+        case other =>
+          val left = expr(node.left, scope, None, context)
+          val right = expr(node.right, scope, Some(left.expr.valueType), context)
+          error(
+            "cosmo0.type.invalid-binary",
+            s"unsupported binary operator $other",
+            node.span,
+          )
+          ExprInfo(TypedBinary(other, left.expr, right.expr, SourceType.Error, node.span), false, false)
+
+    private def ifExpr(
+        node: UntypedIf,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      val cond = expr(node.cond, scope, Some(SourceType.Bool), context)
+      requireBool(cond, node.cond.span)
+      val thenBranch = expr(node.thenBranch, scope.child, expected, context)
+      val elseBranch = node.elseBranch.map(expr(_, scope.child, expected, context))
+      val valueType = elseBranch match
+        case Some(other) if SourceType.same(thenBranch.expr.valueType, other.expr.valueType) =>
+          thenBranch.expr.valueType
+        case Some(other) =>
+          error(
+            "cosmo0.type.branch-mismatch",
+            s"if branches have types ${thenBranch.expr.valueType.display} and ${other.expr.valueType.display}",
+            node.span,
+          )
+          SourceType.Error
+        case None => SourceType.Unit
+      ExprInfo(TypedIf(cond.expr, thenBranch.expr, elseBranch.map(_.expr), valueType, node.span), false, mutationCapability(valueType))
+
+    private def forExpr(
+        node: UntypedFor,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      val iter = expr(node.iter, scope, None, context)
+      val itemType = SourceType.dealias(iter.expr.valueType) match
+        case SourceType.Standard("Vec" | "Set" | "Arena", item :: Nil) => item
+        case other =>
+          error(
+            "cosmo0.type.invalid-iterator",
+            s"type ${other.display} is not iterable in cosmo0",
+            node.iter.span,
+          )
+          SourceType.Error
+      val bodyScope = scope.child
+      bodyScope.define(ValueSymbol(node.name, itemType, false, mutationCapability(itemType), node.span))
+      val body = expr(node.body, bodyScope, Some(SourceType.Unit), context)
+      ExprInfo(TypedFor(node.name, itemType, iter.expr, body.expr, SourceType.Unit, node.span), false, true)
+
+    private def matchExpr(
+        node: UntypedMatch,
+        scope: Scope,
+        expected: Option[SourceType],
+        context: FunctionContext,
+    ): ExprInfo =
+      val scrutinee = expr(node.scrutinee, scope, None, context)
+      val arms = node.arms.map { arm =>
+        val armScope = scope.child
+        val typedPattern = pattern(arm.pattern, scrutinee.expr.valueType, armScope)
+        val body = arm.body.map(expr(_, armScope, expected, context))
+        TypedMatchArm(typedPattern, body.map(_.expr), arm.span)
+      }
+      val bodyTypes = arms.flatMap(_.body.map(_.valueType))
+      val valueType =
+        if bodyTypes.isEmpty then SourceType.Unit
+        else
+          val first = bodyTypes.head
+          if bodyTypes.tail.forall(valueType => SourceType.same(first, valueType)) then first
+          else
+            error(
+              "cosmo0.type.branch-mismatch",
+              "match arms must produce the same type",
+              node.span,
+            )
+            SourceType.Error
+      ExprInfo(TypedMatch(scrutinee.expr, arms, valueType, node.span), false, mutationCapability(valueType))
+
+    private def returnExpr(
+        node: UntypedReturn,
+        scope: Scope,
+        context: FunctionContext,
+    ): ExprInfo =
+      context match
+        case FunctionContext.Some(returnType, _) =>
+          val value = expr(node.value, scope, Some(returnType), context)
+          if !SourceType.assignable(value.expr.valueType, returnType) then
+            error(
+              "cosmo0.type.return-mismatch",
+              s"return has type ${value.expr.valueType.display}, expected ${returnType.display}",
+              node.span,
+            )
+          ExprInfo(TypedReturn(value.expr, SourceType.Never, node.span), false, false)
+        case FunctionContext.None =>
+          val value = expr(node.value, scope, None, context)
+          error(
+            "cosmo0.type.invalid-return",
+            "return can only appear inside a function",
+            node.span,
+          )
+          ExprInfo(TypedReturn(value.expr, SourceType.Never, node.span), false, false)
+
+    private def pattern(
+        node: UntypedPattern,
+        expectedType: SourceType,
+        scope: Scope,
+    ): TypedPattern =
+      node match
+        case value: UntypedWildcardPattern =>
+          TypedWildcardPattern(expectedType, value.span)
+        case value: UntypedBindingPattern =>
+          scope.define(
+            ValueSymbol(
+              value.name,
+              expectedType,
+              mutableBinding = false,
+              mutationAllowed = mutationCapability(expectedType),
+              value.span,
+            ),
+          )
+          TypedBindingPattern(value.name, expectedType, value.span)
+        case value: UntypedBoolLiteral =>
+          if !SourceType.same(expectedType, SourceType.Bool) then
+            invalidPatternType(value.span, expectedType, SourceType.Bool)
+          TypedBoolLiteral(value.value, SourceType.Bool, value.span)
+        case value: UntypedIntLiteral =>
+          val valueType =
+            if SourceType.isInteger(expectedType) then expectedType else SourceType.I32
+          if !SourceType.isInteger(expectedType) then
+            invalidPatternType(value.span, expectedType, valueType)
+          TypedIntLiteral(value.value, valueType, value.span)
+        case value: UntypedFloatLiteral =>
+          val valueType =
+            if SourceType.isFloat(expectedType) then expectedType else SourceType.F64
+          if !SourceType.isFloat(expectedType) then
+            invalidPatternType(value.span, expectedType, valueType)
+          TypedFloatLiteral(value.value, valueType, value.span)
+        case value: UntypedStringLiteral =>
+          if !SourceType.same(expectedType, SourceType.String) then
+            invalidPatternType(value.span, expectedType, SourceType.String)
+          TypedStringLiteral(value.value, SourceType.String, value.span)
+        case value: UntypedVariantPattern =>
+          variantPattern(value, expectedType, scope)
+
+    private def variantPattern(
+        node: UntypedVariantPattern,
+        expectedType: SourceType,
+        scope: Scope,
+    ): TypedPattern =
+      val constructor = constructorExprForPattern(node.constructor, expectedType)
+      val signature = constructor.flatMap { case (ownerType, variantName, expr) =>
+        constructorSignature(ownerType, variantName, expr.span).map(signature => (signature, expr))
+      }
+      signature match
+        case Some((callable, constructorExpr)) =>
+          if !SourceType.same(callable.returnType, expectedType) then
+            error(
+              "cosmo0.type.invalid-match-payload",
+              s"pattern constructor returns ${callable.returnType.display}, expected ${expectedType.display}",
+              node.span,
+            )
+          if node.args.length != callable.params.length then
+            error(
+              "cosmo0.type.wrong-arity",
+              s"pattern expects ${callable.params.length} payload(s), got ${node.args.length}",
+              node.span,
+            )
+          val args = node.args.zipWithIndex.map { case (arg, index) =>
+            val argType = callable.params.lift(index).map(_.valueType).getOrElse(SourceType.Error)
+            pattern(arg, argType, scope)
+          }
+          TypedVariantPattern(constructorExpr, args, callable.returnType, node.span)
+        case None =>
+          error(
+            "cosmo0.type.invalid-match-payload",
+            "invalid variant pattern",
+            node.span,
+          )
+          TypedVariantPattern(
+            TypedVariantConstructorExpr(expectedType, "<error>", SourceType.Error, node.span),
+            Nil,
+            SourceType.Error,
+            node.span,
+          )
+
+    private def constructorExprForPattern(
+        node: UntypedExpr,
+        expectedType: SourceType,
+    ): Option[(SourceType, String, TypedExpr)] =
+      node match
+        case UntypedVariantConstructor(owner, variant, span) =>
+          val ownerType = resolveType(owner, None)
+          Some(
+            (
+              ownerType,
+              variant,
+              TypedVariantConstructorExpr(ownerType, variant, SourceType.Function(Nil, ownerType), span),
+            ),
+          )
+        case UntypedSelect(UntypedName(path, _), variant, span) if path.parts.length == 1 =>
+          val ownerType = SourceType.User(path.parts.head)
+          Some(
+            (
+              ownerType,
+              variant,
+              TypedVariantConstructorExpr(ownerType, variant, SourceType.Function(Nil, ownerType), span),
+            ),
+          )
+        case _ =>
+          None
+
+    private def constructorSignature(
+        ownerType: SourceType,
+        variant: String,
+        span: SourceSpan,
+    ): Option[CallableSignature] =
+      SourceType.dealias(ownerType) match
+        case owner @ SourceType.Standard(name, _) =>
+          standardGenerics.get(name).flatMap(_.constructor(variant)).map(_.instantiate(owner, span))
+        case SourceType.User(name) =>
+          classes.get(name).flatMap(_.variants.get(variant)).map(_.signature(name))
+        case _ => None
+
+    private def classConstructor(
+        name: String,
+        span: SourceSpan,
+    ): Option[CallableSignature] =
+      classes.get(name).map(_.constructorSignature)
+
+    private def classInfoFor(valueType: SourceType): Option[ClassInfo] =
+      SourceType.dealias(valueType) match
+        case SourceType.User(name)          => classes.get(name)
+        case SourceType.Ref(SourceType.User(name), _) => classes.get(name)
+        case _                              => None
+
+    private def resolveAlias(name: String): SourceType =
+      resolveAlias(name, Set.empty)
+
+    private def resolveAlias(name: String, seen: Set[String]): SourceType =
+      val resolved = rawAliases.get(name) match
+        case Some(target) if seen.contains(name) =>
+          error(
+            "cosmo0.type.recursive-alias",
+            s"type alias $name is recursive",
+            target.span,
+          )
+          SourceType.Error
+        case Some(target) =>
+          resolveType(target, None, seen + name)
+        case None =>
+          SourceType.Error
+      aliasTypes.getOrElseUpdate(name, resolved)
+
+    private def resolveType(
+        node: UntypedType,
+        owner: Option[String],
+    ): SourceType =
+      resolveType(node, owner, Set.empty)
+
+    private def resolveType(
+        node: UntypedType,
+        owner: Option[String],
+        seenAliases: Set[String],
+    ): SourceType =
+      node match
+        case UntypedNamedType(path, span) =>
+          path.parts match
+            case name :: Nil if owner.contains(name) || (name == "self" && owner.nonEmpty) =>
+              SourceType.User(owner.get)
+            case name :: Nil =>
+              SourceType.scalar(name)
+                .orElse(
+                  rawAliases.get(name).map(_ =>
+                    SourceType.Alias(name, resolveAlias(name, seenAliases)),
+                  ),
+                )
+                .orElse(
+                  if classNames.contains(name) then Some(SourceType.User(name)) else None,
+                )
+                .getOrElse {
+                  error(
+                    "cosmo0.type.unknown-type",
+                    s"unknown type ${path.text}",
+                    span,
+                  )
+                  SourceType.Error
+                }
+            case _ =>
+              error(
+                "cosmo0.type.unknown-type",
+                s"unknown type ${path.text}",
+                span,
+              )
+              SourceType.Error
+        case UntypedAppliedType(base, args, span) =>
+          val name = base.parts.lastOption.getOrElse(base.text)
+          standardGenerics.get(name) match
+            case Some(descriptor) =>
+              if descriptor.arity != args.length then
+                error(
+                  "cosmo0.type.wrong-arity",
+                  s"$name expects ${descriptor.arity} type argument(s), got ${args.length}",
+                  span,
+                )
+              SourceType.Standard(name, args.map(resolveType(_, owner, seenAliases)))
+            case None =>
+              error(
+                "cosmo0.type.unknown-type",
+                s"unknown standard generic type ${base.text}",
+                span,
+              )
+              SourceType.Error
+        case UntypedRefType(target, mutable, _) =>
+          SourceType.Ref(resolveType(target, owner, seenAliases), mutable)
+
+    private def canPass(actual: ExprInfo, expected: SourceType): Boolean =
+      SourceType.dealias(expected) match
+        case SourceType.Ref(target, mutable) =>
+          SourceType.dealias(actual.expr.valueType) match
+            case SourceType.Ref(actualTarget, actualMutable) =>
+              SourceType.same(actualTarget, target) && (!mutable || actualMutable)
+            case other =>
+              SourceType.same(other, target) && (!mutable || actual.mutationAllowed)
+        case other =>
+          SourceType.assignable(actual.expr.valueType, other)
+
+    private def checkAssignable(
+        actual: ExprInfo,
+        expected: SourceType,
+        span: SourceSpan,
+        code: String,
+    ): Unit =
+      if !SourceType.assignable(actual.expr.valueType, expected) then
+        error(
+          code,
+          s"expected ${expected.display}, got ${actual.expr.valueType.display}",
+          span,
+        )
+
+    private def checkReceiverMutation(
+        receiver: ExprInfo,
+        signature: CallableSignature,
+        span: SourceSpan,
+    ): Unit =
+      signature.receiver.foreach { receiverInfo =>
+        if receiverInfo.mutable && !receiver.mutationAllowed then
+          error(
+            "cosmo0.type.invalid-mutability",
+            s"${signature.name} requires a mutable receiver",
+            span,
+          )
+      }
+
+    private def requireBool(value: ExprInfo, span: SourceSpan): Unit =
+      if !SourceType.same(value.expr.valueType, SourceType.Bool) then
+        error(
+          "cosmo0.type.expected-bool",
+          s"expected Bool, got ${value.expr.valueType.display}",
+          span,
+        )
+
+    private def invalidPatternType(
+        span: SourceSpan,
+        expected: SourceType,
+        actual: SourceType,
+    ): Unit =
+      error(
+        "cosmo0.type.invalid-match-payload",
+        s"pattern has type ${actual.display}, expected ${expected.display}",
+        span,
+      )
+
+    private def valueSymbol(
+        name: String,
+        valueType: SourceType,
+        kind: UntypedValueKind,
+        span: SourceSpan,
+    ): ValueSymbol =
+      ValueSymbol(
+        name,
+        valueType,
+        mutableBinding = kind == UntypedValueKind.Var,
+        mutationAllowed = mutationCapability(valueType),
+        span,
+      )
+
+    private def mutationCapability(valueType: SourceType): Boolean =
+      SourceType.dealias(valueType) match
+        case SourceType.Ref(_, mutable) => mutable
+        case SourceType.Never | SourceType.Error => false
+        case _ => true
+
+    private def error(
+        code: String,
+        message: String,
+        span: SourceSpan,
+    ): Unit =
+      diagnostics += Diagnostic(
+        Phase.Check,
+        DiagnosticSeverity.Error,
+        code,
+        message,
+        Some(span),
+      )
+
+  private enum FunctionContext:
+    case Some(returnType: SourceType, containingOwner: Option[String])
+    case None
+
+    def ownerName: Option[String] =
+      this match
+        case Some(_, containingOwner) => containingOwner
+        case None                     => scala.None

--- a/packages/cosmo0/src/main/scala/cosmo0/SourceTypes.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/SourceTypes.scala
@@ -1,0 +1,331 @@
+package cosmo0
+
+enum SourceType:
+  case Builtin(name: String)
+  case User(name: String)
+  case Alias(name: String, target: SourceType)
+  case Ref(target: SourceType, mutable: Boolean)
+  case Standard(name: String, args: List[SourceType])
+  case Function(params: List[SourceType], returnType: SourceType)
+  case Never
+  case Error
+
+  def display: String =
+    this match
+      case SourceType.Builtin(name) => name
+      case SourceType.User(name)    => name
+      case SourceType.Alias(name, _) => name
+      case SourceType.Ref(target, true) =>
+        s"&mut ${target.display}"
+      case SourceType.Ref(target, false) =>
+        s"&${target.display}"
+      case SourceType.Standard(name, args) =>
+        s"$name[${args.map(_.display).mkString(", ")}]"
+      case SourceType.Function(params, returnType) =>
+        s"(${params.map(_.display).mkString(", ")}) -> ${returnType.display}"
+      case SourceType.Never => "never"
+      case SourceType.Error => "<error>"
+
+object SourceType:
+  val Unit: SourceType = Builtin("Unit")
+  val Bool: SourceType = Builtin("Bool")
+  val I32: SourceType = Builtin("i32")
+  val Usize: SourceType = Builtin("usize")
+  val String: SourceType = Builtin("String")
+  val Char: SourceType = Builtin("Char")
+  val Byte: SourceType = Builtin("u8")
+  val F64: SourceType = Builtin("f64")
+
+  val scalarTypes: Map[String, SourceType] =
+    Map(
+      "Unit" -> Unit,
+      "Bool" -> Bool,
+      "bool" -> Bool,
+      "i8" -> Builtin("i8"),
+      "i16" -> Builtin("i16"),
+      "i32" -> I32,
+      "i64" -> Builtin("i64"),
+      "u8" -> Byte,
+      "u16" -> Builtin("u16"),
+      "u32" -> Builtin("u32"),
+      "u64" -> Builtin("u64"),
+      "usize" -> Usize,
+      "Byte" -> Byte,
+      "Char" -> Char,
+      "String" -> String,
+      "str" -> String,
+      "f32" -> Builtin("f32"),
+      "f64" -> F64,
+    )
+
+  def scalar(name: String): Option[SourceType] =
+    scalarTypes.get(name)
+
+  def dealias(value: SourceType): SourceType =
+    value match
+      case Alias(_, target) => dealias(target)
+      case Ref(target, mutable) =>
+        Ref(dealias(target), mutable)
+      case Standard(name, args) =>
+        Standard(name, args.map(dealias))
+      case Function(params, returnType) =>
+        Function(params.map(dealias), dealias(returnType))
+      case other => other
+
+  def same(left: SourceType, right: SourceType): Boolean =
+    (dealias(left), dealias(right)) match
+      case (Error, _) | (_, Error)     => true
+      case (Never, _) | (_, Never)     => true
+      case (Builtin(a), Builtin(b))    => a == b
+      case (User(a), User(b))          => a == b
+      case (Ref(a, ma), Ref(b, mb))    => ma == mb && same(a, b)
+      case (Standard(na, aa), Standard(nb, ab)) =>
+        na == nb && aa.length == ab.length && aa.zip(ab).forall { case (a, b) => same(a, b) }
+      case (Function(ap, ar), Function(bp, br)) =>
+        ap.length == bp.length && ap.zip(bp).forall { case (a, b) => same(a, b) } && same(ar, br)
+      case _ => false
+
+  def assignable(from: SourceType, to: SourceType): Boolean =
+    same(from, to)
+
+  def isInteger(value: SourceType): Boolean =
+    dealias(value) match
+      case Builtin("i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "usize") =>
+        true
+      case _ => false
+
+  def isFloat(value: SourceType): Boolean =
+    dealias(value) match
+      case Builtin("f32" | "f64") => true
+      case _                      => false
+
+  def isNumeric(value: SourceType): Boolean =
+    isInteger(value) || isFloat(value)
+
+  def deref(value: SourceType): SourceType =
+    dealias(value) match
+      case Ref(target, _) => target
+      case other          => other
+
+  def refMutable(value: SourceType): Option[Boolean] =
+    dealias(value) match
+      case Ref(_, mutable) => Some(mutable)
+      case _               => None
+
+sealed trait SourceTypeTemplate:
+  def instantiate(args: List[SourceType]): SourceType
+
+object SourceTypeTemplate:
+  final case class Arg(index: Int) extends SourceTypeTemplate:
+    def instantiate(args: List[SourceType]): SourceType =
+      args.lift(index).getOrElse(SourceType.Error)
+
+  final case class Concrete(value: SourceType) extends SourceTypeTemplate:
+    def instantiate(args: List[SourceType]): SourceType = value
+
+  final case class Ref(target: SourceTypeTemplate, mutable: Boolean) extends SourceTypeTemplate:
+    def instantiate(args: List[SourceType]): SourceType =
+      SourceType.Ref(target.instantiate(args), mutable)
+
+  final case class Standard(name: String, values: List[SourceTypeTemplate])
+      extends SourceTypeTemplate:
+    def instantiate(args: List[SourceType]): SourceType =
+      SourceType.Standard(name, values.map(_.instantiate(args)))
+
+final case class CallableParam(
+    name: String,
+    valueType: SourceType,
+    span: SourceSpan,
+)
+
+final case class CallableReceiver(
+    valueType: SourceType,
+    mutable: Boolean,
+)
+
+final case class CallableSignature(
+    name: String,
+    params: List[CallableParam],
+    returnType: SourceType,
+    receiver: Option[CallableReceiver] = None,
+):
+  def functionType: SourceType =
+    SourceType.Function(params.map(_.valueType), returnType)
+
+final case class DescriptorParam(
+    name: String,
+    valueType: SourceTypeTemplate,
+)
+
+final case class DescriptorCallable(
+    name: String,
+    params: List[DescriptorParam],
+    returnType: SourceTypeTemplate,
+    receiverMutable: Boolean = false,
+):
+  def instantiate(owner: SourceType.Standard, span: SourceSpan): CallableSignature =
+    CallableSignature(
+      name,
+      params.map(param =>
+        CallableParam(param.name, param.valueType.instantiate(owner.args), span),
+      ),
+      returnType.instantiate(owner.args),
+      Some(CallableReceiver(owner, receiverMutable)),
+    )
+
+final case class StandardGenericDescriptor(
+    name: String,
+    arity: Int,
+    constructors: Map[String, DescriptorCallable],
+    methods: Map[String, DescriptorCallable],
+):
+  def constructor(name: String): Option[DescriptorCallable] =
+    constructors.get(name)
+
+  def method(name: String): Option[DescriptorCallable] =
+    methods.get(name)
+
+object StandardGenericDescriptors:
+  private val T = SourceTypeTemplate.Arg(0)
+  private val U = SourceTypeTemplate.Arg(1)
+  private val UnitT = SourceTypeTemplate.Concrete(SourceType.Unit)
+  private val BoolT = SourceTypeTemplate.Concrete(SourceType.Bool)
+  private val UsizeT = SourceTypeTemplate.Concrete(SourceType.Usize)
+
+  val all: Map[String, StandardGenericDescriptor] =
+    List(
+      descriptor(
+        "Vec",
+        1,
+        constructors = List(call("<init>", Nil, SourceTypeTemplate.Standard("Vec", List(T)))),
+        methods = List(
+          call("push", List(param("value", T)), UnitT, receiverMutable = true),
+          call("get", List(param("index", UsizeT)), T),
+          call("set", List(param("index", UsizeT), param("value", T)), UnitT, receiverMutable = true),
+          call("size", Nil, UsizeT),
+          call("is_empty", Nil, BoolT),
+        ),
+      ),
+      descriptor(
+        "Option",
+        1,
+        constructors = List(
+          call("Some", List(param("value", T)), SourceTypeTemplate.Standard("Option", List(T))),
+          call("None", Nil, SourceTypeTemplate.Standard("Option", List(T))),
+        ),
+        methods = List(
+          call("is_some", Nil, BoolT),
+          call("is_none", Nil, BoolT),
+        ),
+      ),
+      descriptor(
+        "Result",
+        2,
+        constructors = List(
+          call("Ok", List(param("value", T)), SourceTypeTemplate.Standard("Result", List(T, U))),
+          call("Err", List(param("error", U)), SourceTypeTemplate.Standard("Result", List(T, U))),
+        ),
+        methods = List(
+          call("is_ok", Nil, BoolT),
+          call("is_err", Nil, BoolT),
+        ),
+      ),
+      descriptor(
+        "Arena",
+        1,
+        constructors = List(call("<init>", Nil, SourceTypeTemplate.Standard("Arena", List(T)))),
+        methods = List(
+          call(
+            "alloc",
+            List(param("value", T)),
+            SourceTypeTemplate.Standard("Id", List(T)),
+            receiverMutable = true,
+          ),
+          call(
+            "get",
+            List(param("id", SourceTypeTemplate.Standard("Id", List(T)))),
+            SourceTypeTemplate.Ref(T, mutable = false),
+          ),
+        ),
+      ),
+      descriptor("Id", 1, constructors = Nil, methods = Nil),
+      descriptor(
+        "Map",
+        2,
+        constructors = List(call("<init>", Nil, SourceTypeTemplate.Standard("Map", List(T, U)))),
+        methods = List(
+          call("get", List(param("key", T)), SourceTypeTemplate.Standard("Option", List(U))),
+          call(
+            "insert",
+            List(param("key", T), param("value", U)),
+            SourceTypeTemplate.Standard("Option", List(U)),
+            receiverMutable = true,
+          ),
+          call("contains", List(param("key", T)), BoolT),
+          call("contains_key", List(param("key", T)), BoolT),
+        ),
+      ),
+      descriptor(
+        "Set",
+        1,
+        constructors = List(call("<init>", Nil, SourceTypeTemplate.Standard("Set", List(T)))),
+        methods = List(
+          call("insert", List(param("value", T)), UnitT, receiverMutable = true),
+          call("contains", List(param("value", T)), BoolT),
+        ),
+      ),
+      descriptor(
+        "Ptr",
+        1,
+        constructors = List(
+          call(
+            "<init>",
+            List(param("value", SourceTypeTemplate.Ref(T, false))),
+            SourceTypeTemplate.Standard("Ptr", List(T)),
+          ),
+        ),
+        methods = Nil,
+      ),
+      descriptor(
+        "Box",
+        1,
+        constructors = List(
+          call("<init>", List(param("value", T)), SourceTypeTemplate.Standard("Box", List(T))),
+        ),
+        methods = List(
+          call("get", Nil, SourceTypeTemplate.Ref(T, mutable = false)),
+        ),
+      ),
+      descriptor("Ref", 1, constructors = Nil, methods = Nil),
+      descriptor("RefMut", 1, constructors = Nil, methods = Nil),
+    ).map(descriptor => descriptor.name -> descriptor).toMap
+
+  def get(name: String): Option[StandardGenericDescriptor] =
+    all.get(name)
+
+  private def descriptor(
+      name: String,
+      arity: Int,
+      constructors: List[DescriptorCallable],
+      methods: List[DescriptorCallable],
+  ): StandardGenericDescriptor =
+    StandardGenericDescriptor(
+      name,
+      arity,
+      constructors.map(call => call.name -> call).toMap,
+      methods.map(call => call.name -> call).toMap,
+    )
+
+  private def call(
+      name: String,
+      params: List[DescriptorParam],
+      returnType: SourceTypeTemplate,
+      receiverMutable: Boolean = false,
+  ): DescriptorCallable =
+    DescriptorCallable(name, params, returnType, receiverMutable)
+
+  private def param(
+      name: String,
+      valueType: SourceTypeTemplate,
+  ): DescriptorParam =
+    DescriptorParam(name, valueType)

--- a/packages/cosmo0/src/main/scala/cosmo0/Typed.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Typed.scala
@@ -1,0 +1,276 @@
+package cosmo0
+
+sealed trait TypedNode:
+  def span: SourceSpan
+
+final case class TypedModule(
+    source: SourceFile,
+    declarations: List[TypedDecl],
+    span: SourceSpan,
+) extends TypedNode
+
+sealed trait TypedDecl extends TypedNode:
+  def name: String
+
+sealed trait TypedClassMember extends TypedNode
+
+sealed trait TypedBlockItem extends TypedNode
+
+sealed trait TypedStmt extends TypedBlockItem
+
+sealed trait TypedExpr extends TypedBlockItem:
+  def valueType: SourceType
+
+sealed trait TypedPattern extends TypedNode
+
+final case class TypedImport(
+    path: UntypedPath,
+    dest: Option[UntypedPath],
+    span: SourceSpan,
+) extends TypedDecl:
+  def name: String = dest.orElse(Some(path)).fold("<import>")(_.text)
+
+final case class TypedClass(
+    name: String,
+    fields: List[TypedValueDecl],
+    aliases: List[TypedTypeAlias],
+    variants: List[TypedVariant],
+    methods: List[TypedFunction],
+    span: SourceSpan,
+) extends TypedDecl
+
+final case class TypedFunction(
+    name: String,
+    params: List[TypedParam],
+    returnType: SourceType,
+    body: Option[TypedExpr],
+    signature: CallableSignature,
+    owner: Option[String],
+    span: SourceSpan,
+) extends TypedDecl
+    with TypedClassMember
+
+final case class TypedValueDecl(
+    kind: UntypedValueKind,
+    name: String,
+    valueType: SourceType,
+    init: Option[TypedExpr],
+    span: SourceSpan,
+) extends TypedDecl
+    with TypedClassMember
+
+final case class TypedTypeAlias(
+    name: String,
+    target: SourceType,
+    span: SourceSpan,
+) extends TypedDecl
+    with TypedClassMember
+
+final case class TypedVariant(
+    name: String,
+    fields: List[TypedVariantField],
+    span: SourceSpan,
+) extends TypedClassMember
+
+final case class TypedVariantField(
+    name: Option[String],
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedNode
+
+final case class TypedParam(
+    name: String,
+    valueType: SourceType,
+    default: Option[TypedExpr],
+    span: SourceSpan,
+) extends TypedNode
+
+final case class TypedLocal(
+    kind: UntypedValueKind,
+    name: String,
+    valueType: SourceType,
+    init: Option[TypedExpr],
+    span: SourceSpan,
+) extends TypedStmt
+
+final case class TypedExprStmt(
+    expr: TypedExpr,
+    span: SourceSpan,
+) extends TypedStmt
+
+final case class TypedBlock(
+    items: List[TypedBlockItem],
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedName(
+    path: UntypedPath,
+    valueType: SourceType,
+    mutableBinding: Boolean,
+    mutationAllowed: Boolean,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedTypeConstructorExpr(
+    constructedType: SourceType,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedSelect(
+    receiver: TypedExpr,
+    field: String,
+    valueType: SourceType,
+    mutableBinding: Boolean,
+    mutationAllowed: Boolean,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedVariantConstructorExpr(
+    owner: SourceType,
+    variant: String,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedCall(
+    callee: TypedExpr,
+    args: List[TypedExpr],
+    valueType: SourceType,
+    signature: CallableSignature,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedAssign(
+    target: TypedExpr,
+    value: TypedExpr,
+    op: String,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedUnary(
+    op: String,
+    expr: TypedExpr,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedBinary(
+    op: String,
+    left: TypedExpr,
+    right: TypedExpr,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedIf(
+    cond: TypedExpr,
+    thenBranch: TypedExpr,
+    elseBranch: Option[TypedExpr],
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedLoop(
+    body: TypedExpr,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedWhile(
+    cond: TypedExpr,
+    body: TypedExpr,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedFor(
+    name: String,
+    itemType: SourceType,
+    iter: TypedExpr,
+    body: TypedExpr,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedMatch(
+    scrutinee: TypedExpr,
+    arms: List[TypedMatchArm],
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedMatchArm(
+    pattern: TypedPattern,
+    body: Option[TypedExpr],
+    span: SourceSpan,
+) extends TypedNode
+
+final case class TypedReturn(
+    value: TypedExpr,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedBreak(
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedContinue(
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedBoolLiteral(
+    value: Boolean,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+    with TypedPattern
+
+final case class TypedIntLiteral(
+    value: BigInt,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+    with TypedPattern
+
+final case class TypedFloatLiteral(
+    value: BigDecimal,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+    with TypedPattern
+
+final case class TypedStringLiteral(
+    value: String,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+    with TypedPattern
+
+final case class TypedUnitLiteral(
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedExpr
+
+final case class TypedWildcardPattern(
+    expectedType: SourceType,
+    span: SourceSpan,
+) extends TypedPattern
+
+final case class TypedBindingPattern(
+    name: String,
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedPattern
+
+final case class TypedVariantPattern(
+    constructor: TypedExpr,
+    args: List[TypedPattern],
+    valueType: SourceType,
+    span: SourceSpan,
+) extends TypedPattern

--- a/packages/cosmo0/src/main/scala/cosmo0/Untyped.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Untyped.scala
@@ -142,6 +142,11 @@ final case class UntypedVariantConstructor(
     span: SourceSpan,
 ) extends UntypedExpr
 
+final case class UntypedTypeConstructor(
+    valueType: UntypedType,
+    span: SourceSpan,
+) extends UntypedExpr
+
 final case class UntypedCall(
     callee: UntypedExpr,
     args: List[UntypedExpr],

--- a/packages/cosmo0/src/test/scala/cosmo0/FacadeTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/FacadeTests.scala
@@ -23,13 +23,17 @@ class FacadeTests extends munit.FunSuite:
     assertEquals(result.diagnostics.head.code, "cosmo0.parse.failed")
     assert(result.diagnostics.head.span.nonEmpty)
 
-  test("check returns a structured pending result"):
+  test("check returns a typed module for accepted source"):
     val result = Cosmo0().check("val answer = 42")
 
     assertEquals(result.phase, Phase.Check)
-    assertEquals(result.status, PhaseStatus.Pending)
-    assert(result.value.isEmpty)
-    assertEquals(result.diagnostics.head.code, "cosmo0.check.pending")
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    assert(result.value.nonEmpty)
+    assert(result.diagnostics.isEmpty)
+
+    val value = result.value.get.typed.declarations.head.asInstanceOf[TypedValueDecl]
+    assertEquals(value.name, "answer")
+    assertEquals(value.valueType, SourceType.I32)
 
   test("elaborate builds untyped representation for accepted core declarations"):
     val result = Cosmo0().elaborate(
@@ -139,6 +143,114 @@ class FacadeTests extends munit.FunSuite:
     assertEquals(result.phase, Phase.Check)
     assertEquals(result.status, PhaseStatus.Unsupported)
     assertEquals(result.diagnostics.head.code, "cosmo0.elaborate.unsupported.trait")
+
+  test("check resolves aliases, constructors, descriptor methods, and match bindings"):
+    val result = Cosmo0().check(
+      """class Token {
+        |  val text: String
+        |}
+        |
+        |type TokenId = Id[Token]
+        |
+        |class Severity {
+        |  case Note
+        |  case Error(String)
+        |}
+        |
+        |class Diagnostic {
+        |  val severity: Severity
+        |  val labels: Vec[String]
+        |}
+        |
+        |def describe(token: Option[Token]): String = {
+        |  token match {
+        |    case Option[Token]::Some(value) => {
+        |      value.text
+        |    }
+        |    case Option[Token]::None => {
+        |      "none"
+        |    }
+        |  }
+        |}
+        |
+        |def build(): Diagnostic = {
+        |  val labels = Vec[String]();
+        |  labels.push("primary");
+        |  Diagnostic(Severity.Error("bad"), labels)
+        |}
+        |
+        |def collect(): Unit = {
+        |  val labels = Vec[String]();
+        |  labels.push("primary");
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    assert(result.diagnostics.isEmpty)
+
+    val module = result.value.get.typed
+    val alias = module.declarations.collectFirst { case value: TypedTypeAlias => value }.get
+    assertEquals(alias.name, "TokenId")
+    assert(SourceType.same(alias.target, SourceType.Standard("Id", List(SourceType.User("Token")))))
+
+    val build = module.declarations.collectFirst {
+      case fn: TypedFunction if fn.name == "build" => fn
+    }.get
+    assertEquals(build.returnType, SourceType.User("Diagnostic"))
+    assert(build.body.exists(_.valueType == SourceType.User("Diagnostic")))
+
+    val collect = module.declarations.collectFirst {
+      case fn: TypedFunction if fn.name == "collect" => fn
+    }.get
+    assertEquals(collect.body.map(_.valueType), Some(SourceType.Unit))
+
+  test("check emits typed diagnostics for representative source errors"):
+    val cases = List(
+      "def f(): i32 = missing" -> "cosmo0.type.unresolved-name",
+      "def f(): Vec[i32] = { Vec[i32](1) }" -> "cosmo0.type.wrong-arity",
+      "class A {}\ndef f(a: A): i32 = { a.missing }" -> "cosmo0.type.invalid-field",
+      "var x: i32 = true" -> "cosmo0.type.assignment-mismatch",
+      "def f(): Bool = { 1 }" -> "cosmo0.type.return-mismatch",
+      """class A {
+        |  var count: usize
+        |
+        |  def f(&self): Unit = {
+        |    self.count = 1
+        |  }
+        |}
+        |""".stripMargin -> "cosmo0.type.invalid-mutability",
+      "def f(items: &Vec[i32]): Unit = { items.push(1) }" ->
+        "cosmo0.type.invalid-mutability",
+      """class Token {}
+        |
+        |def f(value: Option[Token]): String = {
+        |  value match {
+        |    case Option[Token]::Some => {
+        |      "bad"
+        |    }
+        |    case Option[Token]::None => {
+        |      "none"
+        |    }
+        |  }
+        |}
+        |""".stripMargin -> "cosmo0.type.wrong-arity",
+    )
+
+    cases.foreach { case (source, code) =>
+      val result = Cosmo0().check(source)
+
+      assertEquals(result.phase, Phase.Check)
+      assertEquals(result.status, PhaseStatus.Failed)
+      assert(
+        result.diagnostics.exists(_.code == code),
+        s"missing diagnostic $code in ${result.diagnostics.map(_.code)}",
+      )
+    }
+
+  test("cosmo0 typed-expression typer does not call the full Cosmo typer"):
+    assert(classOf[SourceTyper].getName.contains("cosmo0.SourceTyper"))
 
   test("elaboration preserves spans for accepted nodes and diagnostics"):
     val accepted = Cosmo0().elaborate("\nval answer = 42")


### PR DESCRIPTION
## Summary
- replace the pending cosmo0 check phase with a real source typer that produces `TypedModule`
- add source-level type modeling plus typed AST nodes for declarations, statements, expressions, patterns, and callable signatures
- support aliases, class constructors, standard generic descriptors, method calls, references, mutation checks, blocks, conditionals, loops, matches, and returns
- extend elaboration to surface typed constructors and expression statements where needed
- update facade tests to cover successful typing and representative diagnostics

## Notes
- typed check results now return structured typed modules instead of a pending placeholder
- the new typer covers the early cosmo0 source subset needed for compiler-shaped code