### PR TITLE
feat: add cosmo0 lir type checker

### DIFF
--- a/openspec/changes/add-cosmo0-lir-type-checker/tasks.md
+++ b/openspec/changes/add-cosmo0-lir-type-checker/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Checker Structure
 
-- [ ] 1.1 Add a LIR checker entry point that accepts a LIR module and returns structured diagnostics.
-- [ ] 1.2 Build checker environments for functions, locals, labels, declarations, call signatures, variants, and descriptor intrinsics.
-- [ ] 1.3 Reuse cosmo0 diagnostic and source span types where LIR nodes retain source origin.
+- [x] 1.1 Add a LIR checker entry point that accepts a LIR module and returns structured diagnostics.
+- [x] 1.2 Build checker environments for functions, locals, labels, declarations, call signatures, variants, and descriptor intrinsics.
+- [x] 1.3 Reuse cosmo0 diagnostic and source span types where LIR nodes retain source origin.
 
 ## 2. Structural Validation
 
-- [ ] 2.1 Validate function signatures, parameter locals, local declarations, and local use-before-definition rules.
-- [ ] 2.2 Validate every block has exactly one valid terminator.
-- [ ] 2.3 Validate branch targets exist and branch conditions have boolean type.
-- [ ] 2.4 Validate all reachable return terminators match the function return type.
+- [x] 2.1 Validate function signatures, parameter locals, local declarations, and local use-before-definition rules.
+- [x] 2.2 Validate every block has exactly one valid terminator.
+- [x] 2.3 Validate branch targets exist and branch conditions have boolean type.
+- [x] 2.4 Validate all reachable return terminators match the function return type.
 
 ## 3. Type Validation
 
-- [ ] 3.1 Validate assignment, field get/set, direct call, descriptor intrinsic, variant construction, tag read, and payload read operation types.
-- [ ] 3.2 Validate reference and mutability invariants that must hold after lowering.
-- [ ] 3.3 Validate variant payload shape and match-lowering support operations.
-- [ ] 3.4 Validate deterministic descriptor operation signatures used by later backend emission.
+- [x] 3.1 Validate assignment, field get/set, direct call, descriptor intrinsic, variant construction, tag read, and payload read operation types.
+- [x] 3.2 Validate reference and mutability invariants that must hold after lowering.
+- [x] 3.3 Validate variant payload shape and match-lowering support operations.
+- [x] 3.4 Validate deterministic descriptor operation signatures used by later backend emission.
 
 ## 4. Tests
 
-- [ ] 4.1 Add hand-written valid LIR fixtures that pass the checker.
-- [ ] 4.2 Add negative LIR fixtures for missing terminators, invalid branch targets, type mismatches, invalid calls, invalid variants, and invalid mutability.
-- [ ] 4.3 Add tests proving checker diagnostics are deterministic and identify the failing LIR construct.
+- [x] 4.1 Add hand-written valid LIR fixtures that pass the checker.
+- [x] 4.2 Add negative LIR fixtures for missing terminators, invalid branch targets, type mismatches, invalid calls, invalid variants, and invalid mutability.
+- [x] 4.3 Add tests proving checker diagnostics are deterministic and identify the failing LIR construct.

--- a/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
@@ -1,0 +1,985 @@
+package cosmo0
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+object LirTypeChecker:
+  def apply(): LirTypeChecker =
+    new LirTypeChecker(StandardGenericDescriptors.all)
+
+final class LirTypeChecker(
+    descriptors: Map[String, StandardGenericDescriptor] = StandardGenericDescriptors.all,
+):
+  def check(module: LirModule): Result[LirModule] =
+    val state = State(module, descriptors)
+    state.check()
+    val diagnostics = state.diagnostics
+    if diagnostics.isEmpty then Result.success(Phase.Check, module)
+    else Result.failure(Phase.Check, diagnostics)
+
+  private final case class DeclEnv(
+      declarations: Map[LirDeclId, LirDeclaration],
+      functions: Map[LirDeclId, LirFunction],
+      globals: Map[LirDeclId, LirGlobal],
+      typesByName: Map[String, LirTypeDecl],
+      typesById: Map[LirDeclId, LirTypeDecl],
+  )
+
+  private final case class LocalInfo(
+      id: LirLocalId,
+      name: String,
+      valueType: LirTypeRef,
+      mutable: Boolean,
+      param: Boolean,
+  )
+
+  private final case class FunctionEnv(
+      function: LirFunction,
+      declarations: DeclEnv,
+      locals: Map[LirLocalId, LocalInfo],
+      blocks: Map[LirLabel, LirBlock],
+      entry: LirLabel,
+  )
+
+  private final case class PlaceInfo(
+      valueType: LirTypeRef,
+      mutable: Boolean,
+      local: Option[LirLocalId],
+      description: String,
+  )
+
+  private final case class VariantShape(
+      owner: LirTypeRef,
+      variant: String,
+      payload: List[LirTypeRef],
+  )
+
+  private final class State(
+      module: LirModule,
+      descriptors: Map[String, StandardGenericDescriptor],
+  ):
+    private val errors = ListBuffer.empty[Diagnostic]
+
+    def diagnostics: List[Diagnostic] =
+      errors.toList
+
+    def check(): Unit =
+      val declarations = buildDeclarationEnv()
+      checkTypeDeclarations(declarations)
+      checkGlobals(declarations)
+      declarations.functions.values.toList.sortBy(_.id.value).foreach(checkFunction(_, declarations))
+
+    private def buildDeclarationEnv(): DeclEnv =
+      module.declarations
+        .groupBy(_.id)
+        .toList
+        .sortBy(_._1.value)
+        .foreach { case (id, declarations) =>
+          if declarations.length > 1 then
+            error(
+              "cosmo0.lir.duplicate-declaration",
+              s"duplicate LIR declaration id $id",
+            )
+        }
+
+      val declarations = firstBy(module.declarations)(_.id)
+      val functions = declarations.collect { case (id, function: LirFunction) => id -> function }
+      val globals = declarations.collect { case (id, global: LirGlobal) => id -> global }
+      val typeDecls = declarations.collect { case (id, ty: LirTypeDecl) => id -> ty }
+
+      typeDecls.values
+        .toList
+        .groupBy(_.name)
+        .toList
+        .sortBy(_._1)
+        .foreach { case (name, declarations) =>
+          if declarations.length > 1 then
+            error(
+              "cosmo0.lir.duplicate-type",
+              s"duplicate LIR type name $name",
+            )
+        }
+
+      DeclEnv(
+        declarations,
+        functions,
+        globals,
+        typeDecls.values.map(ty => ty.name -> ty).toMap,
+        typeDecls,
+      )
+
+    private def checkTypeDeclarations(declarations: DeclEnv): Unit =
+      declarations.typesById.values.toList.sortBy(_.id.value).foreach { ty =>
+        ty.fields
+          .groupBy(_.name)
+          .toList
+          .sortBy(_._1)
+          .foreach { case (name, fields) =>
+            if fields.length > 1 then
+              error(
+                "cosmo0.lir.duplicate-field",
+                s"${ty.id} declares duplicate field $name",
+              )
+          }
+
+        ty.variants
+          .groupBy(_.name)
+          .toList
+          .sortBy(_._1)
+          .foreach { case (name, variants) =>
+            if variants.length > 1 then
+              error(
+                "cosmo0.lir.duplicate-variant",
+                s"${ty.id} declares duplicate variant $name",
+              )
+          }
+      }
+
+    private def checkGlobals(declarations: DeclEnv): Unit =
+      declarations.globals.values.toList.sortBy(_.id.value).foreach { global =>
+        global.initializer.foreach { initializer =>
+          checkModuleValue(initializer, declarations)
+          if !assignable(initializer.valueType, global.valueType) then
+            error(
+              "cosmo0.lir.assignment-mismatch",
+              s"${global.id} initializer has type ${initializer.valueType.display}, expected ${global.valueType.display}",
+            )
+        }
+      }
+
+    private def checkFunction(function: LirFunction, declarations: DeclEnv): Unit =
+      if function.blocks.isEmpty then
+        error(
+          "cosmo0.lir.missing-block",
+          s"${function.id} has no LIR blocks",
+        )
+        return
+
+      function.sourceSignature.foreach(checkSourceSignature(function, _))
+
+      val locals = buildLocalEnv(function)
+      val blocks = buildBlockEnv(function)
+      val entry = blocks.get(LirLabel("entry")).map(_.label).getOrElse(blocks.keys.toList.sortBy(_.value).head)
+      val env = FunctionEnv(function, declarations, locals, blocks, entry)
+
+      checkBranchTargets(env)
+      val inSets = computeDefinedInputs(env)
+      inSets.keys.toList.sortBy(_.value).foreach { label =>
+        blocks.get(label).foreach { block =>
+          checkReachableBlock(block, env, inSets(label))
+        }
+      }
+
+    private def checkSourceSignature(function: LirFunction, source: CallableSignature): Unit =
+      val sourceParams = source.params.map(param => LirTypeRef(param.valueType))
+      if sourceParams.length != function.params.length then
+        error(
+          "cosmo0.lir.invalid-signature",
+          s"${function.id} has ${function.params.length} LIR parameter(s), source signature has ${sourceParams.length}",
+        )
+      sourceParams.zip(function.params).zipWithIndex.foreach { case ((expected, actual), index) =>
+        if !sameType(expected, actual.valueType) then
+          error(
+            "cosmo0.lir.invalid-signature",
+            s"${function.id} parameter $index has type ${actual.valueType.display}, expected ${expected.display}",
+          )
+      }
+      val expectedReturn = LirTypeRef(source.returnType)
+      if !sameType(expectedReturn, function.returnType) then
+        error(
+          "cosmo0.lir.invalid-signature",
+          s"${function.id} returns ${function.returnType.display}, source signature returns ${expectedReturn.display}",
+        )
+
+    private def buildLocalEnv(function: LirFunction): Map[LirLocalId, LocalInfo] =
+      val params = function.params.map { param =>
+        LocalInfo(param.id, param.name, param.valueType, mutable = false, param = true)
+      }
+      val locals = function.locals.map { local =>
+        LocalInfo(local.id, local.name, local.valueType, local.mutable, param = false)
+      }
+      (params ++ locals)
+        .groupBy(_.id)
+        .toList
+        .sortBy(_._1.value)
+        .foreach { case (id, values) =>
+          if values.length > 1 then
+            error(
+              "cosmo0.lir.duplicate-local",
+              s"${function.id} declares duplicate local $id",
+            )
+        }
+      firstBy(params ++ locals)(_.id)
+
+    private def buildBlockEnv(function: LirFunction): Map[LirLabel, LirBlock] =
+      function.blocks
+        .groupBy(_.label)
+        .toList
+        .sortBy(_._1.value)
+        .foreach { case (label, blocks) =>
+          if blocks.length > 1 then
+            error(
+              "cosmo0.lir.duplicate-label",
+              s"${function.id} declares duplicate block label $label",
+            )
+        }
+      firstBy(function.blocks)(_.label)
+
+    private def checkBranchTargets(env: FunctionEnv): Unit =
+      env.blocks.values.toList.sortBy(_.label.value).foreach { block =>
+        branchTargets(block.terminator).foreach { target =>
+          if !env.blocks.contains(target) then
+            error(
+              "cosmo0.lir.invalid-branch",
+              s"${env.function.id} block ${block.label} branches to unknown target $target",
+            )
+        }
+      }
+
+    private def computeDefinedInputs(env: FunctionEnv): Map[LirLabel, Set[LirLocalId]] =
+      val initial = env.locals.values.filter(_.param).map(_.id).toSet
+      val inputs = mutable.LinkedHashMap.empty[LirLabel, Set[LirLocalId]]
+      val outputs = mutable.LinkedHashMap.empty[LirLabel, Set[LirLocalId]]
+      val queue = mutable.Queue.empty[LirLabel]
+
+      inputs(env.entry) = initial
+      queue.enqueue(env.entry)
+
+      while queue.nonEmpty do
+        val label = queue.dequeue()
+        val block = env.blocks(label)
+        val nextOut = transferDefinitions(block, inputs(label), env)
+        val changedOut = outputs.get(label).forall(_ != nextOut)
+        outputs(label) = nextOut
+        if changedOut then
+          successors(block, env.blocks.keySet).foreach { successor =>
+            val merged = inputs.get(successor).fold(nextOut)(_ intersect nextOut)
+            if inputs.get(successor).forall(_ != merged) then
+              inputs(successor) = merged
+              queue.enqueue(successor)
+          }
+
+      inputs.toMap
+
+    private def transferDefinitions(
+        block: LirBlock,
+        initial: Set[LirLocalId],
+        env: FunctionEnv,
+    ): Set[LirLocalId] =
+      block.operations.foldLeft(initial) { (defined, op) =>
+        op match
+          case LirAllocLocal(local, _) =>
+            if env.locals.contains(local.id) then defined + local.id else defined
+          case LirAssign(LirLocalPlace(id, _), _) =>
+            if env.locals.contains(id) then defined + id else defined
+          case LirAssign(_, _) =>
+            defined
+          case LirFieldGet(output, _, _, _) =>
+            defineKnown(output, defined, env)
+          case LirFieldSet(_, _, _) =>
+            defined
+          case LirDirectCall(output, _, _, _) =>
+            output.fold(defined)(defineKnown(_, defined, env))
+          case LirLoweredMethodCall(output, _, _, _, _) =>
+            output.fold(defined)(defineKnown(_, defined, env))
+          case LirDescriptorIntrinsic(output, _, _, _, _) =>
+            output.fold(defined)(defineKnown(_, defined, env))
+          case LirConstructVariant(output, _, _, _) =>
+            defineKnown(output, defined, env)
+          case LirReadVariantTag(output, _, _) =>
+            defineKnown(output, defined, env)
+          case LirReadVariantPayload(output, _, _, _, _) =>
+            defineKnown(output, defined, env)
+        }
+
+    private def defineKnown(
+        id: LirLocalId,
+        defined: Set[LirLocalId],
+        env: FunctionEnv,
+    ): Set[LirLocalId] =
+      if env.locals.contains(id) then defined + id else defined
+
+    private def checkReachableBlock(
+        block: LirBlock,
+        env: FunctionEnv,
+        initiallyDefined: Set[LirLocalId],
+    ): Unit =
+      val finalDefined = block.operations.foldLeft(initiallyDefined) { (defined, op) =>
+        checkOp(op, env, defined)
+      }
+      checkTerminator(block, env, finalDefined)
+
+    private def checkOp(
+        op: LirOp,
+        env: FunctionEnv,
+        defined: Set[LirLocalId],
+    ): Set[LirLocalId] =
+      op match
+        case LirAllocLocal(local, init) =>
+          val localInfo = env.locals.get(local.id)
+          localInfo match
+            case Some(info) =>
+              if info.param then
+                error(
+                  "cosmo0.lir.invalid-local",
+                  s"${env.function.id} cannot allocate parameter ${local.id}",
+                )
+              if info.name != local.name || !sameType(info.valueType, local.valueType) || info.mutable != local.mutable then
+                error(
+                  "cosmo0.lir.invalid-local",
+                  s"${env.function.id} allocates ${local.id} with metadata that does not match the function local declaration",
+                )
+              if defined.contains(local.id) && !info.mutable then
+                error(
+                  "cosmo0.lir.invalid-mutability",
+                  s"${env.function.id} cannot redefine immutable local ${local.id}",
+                )
+            case None =>
+              error(
+                "cosmo0.lir.unknown-local",
+                s"${env.function.id} allocates undeclared local ${local.id}",
+              )
+
+          init.foreach { value =>
+            checkValue(value, env, defined)
+            if !assignable(value.valueType, local.valueType) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"${env.function.id} initializes ${local.id} with ${value.valueType.display}, expected ${local.valueType.display}",
+              )
+          }
+          if localInfo.nonEmpty then defined + local.id else defined
+
+        case LirAssign(target, value) =>
+          checkValue(value, env, defined)
+          val targetInfo = checkPlace(target, env, defined)
+          targetInfo.foreach { place =>
+            if !place.mutable then
+              error(
+                "cosmo0.lir.invalid-mutability",
+                s"${env.function.id} cannot assign to immutable ${place.description}",
+              )
+            if !assignable(value.valueType, place.valueType) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"${env.function.id} assigns ${value.valueType.display} to ${place.description}: ${place.valueType.display}",
+              )
+          }
+          targetInfo.flatMap(_.local).fold(defined)(id => defined + id)
+
+        case LirFieldGet(output, receiver, field, valueType) =>
+          checkValue(receiver, env, defined)
+          fieldInfo(receiver.valueType, field, env).foreach { fieldInfo =>
+            if !sameType(fieldInfo.valueType, valueType) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"${env.function.id} reads field $field as ${valueType.display}, expected ${fieldInfo.valueType.display}",
+              )
+          }
+          defineOutput(output, valueType, env, defined, s"field_get $field")
+
+        case LirFieldSet(receiver, field, value) =>
+          checkValue(receiver, env, defined)
+          checkValue(value, env, defined)
+          fieldInfo(receiver.valueType, field, env).foreach { fieldInfo =>
+            if !fieldInfo.mutable || !mutableValue(receiver, env) then
+              error(
+                "cosmo0.lir.invalid-mutability",
+                s"${env.function.id} cannot set immutable field $field through ${valueDescription(receiver)}",
+              )
+            if !assignable(value.valueType, fieldInfo.valueType) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"${env.function.id} sets field $field with ${value.valueType.display}, expected ${fieldInfo.valueType.display}",
+              )
+          }
+          defined
+
+        case LirDirectCall(output, callee, args, signature) =>
+          args.foreach(checkValue(_, env, defined))
+          env.declarations.functions.get(callee) match
+            case Some(function) =>
+              if !sameSignature(signature, function.signature) then
+                error(
+                  "cosmo0.lir.invalid-call",
+                  s"${env.function.id} call to $callee uses signature ${signatureDisplay(signature)}, expected ${signatureDisplay(function.signature)}",
+                )
+            case None =>
+              error(
+                "cosmo0.lir.unknown-function",
+                s"${env.function.id} calls unknown function $callee",
+              )
+          checkInvocationArgs(env.function.id, s"call $callee", args, signature.params)
+          defineCallOutput(output, signature.returnType, env, defined, s"call $callee")
+
+        case LirLoweredMethodCall(output, receiver, method, args, signature) =>
+          checkValue(receiver, env, defined)
+          args.foreach(checkValue(_, env, defined))
+          expectedMethodSignature(receiver, method, env).foreach { expected =>
+            if expected.receiverMutable && !mutableValue(receiver, env) then
+              error(
+                "cosmo0.lir.invalid-mutability",
+                s"${env.function.id} method $method requires a mutable receiver",
+              )
+            if !sameSignature(signature, expected.signature) then
+              error(
+                "cosmo0.lir.invalid-call",
+                s"${env.function.id} method $method uses signature ${signatureDisplay(signature)}, expected ${signatureDisplay(expected.signature)}",
+              )
+          }
+          signature.sourceSignature.flatMap(_.receiver).foreach { receiverInfo =>
+            if receiverInfo.mutable && !mutableValue(receiver, env) then
+              error(
+                "cosmo0.lir.invalid-mutability",
+                s"${env.function.id} method $method requires a mutable receiver",
+              )
+          }
+          checkInvocationArgs(env.function.id, s"method $method", args, signature.params)
+          defineCallOutput(output, signature.returnType, env, defined, s"method $method")
+
+        case LirDescriptorIntrinsic(output, descriptor, name, args, resultType) =>
+          args.foreach(checkValue(_, env, defined))
+          expectedDescriptorOperation(descriptor, name) match
+            case Some(expected) =>
+              if expected.receiverMutable then
+                args.headOption.foreach { receiver =>
+                  if !mutableValue(receiver, env) then
+                    error(
+                      "cosmo0.lir.invalid-mutability",
+                      s"${env.function.id} descriptor ${descriptor.name}::$name requires a mutable receiver",
+                    )
+                }
+              checkInvocationArgs(env.function.id, s"descriptor ${descriptor.name}::$name", args, expected.signature.params)
+              val actualResult = resultType.getOrElse(LirTypeRef(SourceType.Unit))
+              if !sameType(actualResult, expected.signature.returnType) then
+                error(
+                  "cosmo0.lir.invalid-descriptor",
+                  s"${env.function.id} descriptor ${descriptor.name}::$name reports ${actualResult.display}, expected ${expected.signature.returnType.display}",
+                )
+              defineCallOutput(output, expected.signature.returnType, env, defined, s"descriptor ${descriptor.name}::$name")
+            case None =>
+              defined
+
+        case LirConstructVariant(output, owner, variant, payload) =>
+          payload.foreach(checkValue(_, env, defined))
+          variantShape(owner, variant, env).foreach { shape =>
+            checkInvocationArgs(env.function.id, s"variant ${owner.display}::$variant", payload, shape.payload)
+          }
+          defineOutput(output, owner, env, defined, s"variant ${owner.display}::$variant")
+
+        case LirReadVariantTag(output, scrutinee, owner) =>
+          checkValue(scrutinee, env, defined)
+          if !sameSourceType(SourceType.deref(scrutinee.valueType.source), owner.source) then
+            error(
+              "cosmo0.lir.assignment-mismatch",
+              s"${env.function.id} reads variant tag for ${owner.display} from ${scrutinee.valueType.display}",
+            )
+          if variantNames(owner, env).isEmpty then
+            error(
+              "cosmo0.lir.invalid-variant",
+              s"${env.function.id} reads variant tag from non-variant type ${owner.display}",
+            )
+          defineOutput(output, LirTypeRef(SourceType.I32), env, defined, s"variant_tag ${owner.display}")
+
+        case LirReadVariantPayload(output, scrutinee, variant, index, valueType) =>
+          checkValue(scrutinee, env, defined)
+          val owner = LirTypeRef(SourceType.deref(scrutinee.valueType.source))
+          variantShape(owner, variant, env).foreach { shape =>
+            if index < 0 || index >= shape.payload.length then
+              error(
+                "cosmo0.lir.invalid-variant",
+                s"${env.function.id} reads invalid payload index $index from ${owner.display}::$variant",
+              )
+            else if !sameType(valueType, shape.payload(index)) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"${env.function.id} reads ${owner.display}::$variant[$index] as ${valueType.display}, expected ${shape.payload(index).display}",
+              )
+          }
+          defineOutput(output, valueType, env, defined, s"variant_payload $variant[$index]")
+
+    private final case class ExpectedCallable(
+        signature: LirCallableSignature,
+        receiverMutable: Boolean,
+    )
+
+    private def expectedMethodSignature(
+        receiver: LirValue,
+        method: String,
+        env: FunctionEnv,
+    ): Option[ExpectedCallable] =
+      SourceType.dealias(SourceType.deref(receiver.valueType.source)) match
+        case owner: SourceType.Standard =>
+          descriptorMethod(owner, method, receiver.valueType)
+        case SourceType.User(name) =>
+          env.declarations.typesByName.get(name).flatMap { ty =>
+            env.declarations.functions.values
+              .find(function => function.owner.contains(ty.id) && function.name == method)
+              .map(function => ExpectedCallable(function.signature, receiverMutable = false))
+          }
+        case _ =>
+          None
+
+    private def expectedDescriptorOperation(
+        descriptor: LirDescriptorRef,
+        name: String,
+    ): Option[ExpectedCallable] =
+      descriptors.get(descriptor.name) match
+        case None =>
+          error(
+            "cosmo0.lir.invalid-descriptor",
+            s"unknown descriptor ${descriptor.name}",
+          )
+          None
+        case Some(info) if info.arity != descriptor.args.length =>
+          error(
+            "cosmo0.lir.invalid-descriptor",
+            s"descriptor ${descriptor.name} expects ${info.arity} type argument(s), got ${descriptor.args.length}",
+          )
+          None
+        case Some(info) =>
+          val owner: SourceType.Standard =
+            SourceType.Standard(descriptor.name, descriptor.args.map(_.source))
+          info.method(name) match
+            case Some(callable) =>
+              val signature = callable.instantiate(owner, syntheticSpan)
+              val params = LirTypeRef(owner) :: signature.params.map(param => LirTypeRef(param.valueType))
+              Some(
+                ExpectedCallable(
+                  LirCallableSignature(params, LirTypeRef(signature.returnType), Some(signature)),
+                  signature.receiver.exists(_.mutable),
+                ),
+              )
+            case None =>
+              info.constructor(name) match
+                case Some(callable) =>
+                  val signature = callable.instantiate(owner, syntheticSpan)
+                  Some(
+                    ExpectedCallable(
+                      LirCallableSignature.fromSource(signature),
+                      receiverMutable = false,
+                    ),
+                  )
+                case None =>
+                  error(
+                    "cosmo0.lir.invalid-descriptor",
+                    s"descriptor ${descriptor.name} has no operation $name",
+                  )
+                  None
+
+    private def descriptorMethod(
+        owner: SourceType.Standard,
+        method: String,
+        receiverType: LirTypeRef,
+    ): Option[ExpectedCallable] =
+      descriptors.get(owner.name).flatMap(_.method(method)).map { callable =>
+        val signature = callable.instantiate(owner, syntheticSpan)
+        ExpectedCallable(
+          LirCallableSignature(signature.params.map(param => LirTypeRef(param.valueType)), LirTypeRef(signature.returnType), Some(signature)),
+          signature.receiver.exists(_.mutable),
+        )
+      }
+
+    private def checkTerminator(
+        block: LirBlock,
+        env: FunctionEnv,
+        defined: Set[LirLocalId],
+    ): Unit =
+      block.terminator match
+        case LirReturn(value) =>
+          value.foreach(checkValue(_, env, defined))
+          (value, env.function.returnType.source) match
+            case (None, SourceType.Unit) =>
+            case (None, _) =>
+              error(
+                "cosmo0.lir.invalid-return",
+                s"${env.function.id} block ${block.label} returns no value, expected ${env.function.returnType.display}",
+              )
+            case (Some(actual), expected) if !assignable(actual.valueType.source, expected) =>
+              error(
+                "cosmo0.lir.invalid-return",
+                s"${env.function.id} block ${block.label} returns ${actual.valueType.display}, expected ${env.function.returnType.display}",
+              )
+            case _ =>
+
+        case LirBranch(_) =>
+
+        case LirCondBranch(condition, _, _) =>
+          checkValue(condition, env, defined)
+          if !sameSourceType(condition.valueType.source, SourceType.Bool) then
+            error(
+              "cosmo0.lir.invalid-branch",
+              s"${env.function.id} block ${block.label} branches on ${condition.valueType.display}, expected Bool",
+            )
+
+        case LirUnreachable(_) =>
+
+        case LirErrorExit(_, _) =>
+
+    private def checkPlace(
+        place: LirPlace,
+        env: FunctionEnv,
+        defined: Set[LirLocalId],
+    ): Option[PlaceInfo] =
+      place match
+        case LirLocalPlace(id, valueType) =>
+          env.locals.get(id) match
+            case Some(local) =>
+              if !sameType(valueType, local.valueType) then
+                error(
+                  "cosmo0.lir.assignment-mismatch",
+                  s"${env.function.id} local place $id has type ${valueType.display}, expected ${local.valueType.display}",
+                )
+              Some(PlaceInfo(local.valueType, local.mutable, Some(id), id.toString))
+            case None =>
+              error(
+                "cosmo0.lir.unknown-local",
+                s"${env.function.id} references undeclared local $id",
+              )
+              None
+
+        case LirFieldPlace(receiver, field, valueType) =>
+          checkValue(receiver, env, defined)
+          fieldInfo(receiver.valueType, field, env).map { fieldInfo =>
+            if !sameType(valueType, fieldInfo.valueType) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"${env.function.id} field place $field has type ${valueType.display}, expected ${fieldInfo.valueType.display}",
+              )
+            PlaceInfo(
+              fieldInfo.valueType,
+              fieldInfo.mutable && mutableValue(receiver, env),
+              None,
+              s"${valueDescription(receiver)}.$field",
+            )
+          }
+
+    private def checkValue(
+        value: LirValue,
+        env: FunctionEnv,
+        defined: Set[LirLocalId],
+    ): Unit =
+      value match
+        case LirUnitValue =>
+
+        case LirBoolValue(_) =>
+
+        case LirIntValue(_, valueType) =>
+          if !SourceType.isInteger(valueType.source) then
+            error(
+              "cosmo0.lir.assignment-mismatch",
+              s"integer literal is annotated as ${valueType.display}",
+            )
+
+        case LirFloatValue(_, valueType) =>
+          if !SourceType.isFloat(valueType.source) then
+            error(
+              "cosmo0.lir.assignment-mismatch",
+              s"float literal is annotated as ${valueType.display}",
+            )
+
+        case LirStringValue(_) =>
+
+        case LirCharValue(_) =>
+
+        case LirLocalRef(id, valueType) =>
+          env.locals.get(id) match
+            case Some(local) =>
+              if !sameType(valueType, local.valueType) then
+                error(
+                  "cosmo0.lir.assignment-mismatch",
+                  s"${env.function.id} local reference $id has type ${valueType.display}, expected ${local.valueType.display}",
+                )
+              if !defined.contains(id) then
+                error(
+                  "cosmo0.lir.use-before-definition",
+                  s"${env.function.id} reads $id before it is defined",
+                )
+            case None =>
+              error(
+                "cosmo0.lir.unknown-local",
+                s"${env.function.id} references undeclared local $id",
+              )
+
+        case LirGlobalRef(id, valueType) =>
+          env.declarations.globals.get(id) match
+            case Some(global) =>
+              if !sameType(valueType, global.valueType) then
+                error(
+                  "cosmo0.lir.assignment-mismatch",
+                  s"${env.function.id} global reference $id has type ${valueType.display}, expected ${global.valueType.display}",
+                )
+            case None =>
+              error(
+                "cosmo0.lir.unknown-global",
+                s"${env.function.id} references unknown global $id",
+              )
+
+        case LirFunctionRef(id, signature) =>
+          env.declarations.functions.get(id) match
+            case Some(function) =>
+              if !sameSignature(signature, function.signature) then
+                error(
+                  "cosmo0.lir.invalid-call",
+                  s"${env.function.id} function reference $id has signature ${signatureDisplay(signature)}, expected ${signatureDisplay(function.signature)}",
+                )
+            case None =>
+              error(
+                "cosmo0.lir.unknown-function",
+                s"${env.function.id} references unknown function $id",
+              )
+
+    private def checkModuleValue(value: LirValue, declarations: DeclEnv): Unit =
+      value match
+        case LirGlobalRef(id, valueType) =>
+          declarations.globals.get(id).foreach { global =>
+            if !sameType(valueType, global.valueType) then
+              error(
+                "cosmo0.lir.assignment-mismatch",
+                s"global reference $id has type ${valueType.display}, expected ${global.valueType.display}",
+              )
+          }
+        case LirFunctionRef(id, signature) =>
+          declarations.functions.get(id).foreach { function =>
+            if !sameSignature(signature, function.signature) then
+              error(
+                "cosmo0.lir.invalid-call",
+                s"function reference $id has signature ${signatureDisplay(signature)}, expected ${signatureDisplay(function.signature)}",
+              )
+          }
+        case _ =>
+
+    private def defineOutput(
+        output: LirLocalId,
+        expectedType: LirTypeRef,
+        env: FunctionEnv,
+        defined: Set[LirLocalId],
+        construct: String,
+    ): Set[LirLocalId] =
+      env.locals.get(output) match
+        case Some(local) =>
+          if local.param then
+            error(
+              "cosmo0.lir.invalid-output",
+              s"${env.function.id} writes $construct result to parameter $output",
+            )
+          if !sameType(local.valueType, expectedType) then
+            error(
+              "cosmo0.lir.invalid-output",
+              s"${env.function.id} writes $construct result ${expectedType.display} to $output: ${local.valueType.display}",
+            )
+          if defined.contains(output) && !local.mutable then
+            error(
+              "cosmo0.lir.invalid-mutability",
+              s"${env.function.id} cannot redefine immutable local $output with $construct",
+            )
+          defined + output
+        case None =>
+          error(
+            "cosmo0.lir.unknown-local",
+            s"${env.function.id} writes $construct result to undeclared local $output",
+          )
+          defined
+
+    private def defineCallOutput(
+        output: Option[LirLocalId],
+        resultType: LirTypeRef,
+        env: FunctionEnv,
+        defined: Set[LirLocalId],
+        construct: String,
+    ): Set[LirLocalId] =
+      output match
+        case Some(id) =>
+          defineOutput(id, resultType, env, defined, construct)
+        case None if !sameSourceType(resultType.source, SourceType.Unit) && !sameSourceType(resultType.source, SourceType.Never) =>
+          error(
+            "cosmo0.lir.invalid-output",
+            s"${env.function.id} drops non-Unit result ${resultType.display} from $construct",
+          )
+          defined
+        case None =>
+          defined
+
+    private def checkInvocationArgs(
+        functionId: LirDeclId,
+        construct: String,
+        args: List[LirValue],
+        params: List[LirTypeRef],
+    ): Unit =
+      if args.length != params.length then
+        error(
+          "cosmo0.lir.invalid-call",
+          s"$functionId $construct expects ${params.length} argument(s), got ${args.length}",
+        )
+      args.zip(params).zipWithIndex.foreach { case ((arg, param), index) =>
+        if !assignable(arg.valueType, param) then
+          error(
+            "cosmo0.lir.assignment-mismatch",
+            s"$functionId $construct argument $index has type ${arg.valueType.display}, expected ${param.display}",
+          )
+      }
+
+    private def fieldInfo(
+        receiverType: LirTypeRef,
+        field: String,
+        env: FunctionEnv,
+    ): Option[LirField] =
+      typeDeclFor(receiverType.source, env.declarations) match
+        case Some(ty) =>
+          ty.fields.find(_.name == field) match
+            case Some(value) => Some(value)
+            case None =>
+              error(
+                "cosmo0.lir.unknown-field",
+                s"${ty.id} has no field $field",
+              )
+              None
+        case None =>
+          error(
+            "cosmo0.lir.unknown-type",
+            s"no LIR type declaration for ${receiverType.display}",
+          )
+          None
+
+    private def variantShape(
+        owner: LirTypeRef,
+        variant: String,
+        env: FunctionEnv,
+    ): Option[VariantShape] =
+      SourceType.dealias(owner.source) match
+        case standard: SourceType.Standard =>
+          descriptors.get(standard.name) match
+            case Some(descriptor) if descriptor.arity == standard.args.length =>
+              descriptor.constructor(variant) match
+                case Some(callable) =>
+                  val signature = callable.instantiate(standard, syntheticSpan)
+                  if !sameSourceType(signature.returnType, standard) then
+                    error(
+                      "cosmo0.lir.invalid-variant",
+                      s"${owner.display}::$variant returns ${signature.returnType.display}, expected ${owner.display}",
+                    )
+                  Some(VariantShape(owner, variant, signature.params.map(param => LirTypeRef(param.valueType))))
+                case None =>
+                  error(
+                    "cosmo0.lir.invalid-variant",
+                    s"${owner.display} has no variant $variant",
+                  )
+                  None
+            case Some(descriptor) =>
+              error(
+                "cosmo0.lir.invalid-descriptor",
+                s"${standard.name} expects ${descriptor.arity} type argument(s), got ${standard.args.length}",
+              )
+              None
+            case None =>
+              error(
+                "cosmo0.lir.unknown-type",
+                s"unknown descriptor-backed variant owner ${standard.name}",
+              )
+              None
+
+        case _ =>
+          typeDeclFor(owner.source, env.declarations) match
+            case Some(ty) =>
+              ty.variants.find(_.name == variant) match
+                case Some(value) =>
+                  Some(VariantShape(owner, variant, value.payload.map(_.valueType)))
+                case None =>
+                  error(
+                    "cosmo0.lir.invalid-variant",
+                    s"${ty.id} has no variant $variant",
+                  )
+                  None
+            case None =>
+              error(
+                "cosmo0.lir.unknown-type",
+                s"no LIR type declaration for variant owner ${owner.display}",
+              )
+              None
+
+    private def variantNames(owner: LirTypeRef, env: FunctionEnv): Set[String] =
+      SourceType.dealias(owner.source) match
+        case standard: SourceType.Standard =>
+          descriptors.get(standard.name).filter(_.arity == standard.args.length).fold(Set.empty[String])(_.constructors.keySet)
+        case _ =>
+          typeDeclFor(owner.source, env.declarations).fold(Set.empty[String])(_.variants.map(_.name).toSet)
+
+    private def typeDeclFor(
+        sourceType: SourceType,
+        declarations: DeclEnv,
+    ): Option[LirTypeDecl] =
+      SourceType.dealias(SourceType.deref(sourceType)) match
+        case SourceType.User(name) =>
+          declarations.typesByName.get(name)
+        case _ =>
+          None
+
+    private def mutableValue(value: LirValue, env: FunctionEnv): Boolean =
+      SourceType.refMutable(value.valueType.source).contains(true) ||
+        (value match
+          case LirLocalRef(id, _)  => env.locals.get(id).exists(_.mutable)
+          case LirGlobalRef(id, _) => env.declarations.globals.get(id).exists(_.mutable)
+          case _                   => false
+        )
+
+    private def successors(
+        block: LirBlock,
+        knownLabels: Set[LirLabel],
+    ): List[LirLabel] =
+      branchTargets(block.terminator).filter(knownLabels.contains)
+
+    private def branchTargets(terminator: LirTerminator): List[LirLabel] =
+      terminator match
+        case LirBranch(target) =>
+          List(target)
+        case LirCondBranch(_, trueTarget, falseTarget) =>
+          List(trueTarget, falseTarget)
+        case _ =>
+          Nil
+
+    private def firstBy[A, K](values: List[A])(key: A => K): Map[K, A] =
+      values.foldLeft(Map.empty[K, A]) { (acc, value) =>
+        val valueKey = key(value)
+        if acc.contains(valueKey) then acc else acc.updated(valueKey, value)
+      }
+
+    private def sameSignature(
+        left: LirCallableSignature,
+        right: LirCallableSignature,
+    ): Boolean =
+      left.params.length == right.params.length &&
+        left.params.zip(right.params).forall { case (a, b) => sameType(a, b) } &&
+        sameType(left.returnType, right.returnType)
+
+    private def sameType(left: LirTypeRef, right: LirTypeRef): Boolean =
+      sameSourceType(left.source, right.source)
+
+    private def sameSourceType(left: SourceType, right: SourceType): Boolean =
+      SourceType.same(left, right)
+
+    private def assignable(from: LirTypeRef, to: LirTypeRef): Boolean =
+      assignable(from.source, to.source)
+
+    private def assignable(from: SourceType, to: SourceType): Boolean =
+      SourceType.assignable(from, to)
+
+    private def valueDescription(value: LirValue): String =
+      value match
+        case LirLocalRef(id, _)    => id.toString
+        case LirGlobalRef(id, _)   => id.toString
+        case LirFunctionRef(id, _) => id.toString
+        case _                     => value.valueType.display
+
+    private def signatureDisplay(signature: LirCallableSignature): String =
+      s"(${signature.params.map(_.display).mkString(", ")}) -> ${signature.returnType.display}"
+
+    private lazy val syntheticSpan: SourceSpan =
+      SourceFile("<lir>", "").span(0, 0)
+
+    private def error(code: String, message: String): Unit =
+      errors += Diagnostic(
+        Phase.Check,
+        DiagnosticSeverity.Error,
+        code,
+        message,
+      )

--- a/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
@@ -126,6 +126,52 @@ class LirTests extends munit.FunSuite:
     assertEquals(function.signature.sourceSignature, Some(sourceSignature))
     assertEquals(function.signature.params, List(Lir.t(SourceType.I32)))
 
+  test("LIR type checker accepts a valid hand-written module"):
+    val result = LirTypeChecker().check(checkedLirModule())
+
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    assert(result.diagnostics.isEmpty)
+    assertEquals(result.value, Some(checkedLirModule()))
+
+  test("LIR type checker rejects structural, type, call, variant, and mutability errors"):
+    val cases = List(
+      missingBlockModule() -> "cosmo0.lir.missing-block",
+      invalidBranchModule() -> "cosmo0.lir.invalid-branch",
+      invalidBranchConditionModule() -> "cosmo0.lir.invalid-branch",
+      invalidReturnModule() -> "cosmo0.lir.invalid-return",
+      typeMismatchModule() -> "cosmo0.lir.assignment-mismatch",
+      useBeforeDefinitionModule() -> "cosmo0.lir.use-before-definition",
+      invalidCallModule() -> "cosmo0.lir.invalid-call",
+      invalidDescriptorModule() -> "cosmo0.lir.invalid-descriptor",
+      invalidVariantModule() -> "cosmo0.lir.invalid-variant",
+      invalidMutabilityModule() -> "cosmo0.lir.invalid-mutability",
+    )
+
+    cases.foreach { case (module, code) =>
+      val result = LirTypeChecker().check(module)
+
+      assertEquals(result.phase, Phase.Check)
+      assertEquals(result.status, PhaseStatus.Failed)
+      assert(
+        result.diagnostics.exists(_.code == code),
+        s"missing diagnostic $code in ${result.diagnostics.map(_.code)}",
+      )
+    }
+
+  test("LIR type checker diagnostics are deterministic and identify failing constructs"):
+    val first = invalidBranchModule()
+    val second = first.copy(declarations = first.declarations.reverse)
+
+    val firstDiagnostics = LirTypeChecker().check(first).diagnostics.map(d => d.code -> d.message)
+    val secondDiagnostics = LirTypeChecker().check(second).diagnostics.map(d => d.code -> d.message)
+
+    assertEquals(firstDiagnostics, secondDiagnostics)
+    assert(
+      firstDiagnostics.exists { case (_, message) => message.contains("^missing") },
+      s"expected branch target in diagnostics: $firstDiagnostics",
+    )
+
   test("LIR node classes live in the cosmo0 package boundary"):
     val modelClasses = List(
       classOf[LirModule],
@@ -137,6 +183,211 @@ class LirTests extends munit.FunSuite:
     )
 
     assert(modelClasses.forall(_.getName.startsWith("cosmo0.")))
+
+  private def checkedLirModule(function: LirFunction = checkedProcessFunction()): LirModule =
+    LirModule(
+      "checked",
+      List(tokenDecl(), identityFunction(), function),
+    )
+
+  private def checkedProcessFunction(
+      entryOperations: List[LirOp] = checkedEntryOperations(),
+      entryTerminator: LirTerminator = LirCondBranch(
+        Lir.bool(true),
+        Lir.label("exit"),
+        Lir.label("error"),
+      ),
+      returnTerminator: LirTerminator = LirReturn(Some(Lir.ref("count", SourceType.I32))),
+  ): LirFunction =
+    Lir.function(
+      "checked_process",
+      List(Lir.param("input", tokenType)),
+      SourceType.I32,
+      locals = checkedLocals(),
+      blocks = List(
+        Lir.block(
+          "entry",
+          operations = entryOperations,
+          terminator = entryTerminator,
+        ),
+        Lir.block(
+          "exit",
+          terminator = returnTerminator,
+        ),
+        Lir.block(
+          "error",
+          terminator = LirErrorExit("cosmo0.lir.test", Some("failed")),
+        ),
+      ),
+    )
+
+  private def checkedLocals(): List[LirLocal] =
+    List(
+      Lir.local("token", tokenType, mutable = true),
+      Lir.local("labels", stringVecType, mutable = true),
+      Lir.local("maybe", optionTokenType),
+      Lir.local("tag", SourceType.I32),
+      Lir.local("payload", tokenType),
+      Lir.local("tmp", SourceType.Usize),
+      Lir.local("count", SourceType.I32, mutable = true),
+    )
+
+  private def checkedEntryOperations(): List[LirOp] =
+    List(
+      LirAllocLocal(Lir.local("token", tokenType, mutable = true)),
+      LirAllocLocal(Lir.local("labels", stringVecType, mutable = true)),
+      LirAllocLocal(Lir.local("count", SourceType.I32, mutable = true), Some(Lir.int(0))),
+      LirFieldGet(
+        Lir.localId("tmp"),
+        Lir.ref("input", tokenType),
+        "offset",
+        Lir.t(SourceType.Usize),
+      ),
+      LirFieldSet(
+        Lir.ref("token", tokenType),
+        "offset",
+        Lir.ref("tmp", SourceType.Usize),
+      ),
+      LirAssign(Lir.localPlace("count", SourceType.I32), Lir.int(1)),
+      LirDirectCall(
+        Some(Lir.localId("count")),
+        Lir.declId("identity"),
+        List(Lir.ref("count", SourceType.I32)),
+        Lir.signature(List(SourceType.I32), SourceType.I32),
+      ),
+      LirLoweredMethodCall(
+        None,
+        Lir.ref("labels", stringVecType),
+        "push",
+        List(Lir.string("ok")),
+        Lir.signature(List(SourceType.String), SourceType.Unit),
+      ),
+      LirDescriptorIntrinsic(
+        None,
+        LirDescriptorRef("Vec", List(Lir.t(SourceType.String))),
+        "push",
+        List(Lir.ref("labels", stringVecType), Lir.string("ok")),
+        Some(Lir.t(SourceType.Unit)),
+      ),
+      LirConstructVariant(
+        Lir.localId("maybe"),
+        Lir.t(optionTokenType),
+        "Some",
+        List(Lir.ref("token", tokenType)),
+      ),
+      LirReadVariantTag(
+        Lir.localId("tag"),
+        Lir.ref("maybe", optionTokenType),
+        Lir.t(optionTokenType),
+      ),
+      LirReadVariantPayload(
+        Lir.localId("payload"),
+        Lir.ref("maybe", optionTokenType),
+        "Some",
+        0,
+        Lir.t(tokenType),
+      ),
+    )
+
+  private def missingBlockModule(): LirModule =
+    checkedLirModule(
+      Lir.function(
+        "checked_process",
+        List(Lir.param("input", tokenType)),
+        SourceType.I32,
+        locals = checkedLocals(),
+        blocks = Nil,
+      ),
+    )
+
+  private def invalidBranchModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryTerminator = LirCondBranch(
+          Lir.bool(true),
+          Lir.label("exit"),
+          Lir.label("missing"),
+        ),
+      ),
+    )
+
+  private def invalidBranchConditionModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryTerminator = LirCondBranch(
+          Lir.ref("count", SourceType.I32),
+          Lir.label("exit"),
+          Lir.label("error"),
+        ),
+      ),
+    )
+
+  private def invalidReturnModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        returnTerminator = LirReturn(Some(Lir.bool(false))),
+      ),
+    )
+
+  private def typeMismatchModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryOperations =
+          checkedEntryOperations() :+ LirAssign(Lir.localPlace("count", SourceType.I32), Lir.bool(false)),
+      ),
+    )
+
+  private def useBeforeDefinitionModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryOperations =
+          LirAssign(Lir.localPlace("count", SourceType.I32), Lir.ref("tmp", SourceType.Usize)) :: checkedEntryOperations(),
+      ),
+    )
+
+  private def invalidCallModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryOperations = checkedEntryOperations().map {
+          case LirDirectCall(output, callee, args, _) =>
+            LirDirectCall(output, callee, args, Lir.signature(List(SourceType.Bool), SourceType.I32))
+          case other => other
+        },
+      ),
+    )
+
+  private def invalidDescriptorModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryOperations = checkedEntryOperations().map {
+          case LirDescriptorIntrinsic(output, descriptor, name, args, _) =>
+            LirDescriptorIntrinsic(output, descriptor, name, args, Some(Lir.t(SourceType.I32)))
+          case other => other
+        },
+      ),
+    )
+
+  private def invalidVariantModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryOperations = checkedEntryOperations().map {
+          case LirConstructVariant(output, owner, _, payload) =>
+            LirConstructVariant(output, owner, "Missing", payload)
+          case other => other
+        },
+      ),
+    )
+
+  private def invalidMutabilityModule(): LirModule =
+    checkedLirModule(
+      checkedProcessFunction(
+        entryOperations = checkedEntryOperations().map {
+          case LirFieldSet(_, field, value) =>
+            LirFieldSet(Lir.ref("input", tokenType), field, value)
+          case other => other
+        },
+      ),
+    )
 
   private def tokenDecl(): LirTypeDecl =
     LirTypeDecl(


### PR DESCRIPTION
Adds a full LIR type checker for cosmo0, including declaration/env construction, structural validation, type and mutability checks, variant and descriptor validation, and deterministic diagnostics.

Also adds hand-written positive and negative LIR fixtures to cover valid modules, invalid branches, returns, calls, variants, mutability, and use-before-definition cases.