### PR TITLE
feat: lower cosmo0 declarations to LIR

### DIFF
--- a/openspec/changes/lower-cosmo0-declarations-to-lir/tasks.md
+++ b/openspec/changes/lower-cosmo0-declarations-to-lir/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Lowering Context
 
-- [ ] 1.1 Add a lowering context that maps typed declarations, functions, fields, variants, parameters, and locals to LIR identifiers.
-- [ ] 1.2 Add deterministic declaration and local ordering for lowered LIR output.
-- [ ] 1.3 Preserve source origin metadata needed by LIR checker diagnostics.
+- [x] 1.1 Add a lowering context that maps typed declarations, functions, fields, variants, parameters, and locals to LIR identifiers.
+- [x] 1.2 Add deterministic declaration and local ordering for lowered LIR output.
+- [x] 1.3 Preserve source origin metadata needed by LIR checker diagnostics.
 
 ## 2. Declaration Lowering
 
-- [ ] 2.1 Lower typed modules and top-level functions into LIR module declarations.
-- [ ] 2.2 Lower classes and fields into LIR layout declarations.
-- [ ] 2.3 Lower function and method signatures, including receiver parameters for `self`, `&self`, and `&mut self`.
-- [ ] 2.4 Lower simple type aliases into the type information consumed by LIR checking.
+- [x] 2.1 Lower typed modules and top-level functions into LIR module declarations.
+- [x] 2.2 Lower classes and fields into LIR layout declarations.
+- [x] 2.3 Lower function and method signatures, including receiver parameters for `self`, `&self`, and `&mut self`.
+- [x] 2.4 Lower simple type aliases into the type information consumed by LIR checking.
 
 ## 3. Function Body Lowering
 
-- [ ] 3.1 Lower parameter binding, local declarations, local reads, local writes, assignments, direct calls, field get/set, and returns.
-- [ ] 3.2 Lower simple expression blocks into linear LIR operation sequences.
-- [ ] 3.3 Emit explicit LIR locals for intermediate values where typed expressions require them.
+- [x] 3.1 Lower parameter binding, local declarations, local reads, local writes, assignments, direct calls, field get/set, and returns.
+- [x] 3.2 Lower simple expression blocks into linear LIR operation sequences.
+- [x] 3.3 Emit explicit LIR locals for intermediate values where typed expressions require them.
 
 ## 4. Verification And Tests
 
-- [ ] 4.1 Run the LIR type checker on declaration-lowered modules.
-- [ ] 4.2 Add tests for lowered top-level functions, methods, fields, assignments, calls, and returns.
-- [ ] 4.3 Add negative tests proving invalid typed input or invalid lowering output is diagnosed before backend emission.
+- [x] 4.1 Run the LIR type checker on declaration-lowered modules.
+- [x] 4.2 Add tests for lowered top-level functions, methods, fields, assignments, calls, and returns.
+- [x] 4.3 Add negative tests proving invalid typed input or invalid lowering output is diagnosed before backend emission.

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -70,7 +70,10 @@ final class Cosmo0:
   def compile(sourceText: String): Result[CompiledModule] =
     compile(SourceFile("<memory>", sourceText))
 
-  def compile(source: SourceFile): Result[CompiledModule] =
+  def lower(sourceText: String): Result[LoweredModule] =
+    lower(SourceFile("<memory>", sourceText))
+
+  def lower(source: SourceFile): Result[LoweredModule] =
     check(source) match
       case checked if checked.isFailure =>
         Result.failure(Phase.Compile, checked.diagnostics)
@@ -80,6 +83,25 @@ final class Cosmo0:
           PhaseStatus.Unsupported,
           None,
           checked.diagnostics,
+        )
+      case checked =>
+        val checkedModule = checked.value.get
+        LirLowerer().lower(checkedModule.typed) match
+          case lowered if lowered.isSuccess =>
+            Result.success(Phase.Compile, LoweredModule(checkedModule, lowered.value.get))
+          case failed =>
+            Result.failure(Phase.Compile, failed.diagnostics)
+
+  def compile(source: SourceFile): Result[CompiledModule] =
+    lower(source) match
+      case lowered if lowered.isFailure =>
+        Result.failure(Phase.Compile, lowered.diagnostics)
+      case lowered if lowered.isUnsupported =>
+        Result(
+          Phase.Compile,
+          PhaseStatus.Unsupported,
+          None,
+          lowered.diagnostics,
         )
       case _ =>
         Result.unsupported(

--- a/packages/cosmo0/src/main/scala/cosmo0/LirLowerer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirLowerer.scala
@@ -1,0 +1,575 @@
+package cosmo0
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+object LirLowerer:
+  def apply(): LirLowerer =
+    new LirLowerer(LirTypeChecker())
+
+final class LirLowerer(
+    checker: LirTypeChecker,
+):
+  def lower(module: TypedModule): Result[LirModule] =
+    val state = State(module)
+    val lowered = state.lower()
+    if state.diagnostics.nonEmpty then
+      Result.failure(Phase.Compile, state.diagnostics)
+    else
+      checker.check(lowered) match
+        case checked if checked.isSuccess =>
+          Result.success(Phase.Compile, checked.value.get)
+        case failed =>
+          Result.failure(Phase.Compile, failed.diagnostics)
+
+  private final case class DeclContext(
+      typeIds: Map[String, LirDeclId],
+      aliasIds: Map[(Option[String], String), LirDeclId],
+      globalIds: Map[String, LirDeclId],
+      functionIds: Map[(Option[String], String), LirDeclId],
+      topLevelFunctions: Map[String, TypedFunction],
+  ):
+    def typeId(name: String): Option[LirDeclId] =
+      typeIds.get(name)
+
+    def aliasId(owner: Option[String], name: String): LirDeclId =
+      aliasIds.getOrElse((owner, name), Lir.declId(qualifiedId(owner, name)))
+
+    def globalId(name: String): Option[LirDeclId] =
+      globalIds.get(name)
+
+    def functionId(owner: Option[String], name: String): Option[LirDeclId] =
+      functionIds.get((owner, name))
+
+    def topLevelFunction(name: String): Option[TypedFunction] =
+      topLevelFunctions.get(name)
+
+  private object DeclContext:
+    def from(module: TypedModule): DeclContext =
+      val typeIds = mutable.LinkedHashMap.empty[String, LirDeclId]
+      val aliasIds = mutable.LinkedHashMap.empty[(Option[String], String), LirDeclId]
+      val globalIds = mutable.LinkedHashMap.empty[String, LirDeclId]
+      val functionIds = mutable.LinkedHashMap.empty[(Option[String], String), LirDeclId]
+      val topLevelFunctions = mutable.LinkedHashMap.empty[String, TypedFunction]
+
+      module.declarations.foreach {
+        case alias: TypedTypeAlias =>
+          aliasIds.update((None, alias.name), Lir.declId(qualifiedId(None, alias.name)))
+        case value: TypedValueDecl =>
+          globalIds.update(value.name, Lir.declId(qualifiedId(None, value.name)))
+        case fn: TypedFunction =>
+          functionIds.update((None, fn.name), Lir.declId(qualifiedId(None, fn.name)))
+          topLevelFunctions.update(fn.name, fn)
+        case cls: TypedClass =>
+          typeIds.update(cls.name, Lir.declId(stablePart(cls.name)))
+          cls.aliases.foreach(alias =>
+            aliasIds.update((Some(cls.name), alias.name), Lir.declId(qualifiedId(Some(cls.name), alias.name))),
+          )
+          cls.methods.foreach(method =>
+            functionIds.update(
+              (Some(cls.name), method.name),
+              Lir.declId(qualifiedId(Some(cls.name), method.name)),
+            ),
+          )
+        case _: TypedImport =>
+      }
+
+      DeclContext(
+        typeIds.toMap,
+        aliasIds.toMap,
+        globalIds.toMap,
+        functionIds.toMap,
+        topLevelFunctions.toMap,
+      )
+
+  private final case class Binding(
+      name: String,
+      id: LirLocalId,
+      valueType: SourceType,
+      mutable: Boolean,
+  )
+
+  private final class FunctionBuilder(
+      function: TypedFunction,
+      context: DeclContext,
+      report: (String, String, SourceSpan) => Unit,
+  ):
+    private val scopes = mutable.ArrayBuffer.empty[mutable.LinkedHashMap[String, Binding]]
+    private val localOrdinals = mutable.LinkedHashMap.empty[String, Int]
+    private val localBuffer = ListBuffer.empty[LirLocal]
+    private val operations = ListBuffer.empty[LirOp]
+    private var sealedTerminator: Option[LirTerminator] = None
+    private var tempIndex = 0
+
+    scopes += mutable.LinkedHashMap.empty[String, Binding]
+
+    val params: List[LirParam] =
+      function.params.map { param =>
+        val id = nextLocalId(param.name)
+        bind(Binding(param.name, id, param.valueType, mutable = false))
+        LirParam(id, param.name, Lir.t(param.valueType))
+      }
+
+    def lower(): LirFunction =
+      function.body match
+        case Some(body) =>
+          val result = lowerExpr(body)
+          if !isTerminated then
+            terminate(returnTerminator(result, function.returnType, function.span))
+        case None =>
+          report(
+            "cosmo0.lir.lower.missing-body",
+            s"function ${function.name} has no body to lower",
+            function.span,
+          )
+          terminate(LirErrorExit("cosmo0.lir.lower.missing-body", Some(function.name)))
+
+      LirFunction(
+        context.functionId(function.owner, function.name).getOrElse(Lir.declId(qualifiedId(function.owner, function.name))),
+        function.name,
+        params,
+        Lir.t(function.returnType),
+        localBuffer.toList.sortBy(_.id.value),
+        List(LirBlock(Lir.label("entry"), operations.toList, sealedTerminator.getOrElse(LirUnreachable()))),
+        owner = function.owner.flatMap(context.typeId),
+        sourceSignature = Some(function.signature),
+      )
+
+    private def lowerBlock(block: TypedBlock): Option[LirValue] =
+      withScope {
+        var result: Option[LirValue] = Some(LirUnitValue)
+        block.items.foreach { item =>
+          if !isTerminated then result = lowerBlockItem(item)
+        }
+        result
+      }
+
+    private def lowerBlockItem(item: TypedBlockItem): Option[LirValue] =
+      item match
+        case local: TypedLocal =>
+          val init = local.init.flatMap(lowerExpr)
+          val mutable = local.kind == UntypedValueKind.Var
+          val binding = declareLocal(local.name, local.valueType, mutable)
+          emit(LirAllocLocal(localFor(binding), init))
+          bind(binding)
+          Some(LirUnitValue)
+        case stmt: TypedExprStmt =>
+          lowerExpr(stmt.expr)
+          Some(LirUnitValue)
+        case expr: TypedExpr =>
+          lowerExpr(expr)
+
+    private def lowerExpr(expr: TypedExpr): Option[LirValue] =
+      if isTerminated then None
+      else
+        expr match
+          case block: TypedBlock =>
+            lowerBlock(block)
+
+          case name: TypedName =>
+            lowerName(name)
+
+          case select: TypedSelect =>
+            if isFunctionType(select.valueType) then
+              unsupported(select, s"method value ${select.field}")
+              None
+            else
+              for receiver <- lowerExpr(select.receiver) yield
+                val output = declareTemp(select.valueType)
+                emit(LirFieldGet(output.id, receiver, select.field, Lir.t(select.valueType)))
+                LirLocalRef(output.id, Lir.t(output.valueType))
+
+          case call: TypedCall =>
+            lowerCall(call)
+
+          case assign: TypedAssign =>
+            lowerAssign(assign)
+            Some(LirUnitValue)
+
+          case ret: TypedReturn =>
+            val value = lowerExpr(ret.value)
+            terminate(returnTerminator(value, function.returnType, ret.span))
+            None
+
+          case TypedUnitLiteral(_, _) =>
+            Some(LirUnitValue)
+          case TypedBoolLiteral(value, _, _) =>
+            Some(LirBoolValue(value))
+          case TypedIntLiteral(value, valueType, _) =>
+            Some(LirIntValue(value, Lir.t(valueType)))
+          case TypedFloatLiteral(value, valueType, _) =>
+            Some(LirFloatValue(value, Lir.t(valueType)))
+          case TypedStringLiteral(value, _, _) =>
+            Some(LirStringValue(value))
+
+          case value: TypedTypeConstructorExpr =>
+            unsupported(value, s"type constructor ${value.constructedType.display}")
+            None
+          case value: TypedVariantConstructorExpr =>
+            unsupported(value, s"variant constructor ${value.owner.display}::${value.variant}")
+            None
+          case value: TypedUnary =>
+            unsupported(value, s"unary operator ${value.op}")
+            None
+          case value: TypedBinary =>
+            unsupported(value, s"binary operator ${value.op}")
+            None
+          case value: TypedIf =>
+            unsupported(value, "if expression")
+            None
+          case value: TypedLoop =>
+            unsupported(value, "loop expression")
+            None
+          case value: TypedWhile =>
+            unsupported(value, "while expression")
+            None
+          case value: TypedFor =>
+            unsupported(value, "for expression")
+            None
+          case value: TypedMatch =>
+            unsupported(value, "match expression")
+            None
+          case value: TypedBreak =>
+            unsupported(value, "break expression")
+            None
+          case value: TypedContinue =>
+            unsupported(value, "continue expression")
+            None
+
+    private def lowerName(name: TypedName): Option[LirValue] =
+      name.path.parts match
+        case valueName :: Nil =>
+          resolve(valueName)
+            .map(binding => LirLocalRef(binding.id, Lir.t(binding.valueType)))
+            .orElse(
+              context.globalId(valueName).map(id => LirGlobalRef(id, Lir.t(name.valueType))),
+            )
+            .orElse(
+              context.topLevelFunction(valueName).flatMap(fn =>
+                context.functionId(None, valueName).map(id =>
+                  LirFunctionRef(id, LirCallableSignature.fromSource(fn.signature)),
+                ),
+              ),
+            )
+            .orElse {
+              report(
+                "cosmo0.lir.lower.unknown-name",
+                s"cannot resolve typed name ${name.path.text} during lowering",
+                name.span,
+              )
+              None
+            }
+        case _ =>
+          report(
+            "cosmo0.lir.lower.unknown-name",
+            s"cannot lower qualified name ${name.path.text}",
+            name.span,
+          )
+          None
+
+    private def lowerCall(call: TypedCall): Option[LirValue] =
+      val output = callOutput(call.valueType)
+      call.callee match
+        case name: TypedName if name.path.parts.length == 1 =>
+          val args = call.args.flatMap(lowerExpr)
+          if args.length != call.args.length then return None
+          val calleeName = name.path.parts.head
+          context.functionId(None, calleeName) match
+            case Some(id) =>
+              emit(
+                LirDirectCall(
+                  output.map(_.id),
+                  id,
+                  args,
+                  LirCallableSignature.fromSource(call.signature),
+                ),
+              )
+              callResult(output, call.valueType)
+            case None =>
+              unsupported(call, s"call to non-function value ${name.path.text}")
+              None
+
+        case select: TypedSelect =>
+          lowerExpr(select.receiver) match
+            case Some(receiver) =>
+              val args = call.args.flatMap(lowerExpr)
+              if args.length != call.args.length then return None
+              emit(
+                LirLoweredMethodCall(
+                  output.map(_.id),
+                  receiver,
+                  select.field,
+                  args,
+                  LirCallableSignature.fromSource(call.signature),
+                ),
+              )
+              callResult(output, call.valueType)
+            case None =>
+              None
+
+        case constructor: TypedVariantConstructorExpr =>
+          unsupported(constructor, s"variant constructor ${constructor.owner.display}::${constructor.variant}")
+          None
+        case constructor: TypedTypeConstructorExpr =>
+          unsupported(constructor, s"type constructor ${constructor.constructedType.display}")
+          None
+        case other =>
+          unsupported(other, "indirect function call")
+          None
+
+    private def lowerAssign(assign: TypedAssign): Unit =
+      if assign.op != "=" then
+        unsupported(assign, s"compound assignment ${assign.op}")
+        return
+
+      assign.target match
+        case name: TypedName if name.path.parts.length == 1 =>
+          lowerExpr(assign.value).foreach { loweredValue =>
+            val valueName = name.path.parts.head
+            resolve(valueName) match
+              case Some(binding) =>
+                emit(LirAssign(LirLocalPlace(binding.id, Lir.t(binding.valueType)), loweredValue))
+              case None =>
+                unsupported(assign.target, s"assignment to non-local ${name.path.text}")
+          }
+
+        case select: TypedSelect =>
+          lowerExpr(select.receiver).foreach { receiver =>
+            lowerExpr(assign.value).foreach { loweredValue =>
+              emit(LirFieldSet(receiver, select.field, loweredValue))
+            }
+          }
+
+        case other =>
+          unsupported(other, "assignment target")
+
+    private def returnTerminator(
+        value: Option[LirValue],
+        expectedType: SourceType,
+        span: SourceSpan,
+    ): LirTerminator =
+      SourceType.dealias(expectedType) match
+        case SourceType.Unit =>
+          LirReturn(None)
+        case _ =>
+          value match
+            case Some(actual) =>
+              LirReturn(Some(actual))
+            case None =>
+              report(
+                "cosmo0.lir.lower.missing-return",
+                s"function ${function.name} did not produce a ${expectedType.display} return value",
+                span,
+              )
+              LirErrorExit("cosmo0.lir.lower.missing-return", Some(function.name))
+
+    private def callOutput(valueType: SourceType): Option[Binding] =
+      SourceType.dealias(valueType) match
+        case SourceType.Unit | SourceType.Never =>
+          None
+        case _ =>
+          Some(declareTemp(valueType))
+
+    private def callResult(output: Option[Binding], valueType: SourceType): Option[LirValue] =
+      output match
+        case Some(binding) =>
+          Some(LirLocalRef(binding.id, Lir.t(valueType)))
+        case None =>
+          Some(LirUnitValue)
+
+    private def declareLocal(
+        name: String,
+        valueType: SourceType,
+        mutable: Boolean,
+    ): Binding =
+      val id = nextLocalId(name)
+      val binding = Binding(name, id, valueType, mutable)
+      localBuffer += localFor(binding)
+      binding
+
+    private def declareTemp(valueType: SourceType): Binding =
+      val name = s"tmp$tempIndex"
+      tempIndex += 1
+      declareLocal(name, valueType, mutable = false)
+
+    private def nextLocalId(name: String): LirLocalId =
+      val base = stablePart(name)
+      val ordinal = localOrdinals.getOrElse(base, 0)
+      localOrdinals.update(base, ordinal + 1)
+      if ordinal == 0 then Lir.localId(base)
+      else Lir.localId(s"${base}_$ordinal")
+
+    private def localFor(binding: Binding): LirLocal =
+      LirLocal(binding.id, binding.name, Lir.t(binding.valueType), binding.mutable)
+
+    private def bind(binding: Binding): Unit =
+      scopes.last.update(binding.name, binding)
+
+    private def resolve(name: String): Option[Binding] =
+      scopes.reverseIterator.flatMap(_.get(name)).nextOption()
+
+    private def withScope[A](body: => A): A =
+      scopes += mutable.LinkedHashMap.empty[String, Binding]
+      try body
+      finally scopes.remove(scopes.length - 1)
+
+    private def emit(op: LirOp): Unit =
+      if !isTerminated then operations += op
+
+    private def terminate(terminator: LirTerminator): Unit =
+      if sealedTerminator.isEmpty then sealedTerminator = Some(terminator)
+
+    private def isTerminated: Boolean =
+      sealedTerminator.nonEmpty
+
+    private def unsupported(node: TypedNode, construct: String): Unit =
+      report(
+        "cosmo0.lir.lower.unsupported-expression",
+        s"declaration lowering does not support $construct yet",
+        node.span,
+      )
+
+    private def isFunctionType(valueType: SourceType): Boolean =
+      SourceType.dealias(valueType) match
+        case SourceType.Function(_, _) => true
+        case _                         => false
+
+  private final class State(module: TypedModule):
+    private val errors = ListBuffer.empty[Diagnostic]
+    private val context = DeclContext.from(module)
+
+    def diagnostics: List[Diagnostic] =
+      errors.toList
+
+    def lower(): LirModule =
+      LirModule(
+        moduleName(module.source),
+        module.declarations.flatMap(lowerDecl).sortBy(_.id.value),
+      )
+
+    private def lowerDecl(declaration: TypedDecl): List[LirDeclaration] =
+      declaration match
+        case _: TypedImport =>
+          Nil
+
+        case alias: TypedTypeAlias =>
+          List(
+            LirTypeAliasDecl(
+              context.aliasId(None, alias.name),
+              alias.name,
+              Lir.t(alias.target),
+            ),
+          )
+
+        case value: TypedValueDecl =>
+          List(
+            LirGlobal(
+              context.globalId(value.name).getOrElse(Lir.declId(qualifiedId(None, value.name))),
+              value.name,
+              Lir.t(value.valueType),
+              mutable = value.kind == UntypedValueKind.Var,
+              initializer = value.init.flatMap(staticValue),
+            ),
+          )
+
+        case fn: TypedFunction =>
+          List(lowerFunction(fn))
+
+        case cls: TypedClass =>
+          val typeDecl =
+            LirTypeDecl(
+              context.typeId(cls.name).getOrElse(Lir.declId(stablePart(cls.name))),
+              cls.name,
+              fields = cls.fields.map(field =>
+                LirField(
+                  field.name,
+                  Lir.t(field.valueType),
+                  mutable = field.kind == UntypedValueKind.Var,
+                ),
+              ),
+              variants = cls.variants.map(variant =>
+                LirVariant(
+                  variant.name,
+                  variant.fields.map(field =>
+                    LirVariantPayload(
+                      field.name,
+                      Lir.t(field.valueType),
+                    ),
+                  ),
+                ),
+              ),
+            )
+          val aliases = cls.aliases.map(alias =>
+            LirTypeAliasDecl(
+              context.aliasId(Some(cls.name), alias.name),
+              alias.name,
+              Lir.t(alias.target),
+            ),
+          )
+          typeDecl :: aliases ::: cls.methods.map(lowerFunction)
+
+    private def lowerFunction(function: TypedFunction): LirFunction =
+      FunctionBuilder(function, context, error).lower()
+
+    private def staticValue(expr: TypedExpr): Option[LirValue] =
+      expr match
+        case TypedUnitLiteral(_, _) =>
+          Some(LirUnitValue)
+        case TypedBoolLiteral(value, _, _) =>
+          Some(LirBoolValue(value))
+        case TypedIntLiteral(value, valueType, _) =>
+          Some(LirIntValue(value, Lir.t(valueType)))
+        case TypedFloatLiteral(value, valueType, _) =>
+          Some(LirFloatValue(value, Lir.t(valueType)))
+        case TypedStringLiteral(value, _, _) =>
+          Some(LirStringValue(value))
+        case name: TypedName if name.path.parts.length == 1 =>
+          val valueName = name.path.parts.head
+          context.globalId(valueName)
+            .map(id => LirGlobalRef(id, Lir.t(name.valueType)))
+            .orElse(
+              context.topLevelFunction(valueName).flatMap(fn =>
+                context.functionId(None, valueName).map(id =>
+                  LirFunctionRef(id, LirCallableSignature.fromSource(fn.signature)),
+                ),
+              ),
+            )
+        case other =>
+          error(
+            "cosmo0.lir.lower.unsupported-initializer",
+            s"global ${other.valueType.display} initializer is not a static LIR value",
+            other.span,
+          )
+          None
+
+    private def error(
+        code: String,
+        message: String,
+        span: SourceSpan,
+    ): Unit =
+      errors += Diagnostic(
+        Phase.Compile,
+        DiagnosticSeverity.Error,
+        code,
+        message,
+        Some(span),
+      )
+
+  private def moduleName(source: SourceFile): String =
+    val raw =
+      source.name match
+        case "" | "<memory>" => "memory"
+        case other           => other.split('/').lastOption.getOrElse(other)
+    stablePart(raw.stripSuffix(".cos"))
+
+  private def qualifiedId(owner: Option[String], name: String): String =
+    (owner.toList :+ name).map(stablePart).mkString(".")
+
+  private def stablePart(value: String): String =
+    val builder = new StringBuilder
+    value.foreach { char =>
+      if char.isLetterOrDigit || char == '_' then builder.append(char)
+      else if builder.nonEmpty && builder.last != '_' then builder.append('_')
+    }
+    val raw = builder.toString.stripPrefix("_").stripSuffix("_")
+    if raw.nonEmpty then raw else "anonymous"

--- a/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
@@ -171,13 +171,28 @@ final class LirTypeChecker(
       }
 
     private def checkSourceSignature(function: LirFunction, source: CallableSignature): Unit =
+      val callableParams =
+        source.receiver match
+          case Some(receiver) =>
+            function.params.headOption match
+              case Some(param) if param.name == "self" =>
+                checkReceiverParam(function, param, receiver)
+                function.params.tail
+              case _ =>
+                error(
+                  "cosmo0.lir.invalid-signature",
+                  s"${function.id} source signature has a receiver but the LIR function has no self parameter",
+                )
+                function.params
+          case None =>
+            function.params
       val sourceParams = source.params.map(param => LirTypeRef(param.valueType))
-      if sourceParams.length != function.params.length then
+      if sourceParams.length != callableParams.length then
         error(
           "cosmo0.lir.invalid-signature",
-          s"${function.id} has ${function.params.length} LIR parameter(s), source signature has ${sourceParams.length}",
+          s"${function.id} has ${callableParams.length} callable LIR parameter(s), source signature has ${sourceParams.length}",
         )
-      sourceParams.zip(function.params).zipWithIndex.foreach { case ((expected, actual), index) =>
+      sourceParams.zip(callableParams).zipWithIndex.foreach { case ((expected, actual), index) =>
         if !sameType(expected, actual.valueType) then
           error(
             "cosmo0.lir.invalid-signature",
@@ -190,6 +205,25 @@ final class LirTypeChecker(
           "cosmo0.lir.invalid-signature",
           s"${function.id} returns ${function.returnType.display}, source signature returns ${expectedReturn.display}",
         )
+
+    private def checkReceiverParam(
+        function: LirFunction,
+        param: LirParam,
+        receiver: CallableReceiver,
+    ): Unit =
+      SourceType.dealias(param.valueType.source) match
+        case SourceType.Ref(target, mutable) =>
+          if !sameSourceType(target, receiver.valueType) || (receiver.mutable && !mutable) then
+            error(
+              "cosmo0.lir.invalid-signature",
+              s"${function.id} receiver parameter has type ${param.valueType.display}, expected receiver ${receiver.valueType.display}",
+            )
+        case other =>
+          if !sameSourceType(other, receiver.valueType) then
+            error(
+              "cosmo0.lir.invalid-signature",
+              s"${function.id} receiver parameter has type ${param.valueType.display}, expected receiver ${receiver.valueType.display}",
+            )
 
     private def buildLocalEnv(function: LirFunction): Map[LirLocalId, LocalInfo] =
       val params = function.params.map { param =>
@@ -515,10 +549,23 @@ final class LirTypeChecker(
           env.declarations.typesByName.get(name).flatMap { ty =>
             env.declarations.functions.values
               .find(function => function.owner.contains(ty.id) && function.name == method)
-              .map(function => ExpectedCallable(function.signature, receiverMutable = false))
+              .map(function => ExpectedCallable(methodCallSignature(function), methodReceiverMutable(function)))
           }
         case _ =>
           None
+
+    private def methodCallSignature(function: LirFunction): LirCallableSignature =
+      val dropReceiver =
+        function.sourceSignature.exists(_.receiver.nonEmpty) &&
+          function.params.headOption.exists(_.name == "self")
+      LirCallableSignature(
+        function.params.drop(if dropReceiver then 1 else 0).map(_.valueType),
+        function.returnType,
+        function.sourceSignature,
+      )
+
+    private def methodReceiverMutable(function: LirFunction): Boolean =
+      function.sourceSignature.flatMap(_.receiver).exists(_.mutable)
 
     private def expectedDescriptorOperation(
         descriptor: LirDescriptorRef,

--- a/packages/cosmo0/src/main/scala/cosmo0/Model.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Model.scala
@@ -115,6 +115,11 @@ final case class CheckedModule(
     typed: TypedModule,
 )
 
+final case class LoweredModule(
+    checked: CheckedModule,
+    lir: LirModule,
+)
+
 final case class CompiledModule(
     checked: CheckedModule,
     output: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/SourceTyper.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/SourceTyper.scala
@@ -1245,7 +1245,7 @@ final class SourceTyper(
       node match
         case UntypedNamedType(path, span) =>
           path.parts match
-            case name :: Nil if owner.contains(name) || (name == "self" && owner.nonEmpty) =>
+            case name :: Nil if owner.contains(name) || ((name == "self" || name == "Self") && owner.nonEmpty) =>
               SourceType.User(owner.get)
             case name :: Nil =>
               SourceType.scalar(name)

--- a/packages/cosmo0/src/test/scala/cosmo0/LirLowererTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/LirLowererTests.scala
@@ -1,0 +1,178 @@
+package cosmo0
+
+class LirLowererTests extends munit.FunSuite:
+  test("lowers typed declarations and ordinary function bodies to checked LIR"):
+    val result = Cosmo0().lower(
+      """type Count = i32
+        |
+        |class Counter {
+        |  var count: i32
+        |
+        |  def get(&self): i32 = {
+        |    self.count
+        |  }
+        |
+        |  def set(&mut self, value: i32): Unit = {
+        |    self.count = value
+        |  }
+        |}
+        |
+        |def id(value: i32): i32 = {
+        |  return value
+        |}
+        |
+        |def read(counter: &Counter): i32 = {
+        |  counter.get()
+        |}
+        |
+        |def replace(value: i32): i32 = {
+        |  var current: i32 = 0;
+        |  current = id(value);
+        |  current
+        |}
+        |
+        |def write(counter: &mut Counter, value: i32): Unit = {
+        |  counter.set(value)
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+    assert(result.diagnostics.isEmpty)
+
+    assertEquals(
+      LirDebugRenderer.renderModule(result.value.get.lir),
+      """module memory {
+        |  typealias @Count Count = i32
+        |
+        |  type @Counter Counter {
+        |    field var count: i32
+        |  }
+        |
+        |  fn @Counter.get get(%self self: &Counter) -> i32 owner @Counter {
+        |    local %tmp0 tmp0: i32
+        |
+        |    ^entry:
+        |      %tmp0 = field_get %self.count: i32
+        |      return %tmp0
+        |  }
+        |
+        |  fn @Counter.set set(%self self: &mut Counter, %value value: i32) -> Unit owner @Counter {
+        |    ^entry:
+        |      field_set %self.count = %value
+        |      return
+        |  }
+        |
+        |  fn @id id(%value value: i32) -> i32 {
+        |    ^entry:
+        |      return %value
+        |  }
+        |
+        |  fn @read read(%counter counter: &Counter) -> i32 {
+        |    local %tmp0 tmp0: i32
+        |
+        |    ^entry:
+        |      %tmp0 = method_call %counter.get() -> i32
+        |      return %tmp0
+        |  }
+        |
+        |  fn @replace replace(%value value: i32) -> i32 {
+        |    local %current current: i32 mut
+        |    local %tmp0 tmp0: i32
+        |
+        |    ^entry:
+        |      alloc %current current: i32 mut = 0:i32
+        |      %tmp0 = call @id(%value) -> i32
+        |      assign %current = %tmp0
+        |      return %current
+        |  }
+        |
+        |  fn @write write(%counter counter: &mut Counter, %value value: i32) -> Unit {
+        |    ^entry:
+        |      method_call %counter.set(%value) -> Unit
+        |      return
+        |  }
+        |}""".stripMargin,
+    )
+
+  test("lower stops on source typing errors before LIR emission"):
+    val result = Cosmo0().lower("def f(): i32 = true")
+
+    assertEquals(result.phase, Phase.Compile)
+    assertEquals(result.status, PhaseStatus.Failed)
+    assert(result.value.isEmpty)
+    assert(
+      result.diagnostics.exists(_.code == "cosmo0.type.return-mismatch"),
+      s"missing source typing diagnostic in ${result.diagnostics.map(_.code)}",
+    )
+
+  test("lower reports unsupported typed constructs with source spans"):
+    val result = Cosmo0().lower(
+      """def choose(flag: Bool): i32 = {
+        |  if (flag) {
+        |    1
+        |  } else {
+        |    2
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assertEquals(result.status, PhaseStatus.Failed)
+    assert(result.value.isEmpty)
+    assert(
+      result.diagnostics.exists(_.code == "cosmo0.lir.lower.unsupported-expression"),
+      s"missing lowering diagnostic in ${result.diagnostics.map(_.code)}",
+    )
+    assert(result.diagnostics.exists(_.span.nonEmpty))
+
+  test("lowered output is checked before backend emission"):
+    val source = SourceFile("<typed>", "")
+    val span = source.span(0, 0)
+    val idSignature = CallableSignature(
+      "id",
+      List(CallableParam("value", SourceType.I32, span)),
+      SourceType.I32,
+    )
+    val idFunction = TypedFunction(
+      "id",
+      List(TypedParam("value", SourceType.I32, None, span)),
+      SourceType.I32,
+      Some(TypedName(UntypedPath(List("value"), span), SourceType.I32, false, true, span)),
+      idSignature,
+      None,
+      span,
+    )
+    val badFunction = TypedFunction(
+      "bad",
+      Nil,
+      SourceType.I32,
+      Some(
+        TypedCall(
+          TypedName(UntypedPath(List("id"), span), idSignature.functionType, false, false, span),
+          List(TypedBoolLiteral(true, SourceType.Bool, span)),
+          SourceType.I32,
+          idSignature,
+          span,
+        ),
+      ),
+      CallableSignature("bad", Nil, SourceType.I32),
+      None,
+      span,
+    )
+    val module = TypedModule(source, List(idFunction, badFunction), span)
+
+    val result = LirLowerer().lower(module)
+
+    assertEquals(result.phase, Phase.Compile)
+    assertEquals(result.status, PhaseStatus.Failed)
+    assert(result.value.isEmpty)
+    assert(
+      result.diagnostics.exists(_.code == "cosmo0.lir.assignment-mismatch"),
+      s"missing LIR checker diagnostic in ${result.diagnostics.map(_.code)}",
+    )


### PR DESCRIPTION
## Summary
- add a `Cosmo0.lower` entrypoint that stops after LIR lowering and type checking
- implement declaration and function-body lowering from typed cosmo0 modules into LIR
- extend the LIR checker to understand lowered receiver parameters and method calls
- treat `Self` as a valid self-referential type name during source typing
- add coverage for successful lowering, unsupported constructs, source typing failures, and post-lowering checker validation

## Notes
- lowering now preserves declaration ordering, source spans, and deterministic local ids
- method lowering emits explicit receiver parameters and supports direct method calls through LIR
- global initializers are restricted to static LIR values before backend emission