### PR TITLE
feat: add cosmo0 lir model

### DIFF
--- a/openspec/changes/add-cosmo0-lir-model/tasks.md
+++ b/openspec/changes/add-cosmo0-lir-model/tasks.md
@@ -1,22 +1,22 @@
 ## 1. LIR Core Data Model
 
-- [ ] 1.1 Define LIR modules, declarations, functions, parameters, locals, labels, blocks, operations, values, and terminators.
-- [ ] 1.2 Define LIR type references and callable signatures using cosmo0 source type information where needed.
-- [ ] 1.3 Define explicit local identifiers and declaration identifiers that are stable across rendering and tests.
+- [x] 1.1 Define LIR modules, declarations, functions, parameters, locals, labels, blocks, operations, values, and terminators.
+- [x] 1.2 Define LIR type references and callable signatures using cosmo0 source type information where needed.
+- [x] 1.3 Define explicit local identifiers and declaration identifiers that are stable across rendering and tests.
 
 ## 2. LIR Operations
 
-- [ ] 2.1 Add LIR operations for local allocation, assignment, field get/set, direct calls, method-like lowered calls, descriptor intrinsics, variant construction, tag reads, and payload reads.
-- [ ] 2.2 Add LIR terminators for return, unconditional branch, conditional branch, and unreachable/error exits.
-- [ ] 2.3 Represent structured source control flow only through explicit blocks and terminators.
+- [x] 2.1 Add LIR operations for local allocation, assignment, field get/set, direct calls, method-like lowered calls, descriptor intrinsics, variant construction, tag reads, and payload reads.
+- [x] 2.2 Add LIR terminators for return, unconditional branch, conditional branch, and unreachable/error exits.
+- [x] 2.3 Represent structured source control flow only through explicit blocks and terminators.
 
 ## 3. Inspection Utilities
 
-- [ ] 3.1 Add a deterministic debug renderer for LIR modules and functions.
-- [ ] 3.2 Add helper constructors for concise hand-written LIR tests.
-- [ ] 3.3 Add tests proving rendering is stable for equivalent LIR inputs.
+- [x] 3.1 Add a deterministic debug renderer for LIR modules and functions.
+- [x] 3.2 Add helper constructors for concise hand-written LIR tests.
+- [x] 3.3 Add tests proving rendering is stable for equivalent LIR inputs.
 
 ## 4. Boundary Checks
 
-- [ ] 4.1 Ensure LIR nodes do not depend on shared parser syntax nodes.
-- [ ] 4.2 Ensure LIR nodes do not depend on full-language `cosmo.ir` type-level, reflection, staging, or quotation constructs.
+- [x] 4.1 Ensure LIR nodes do not depend on shared parser syntax nodes.
+- [x] 4.2 Ensure LIR nodes do not depend on full-language `cosmo.ir` type-level, reflection, staging, or quotation constructs.

--- a/packages/cosmo0/src/main/scala/cosmo0/Lir.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Lir.scala
@@ -1,0 +1,522 @@
+package cosmo0
+
+final case class LirModule(
+    name: String,
+    declarations: List[LirDeclaration],
+)
+
+sealed trait LirDeclaration:
+  def id: LirDeclId
+  def name: String
+
+final case class LirDeclId(value: String):
+  require(value.nonEmpty, "LIR declaration identifiers must be non-empty")
+  override def toString: String = s"@$value"
+
+final case class LirLocalId(value: String):
+  require(value.nonEmpty, "LIR local identifiers must be non-empty")
+  override def toString: String = s"%$value"
+
+final case class LirLabel(value: String):
+  require(value.nonEmpty, "LIR labels must be non-empty")
+  override def toString: String = s"^$value"
+
+final case class LirTypeRef(source: SourceType):
+  def display: String = source.display
+
+final case class LirCallableSignature(
+    params: List[LirTypeRef],
+    returnType: LirTypeRef,
+    sourceSignature: Option[CallableSignature] = None,
+)
+
+object LirCallableSignature:
+  def fromSource(signature: CallableSignature): LirCallableSignature =
+    LirCallableSignature(
+      signature.params.map(param => LirTypeRef(param.valueType)),
+      LirTypeRef(signature.returnType),
+      Some(signature),
+    )
+
+final case class LirParam(
+    id: LirLocalId,
+    name: String,
+    valueType: LirTypeRef,
+)
+
+final case class LirLocal(
+    id: LirLocalId,
+    name: String,
+    valueType: LirTypeRef,
+    mutable: Boolean = false,
+)
+
+final case class LirFunction(
+    id: LirDeclId,
+    name: String,
+    params: List[LirParam],
+    returnType: LirTypeRef,
+    locals: List[LirLocal],
+    blocks: List[LirBlock],
+    owner: Option[LirDeclId] = None,
+    sourceSignature: Option[CallableSignature] = None,
+) extends LirDeclaration:
+  def signature: LirCallableSignature =
+    LirCallableSignature(
+      params.map(_.valueType),
+      returnType,
+      sourceSignature,
+    )
+
+final case class LirGlobal(
+    id: LirDeclId,
+    name: String,
+    valueType: LirTypeRef,
+    mutable: Boolean,
+    initializer: Option[LirValue] = None,
+) extends LirDeclaration
+
+final case class LirTypeAliasDecl(
+    id: LirDeclId,
+    name: String,
+    target: LirTypeRef,
+) extends LirDeclaration
+
+final case class LirTypeDecl(
+    id: LirDeclId,
+    name: String,
+    fields: List[LirField],
+    variants: List[LirVariant] = Nil,
+) extends LirDeclaration
+
+final case class LirField(
+    name: String,
+    valueType: LirTypeRef,
+    mutable: Boolean = false,
+)
+
+final case class LirVariant(
+    name: String,
+    payload: List[LirVariantPayload] = Nil,
+)
+
+final case class LirVariantPayload(
+    name: Option[String],
+    valueType: LirTypeRef,
+)
+
+final case class LirBlock(
+    label: LirLabel,
+    operations: List[LirOp],
+    terminator: LirTerminator,
+)
+
+sealed trait LirValue:
+  def valueType: LirTypeRef
+
+case object LirUnitValue extends LirValue:
+  val valueType: LirTypeRef = LirTypeRef(SourceType.Unit)
+
+final case class LirBoolValue(value: Boolean) extends LirValue:
+  val valueType: LirTypeRef = LirTypeRef(SourceType.Bool)
+
+final case class LirIntValue(
+    value: BigInt,
+    valueType: LirTypeRef = LirTypeRef(SourceType.I32),
+) extends LirValue
+
+final case class LirFloatValue(
+    value: BigDecimal,
+    valueType: LirTypeRef = LirTypeRef(SourceType.F64),
+) extends LirValue
+
+final case class LirStringValue(value: String) extends LirValue:
+  val valueType: LirTypeRef = LirTypeRef(SourceType.String)
+
+final case class LirCharValue(value: Char) extends LirValue:
+  val valueType: LirTypeRef = LirTypeRef(SourceType.Char)
+
+final case class LirLocalRef(
+    id: LirLocalId,
+    valueType: LirTypeRef,
+) extends LirValue
+
+final case class LirGlobalRef(
+    id: LirDeclId,
+    valueType: LirTypeRef,
+) extends LirValue
+
+final case class LirFunctionRef(
+    id: LirDeclId,
+    signature: LirCallableSignature,
+) extends LirValue:
+  def valueType: LirTypeRef =
+    LirTypeRef(
+      SourceType.Function(
+        signature.params.map(_.source),
+        signature.returnType.source,
+      ),
+    )
+
+sealed trait LirPlace:
+  def valueType: LirTypeRef
+
+final case class LirLocalPlace(
+    id: LirLocalId,
+    valueType: LirTypeRef,
+) extends LirPlace
+
+final case class LirFieldPlace(
+    receiver: LirValue,
+    field: String,
+    valueType: LirTypeRef,
+) extends LirPlace
+
+final case class LirDescriptorRef(
+    name: String,
+    args: List[LirTypeRef] = Nil,
+)
+
+sealed trait LirOp
+
+final case class LirAllocLocal(
+    local: LirLocal,
+    init: Option[LirValue] = None,
+) extends LirOp
+
+final case class LirAssign(
+    target: LirPlace,
+    value: LirValue,
+) extends LirOp
+
+final case class LirFieldGet(
+    output: LirLocalId,
+    receiver: LirValue,
+    field: String,
+    valueType: LirTypeRef,
+) extends LirOp
+
+final case class LirFieldSet(
+    receiver: LirValue,
+    field: String,
+    value: LirValue,
+) extends LirOp
+
+final case class LirDirectCall(
+    output: Option[LirLocalId],
+    callee: LirDeclId,
+    args: List[LirValue],
+    signature: LirCallableSignature,
+) extends LirOp
+
+final case class LirLoweredMethodCall(
+    output: Option[LirLocalId],
+    receiver: LirValue,
+    method: String,
+    args: List[LirValue],
+    signature: LirCallableSignature,
+) extends LirOp
+
+final case class LirDescriptorIntrinsic(
+    output: Option[LirLocalId],
+    descriptor: LirDescriptorRef,
+    name: String,
+    args: List[LirValue],
+    resultType: Option[LirTypeRef],
+) extends LirOp
+
+final case class LirConstructVariant(
+    output: LirLocalId,
+    owner: LirTypeRef,
+    variant: String,
+    payload: List[LirValue],
+) extends LirOp
+
+final case class LirReadVariantTag(
+    output: LirLocalId,
+    scrutinee: LirValue,
+    owner: LirTypeRef,
+) extends LirOp
+
+final case class LirReadVariantPayload(
+    output: LirLocalId,
+    scrutinee: LirValue,
+    variant: String,
+    index: Int,
+    valueType: LirTypeRef,
+) extends LirOp
+
+sealed trait LirTerminator
+
+final case class LirReturn(value: Option[LirValue]) extends LirTerminator
+
+final case class LirBranch(target: LirLabel) extends LirTerminator
+
+final case class LirCondBranch(
+    condition: LirValue,
+    trueTarget: LirLabel,
+    falseTarget: LirLabel,
+) extends LirTerminator
+
+final case class LirUnreachable(reason: Option[String] = None) extends LirTerminator
+
+final case class LirErrorExit(
+    code: String,
+    message: Option[String] = None,
+) extends LirTerminator
+
+object Lir:
+  def declId(value: String): LirDeclId = LirDeclId(value)
+
+  def localId(value: String): LirLocalId = LirLocalId(value)
+
+  def label(value: String): LirLabel = LirLabel(value)
+
+  def t(source: SourceType): LirTypeRef = LirTypeRef(source)
+
+  def signature(params: List[SourceType], returnType: SourceType): LirCallableSignature =
+    LirCallableSignature(
+      params.map(t),
+      t(returnType),
+    )
+
+  def param(
+      name: String,
+      valueType: SourceType,
+      id: String = "",
+  ): LirParam =
+    LirParam(localId(stableId(id, name)), name, t(valueType))
+
+  def local(
+      name: String,
+      valueType: SourceType,
+      mutable: Boolean = false,
+      id: String = "",
+  ): LirLocal =
+    LirLocal(localId(stableId(id, name)), name, t(valueType), mutable)
+
+  def ref(id: String, valueType: SourceType): LirLocalRef =
+    LirLocalRef(localId(id), t(valueType))
+
+  def localPlace(id: String, valueType: SourceType): LirLocalPlace =
+    LirLocalPlace(localId(id), t(valueType))
+
+  def int(value: Int, valueType: SourceType = SourceType.I32): LirIntValue =
+    LirIntValue(BigInt(value), t(valueType))
+
+  def bool(value: Boolean): LirBoolValue =
+    LirBoolValue(value)
+
+  def string(value: String): LirStringValue =
+    LirStringValue(value)
+
+  def block(
+      label: String,
+      operations: List[LirOp] = Nil,
+      terminator: LirTerminator = LirUnreachable(),
+  ): LirBlock =
+    LirBlock(LirLabel(label), operations, terminator)
+
+  def function(
+      name: String,
+      params: List[LirParam],
+      returnType: SourceType,
+      locals: List[LirLocal],
+      blocks: List[LirBlock],
+      id: String = "",
+      owner: Option[LirDeclId] = None,
+      sourceSignature: Option[CallableSignature] = None,
+  ): LirFunction =
+    LirFunction(
+      declId(stableId(id, name)),
+      name,
+      params,
+      t(returnType),
+      locals,
+      blocks,
+      owner,
+      sourceSignature,
+    )
+
+  private def stableId(value: String, fallback: String): String =
+    if value.nonEmpty then value else fallback
+
+object LirDebugRenderer:
+  def renderModule(module: LirModule): String =
+    val declarations = module.declarations.sortBy(_.id.value).map(renderDeclaration(_, 2))
+    if declarations.isEmpty then s"module ${module.name} {\n}"
+    else s"module ${module.name} {\n${declarations.mkString("\n\n")}\n}"
+
+  def renderFunction(function: LirFunction): String =
+    renderFunction(function, 0)
+
+  private def renderDeclaration(declaration: LirDeclaration, indent: Int): String =
+    declaration match
+      case function: LirFunction =>
+        renderFunction(function, indent)
+      case global: LirGlobal =>
+        val mutability = if global.mutable then " var" else ""
+        val init = global.initializer.fold("")(value => s" = ${renderValue(value)}")
+        line(indent, s"global${mutability} ${global.id} ${global.name}: ${renderType(global.valueType)}$init")
+      case alias: LirTypeAliasDecl =>
+        line(indent, s"typealias ${alias.id} ${alias.name} = ${renderType(alias.target)}")
+      case ty: LirTypeDecl =>
+        renderTypeDecl(ty, indent)
+
+  private def renderTypeDecl(ty: LirTypeDecl, indent: Int): String =
+    val fields = ty.fields.sortBy(_.name).map { field =>
+      val mutability = if field.mutable then " var" else ""
+      line(indent + 2, s"field${mutability} ${field.name}: ${renderType(field.valueType)}")
+    }
+    val variants = ty.variants.sortBy(_.name).map { variant =>
+      val payload = variant.payload
+        .map(payload =>
+          payload.name match
+            case Some(name) => s"$name: ${renderType(payload.valueType)}"
+            case None       => renderType(payload.valueType)
+        )
+        .mkString(", ")
+      line(indent + 2, s"variant ${variant.name}($payload)")
+    }
+    val body = (fields ++ variants).mkString("\n")
+    if body.isEmpty then line(indent, s"type ${ty.id} ${ty.name} {}")
+    else s"${line(indent, s"type ${ty.id} ${ty.name} {")}\n$body\n${line(indent, "}")}"
+
+  private def renderFunction(function: LirFunction, indent: Int): String =
+    val params = function.params.map(renderParam).mkString(", ")
+    val owner = function.owner.fold("")(owner => s" owner $owner")
+    val header =
+      line(
+        indent,
+        s"fn ${function.id} ${function.name}($params) -> ${renderType(function.returnType)}$owner {",
+      )
+    val localLines =
+      function.locals.sortBy(_.id.value).map(local => line(indent + 2, renderLocal(local)))
+    val blockLines =
+      function.blocks.sortBy(_.label.value).map(block => renderBlock(block, indent + 2))
+    val body =
+      (if localLines.isEmpty then blockLines else localLines ++ List("") ++ blockLines).mkString("\n")
+    if body.isEmpty then s"$header\n${line(indent, "}")}"
+    else s"$header\n$body\n${line(indent, "}")}"
+
+  private def renderBlock(block: LirBlock, indent: Int): String =
+    val operations = block.operations.map(op => line(indent + 2, renderOp(op)))
+    val terminator = line(indent + 2, renderTerminator(block.terminator))
+    s"${line(indent, s"${block.label}:")}\n${(operations :+ terminator).mkString("\n")}"
+
+  private def renderParam(param: LirParam): String =
+    s"${param.id} ${param.name}: ${renderType(param.valueType)}"
+
+  private def renderLocal(local: LirLocal): String =
+    val mutability = if local.mutable then " mut" else ""
+    s"local ${local.id} ${local.name}: ${renderType(local.valueType)}$mutability"
+
+  private def renderOp(op: LirOp): String =
+    op match
+      case LirAllocLocal(local, init) =>
+        val initText = init.fold("")(value => s" = ${renderValue(value)}")
+        s"alloc ${renderLocal(local).stripPrefix("local ")}$initText"
+      case LirAssign(target, value) =>
+        s"assign ${renderPlace(target)} = ${renderValue(value)}"
+      case LirFieldGet(output, receiver, field, valueType) =>
+        s"$output = field_get ${renderValue(receiver)}.$field: ${renderType(valueType)}"
+      case LirFieldSet(receiver, field, value) =>
+        s"field_set ${renderValue(receiver)}.$field = ${renderValue(value)}"
+      case LirDirectCall(output, callee, args, signature) =>
+        s"${renderOutput(output)}call $callee(${renderArgs(args)}) ${renderSignatureResult(signature)}"
+      case LirLoweredMethodCall(output, receiver, method, args, signature) =>
+        s"${renderOutput(output)}method_call ${renderValue(receiver)}.$method(${renderArgs(args)}) ${renderSignatureResult(signature)}"
+      case LirDescriptorIntrinsic(output, descriptor, name, args, resultType) =>
+        val result = resultType.fold("Unit")(renderType)
+        s"${renderOutput(output)}descriptor ${renderDescriptor(descriptor)}::$name(${renderArgs(args)}) -> $result"
+      case LirConstructVariant(output, owner, variant, payload) =>
+        s"$output = variant ${renderType(owner)}::$variant(${renderArgs(payload)})"
+      case LirReadVariantTag(output, scrutinee, owner) =>
+        s"$output = variant_tag ${renderValue(scrutinee)}: ${renderType(owner)}"
+      case LirReadVariantPayload(output, scrutinee, variant, index, valueType) =>
+        s"$output = variant_payload ${renderValue(scrutinee)}.$variant[$index]: ${renderType(valueType)}"
+
+  private def renderTerminator(terminator: LirTerminator): String =
+    terminator match
+      case LirReturn(value) =>
+        value.fold("return")(value => s"return ${renderValue(value)}")
+      case LirBranch(target) =>
+        s"branch $target"
+      case LirCondBranch(condition, trueTarget, falseTarget) =>
+        s"cond_branch ${renderValue(condition)} ? $trueTarget : $falseTarget"
+      case LirUnreachable(reason) =>
+        reason.fold("unreachable")(value => s"unreachable ${quote(value)}")
+      case LirErrorExit(code, message) =>
+        message match
+          case Some(value) => s"error ${quote(code)} ${quote(value)}"
+          case None        => s"error ${quote(code)}"
+
+  private def renderPlace(place: LirPlace): String =
+    place match
+      case LirLocalPlace(id, _) =>
+        id.toString
+      case LirFieldPlace(receiver, field, _) =>
+        s"${renderValue(receiver)}.$field"
+
+  private def renderValue(value: LirValue): String =
+    value match
+      case LirUnitValue =>
+        "()"
+      case LirBoolValue(value) =>
+        value.toString
+      case LirIntValue(value, valueType) =>
+        s"$value:${renderType(valueType)}"
+      case LirFloatValue(value, valueType) =>
+        s"$value:${renderType(valueType)}"
+      case LirStringValue(value) =>
+        quote(value)
+      case LirCharValue(value) =>
+        s"'${escapeChar(value)}'"
+      case LirLocalRef(id, _) =>
+        id.toString
+      case LirGlobalRef(id, _) =>
+        id.toString
+      case LirFunctionRef(id, _) =>
+        s"fn $id"
+
+  private def renderType(valueType: LirTypeRef): String =
+    valueType.display
+
+  private def renderDescriptor(descriptor: LirDescriptorRef): String =
+    if descriptor.args.isEmpty then descriptor.name
+    else s"${descriptor.name}[${descriptor.args.map(renderType).mkString(", ")}]"
+
+  private def renderSignatureResult(signature: LirCallableSignature): String =
+    s"-> ${renderType(signature.returnType)}"
+
+  private def renderOutput(output: Option[LirLocalId]): String =
+    output.fold("")(id => s"$id = ")
+
+  private def renderArgs(args: List[LirValue]): String =
+    args.map(renderValue).mkString(", ")
+
+  private def line(indent: Int, text: String): String =
+    (" " * indent) + text
+
+  private def quote(value: String): String =
+    s""""${escapeString(value)}""""
+
+  private def escapeString(value: String): String =
+    val builder = new StringBuilder
+    value.foreach { char =>
+      builder.append(escapeChar(char))
+    }
+    builder.toString
+
+  private def escapeChar(char: Char): String =
+    char match
+      case '\\' => "\\\\"
+      case '"'  => "\\\""
+      case '\'' => "\\'"
+      case '\n' => "\\n"
+      case '\r' => "\\r"
+      case '\t' => "\\t"
+      case other if other.isControl =>
+        "\\u%04x".format(other.toInt)
+      case other =>
+        other.toString

--- a/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
@@ -1,0 +1,271 @@
+package cosmo0
+
+class LirTests extends munit.FunSuite:
+  private val tokenType = SourceType.User("Token")
+  private val optionTokenType = SourceType.Standard("Option", List(tokenType))
+  private val stringVecType = SourceType.Standard("Vec", List(SourceType.String))
+
+  test("debug renderer covers LIR operations and explicit terminators"):
+    val rendered = LirDebugRenderer.renderFunction(processFunction())
+
+    assertEquals(
+      rendered,
+      """fn @process process(%input input: Token) -> i32 {
+        |  local %count count: i32 mut
+        |  local %labels labels: Vec[String] mut
+        |  local %maybe maybe: Option[Token]
+        |  local %payload payload: Token
+        |  local %tag tag: i32
+        |  local %tmp tmp: usize
+        |  local %token token: Token mut
+        |
+        |  ^dead:
+        |    unreachable "not scheduled"
+        |  ^dispatch:
+        |    branch ^entry
+        |  ^entry:
+        |    alloc %count count: i32 mut = 0:i32
+        |    assign %count = 1:i32
+        |    %tmp = field_get %token.offset: usize
+        |    field_set %token.offset = %tmp
+        |    %count = call @identity(%count) -> i32
+        |    method_call %labels.push("ok") -> Unit
+        |    descriptor Vec[String]::push(%labels, "ok") -> Unit
+        |    %maybe = variant Option[Token]::Some(%token)
+        |    %tag = variant_tag %maybe: Option[Token]
+        |    %payload = variant_payload %maybe.Some[0]: Token
+        |    cond_branch true ? ^exit : ^error
+        |  ^error:
+        |    error "cosmo0.lir.test" "failed"
+        |  ^exit:
+        |    return %count
+        |}""".stripMargin,
+    )
+
+  test("debug renderer is stable for equivalent declaration, local, and block inputs"):
+    val first = LirModule(
+      "core",
+      List(processFunction(), identityFunction(), tokenDecl()),
+    )
+    val second = LirModule(
+      "core",
+      List(
+        tokenDecl().copy(
+          fields = tokenDecl().fields.reverse,
+          variants = tokenDecl().variants.reverse,
+        ),
+        processFunction(
+          locals = processLocals().reverse,
+          blocks = processBlocks().reverse,
+        ),
+        identityFunction(),
+      ),
+    )
+
+    assertEquals(
+      LirDebugRenderer.renderModule(first),
+      LirDebugRenderer.renderModule(second),
+    )
+
+  test("module renderer has a deterministic declaration and type-member layout"):
+    val module = LirModule(
+      "core",
+      List(
+        tokenDecl(),
+        LirTypeAliasDecl(
+          Lir.declId("token_id"),
+          "TokenId",
+          Lir.t(SourceType.Standard("Id", List(tokenType))),
+        ),
+        LirGlobal(
+          Lir.declId("answer"),
+          "answer",
+          Lir.t(SourceType.I32),
+          mutable = true,
+          initializer = Some(Lir.int(42)),
+        ),
+      ),
+    )
+
+    assertEquals(
+      LirDebugRenderer.renderModule(module),
+      """module core {
+        |  global var @answer answer: i32 = 42:i32
+        |
+        |  type @token Token {
+        |    field var offset: usize
+        |    field text: String
+        |    variant Empty()
+        |    variant WithText(value: String)
+        |  }
+        |
+        |  typealias @token_id TokenId = Id[Token]
+        |}""".stripMargin,
+    )
+
+  test("callable signatures retain cosmo0 source type information"):
+    val span = SourceFile("<test>", "").span(0, 0)
+    val sourceSignature = CallableSignature(
+      "identity",
+      List(CallableParam("value", SourceType.I32, span)),
+      SourceType.I32,
+    )
+    val lirSignature = LirCallableSignature.fromSource(sourceSignature)
+    val function = Lir.function(
+      "identity",
+      List(Lir.param("value", SourceType.I32)),
+      SourceType.I32,
+      locals = Nil,
+      blocks = List(Lir.block("entry", terminator = LirReturn(Some(Lir.ref("value", SourceType.I32))))),
+      sourceSignature = Some(sourceSignature),
+    )
+
+    assertEquals(lirSignature.params, List(Lir.t(SourceType.I32)))
+    assertEquals(lirSignature.returnType, Lir.t(SourceType.I32))
+    assertEquals(lirSignature.sourceSignature, Some(sourceSignature))
+    assertEquals(function.signature.sourceSignature, Some(sourceSignature))
+    assertEquals(function.signature.params, List(Lir.t(SourceType.I32)))
+
+  test("LIR node classes live in the cosmo0 package boundary"):
+    val modelClasses = List(
+      classOf[LirModule],
+      classOf[LirFunction],
+      classOf[LirBlock],
+      classOf[LirOp],
+      classOf[LirValue],
+      classOf[LirTerminator],
+    )
+
+    assert(modelClasses.forall(_.getName.startsWith("cosmo0.")))
+
+  private def tokenDecl(): LirTypeDecl =
+    LirTypeDecl(
+      Lir.declId("token"),
+      "Token",
+      fields = List(
+        LirField("text", Lir.t(SourceType.String)),
+        LirField("offset", Lir.t(SourceType.Usize), mutable = true),
+      ),
+      variants = List(
+        LirVariant("WithText", List(LirVariantPayload(Some("value"), Lir.t(SourceType.String)))),
+        LirVariant("Empty"),
+      ),
+    )
+
+  private def identityFunction(): LirFunction =
+    Lir.function(
+      "identity",
+      List(Lir.param("value", SourceType.I32)),
+      SourceType.I32,
+      locals = Nil,
+      blocks = List(
+        Lir.block(
+          "entry",
+          terminator = LirReturn(Some(Lir.ref("value", SourceType.I32))),
+        ),
+      ),
+    )
+
+  private def processFunction(
+      locals: List[LirLocal] = processLocals(),
+      blocks: List[LirBlock] = processBlocks(),
+  ): LirFunction =
+    Lir.function(
+      "process",
+      List(Lir.param("input", tokenType)),
+      SourceType.I32,
+      locals = locals,
+      blocks = blocks,
+    )
+
+  private def processLocals(): List[LirLocal] =
+    List(
+      Lir.local("token", tokenType, mutable = true),
+      Lir.local("labels", stringVecType, mutable = true),
+      Lir.local("maybe", optionTokenType),
+      Lir.local("tag", SourceType.I32),
+      Lir.local("payload", tokenType),
+      Lir.local("tmp", SourceType.Usize),
+      Lir.local("count", SourceType.I32, mutable = true),
+    )
+
+  private def processBlocks(): List[LirBlock] =
+    List(
+      Lir.block(
+        "exit",
+        terminator = LirReturn(Some(Lir.ref("count", SourceType.I32))),
+      ),
+      Lir.block(
+        "entry",
+        operations = List(
+          LirAllocLocal(Lir.local("count", SourceType.I32, mutable = true), Some(Lir.int(0))),
+          LirAssign(Lir.localPlace("count", SourceType.I32), Lir.int(1)),
+          LirFieldGet(
+            Lir.localId("tmp"),
+            Lir.ref("token", tokenType),
+            "offset",
+            Lir.t(SourceType.Usize),
+          ),
+          LirFieldSet(
+            Lir.ref("token", tokenType),
+            "offset",
+            Lir.ref("tmp", SourceType.Usize),
+          ),
+          LirDirectCall(
+            Some(Lir.localId("count")),
+            Lir.declId("identity"),
+            List(Lir.ref("count", SourceType.I32)),
+            Lir.signature(List(SourceType.I32), SourceType.I32),
+          ),
+          LirLoweredMethodCall(
+            None,
+            Lir.ref("labels", stringVecType),
+            "push",
+            List(Lir.string("ok")),
+            Lir.signature(List(SourceType.String), SourceType.Unit),
+          ),
+          LirDescriptorIntrinsic(
+            None,
+            LirDescriptorRef("Vec", List(Lir.t(SourceType.String))),
+            "push",
+            List(Lir.ref("labels", stringVecType), Lir.string("ok")),
+            Some(Lir.t(SourceType.Unit)),
+          ),
+          LirConstructVariant(
+            Lir.localId("maybe"),
+            Lir.t(optionTokenType),
+            "Some",
+            List(Lir.ref("token", tokenType)),
+          ),
+          LirReadVariantTag(
+            Lir.localId("tag"),
+            Lir.ref("maybe", optionTokenType),
+            Lir.t(optionTokenType),
+          ),
+          LirReadVariantPayload(
+            Lir.localId("payload"),
+            Lir.ref("maybe", optionTokenType),
+            "Some",
+            0,
+            Lir.t(tokenType),
+          ),
+        ),
+        terminator = LirCondBranch(
+          Lir.bool(true),
+          Lir.label("exit"),
+          Lir.label("error"),
+        ),
+      ),
+      Lir.block(
+        "dispatch",
+        terminator = LirBranch(Lir.label("entry")),
+      ),
+      Lir.block(
+        "dead",
+        terminator = LirUnreachable(Some("not scheduled")),
+      ),
+      Lir.block(
+        "error",
+        terminator = LirErrorExit("cosmo0.lir.test", Some("failed")),
+      ),
+    )


### PR DESCRIPTION
Adds the initial cosmo0 LIR data model and debug rendering support.

- defines modules, declarations, functions, globals, type aliases, and type declarations
- adds explicit ids for declarations, locals, and labels
- models LIR values, places, operations, and terminators
- includes helper constructors for concise hand-written tests
- adds deterministic debug rendering for modules, functions, blocks, operations, and types
- covers source signature retention and package boundary checks with tests

Also marks the `add-cosmo0-lir-model` OpenSpec tasks as complete.