### PR TITLE
feat: lower cosmo0 control flow and descriptors to lir

### DIFF
--- a/openspec/changes/lower-cosmo0-control-flow-to-lir/tasks.md
+++ b/openspec/changes/lower-cosmo0-control-flow-to-lir/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Block Builder
 
-- [ ] 1.1 Add a LIR block builder for creating labels, appending operations, and sealing terminators.
-- [ ] 1.2 Track loop break and continue targets during lowering.
-- [ ] 1.3 Preserve value-producing expression results across structured control-flow joins where supported.
+- [x] 1.1 Add a LIR block builder for creating labels, appending operations, and sealing terminators.
+- [x] 1.2 Track loop break and continue targets during lowering.
+- [x] 1.3 Preserve value-producing expression results across structured control-flow joins where supported.
 
 ## 2. Structured Control Flow
 
-- [ ] 2.1 Lower `if` and `else` expressions into conditional branches and join blocks.
-- [ ] 2.2 Lower `while` and `loop` into explicit header, body, continue, and exit blocks.
-- [ ] 2.3 Lower `break` and `continue` into branches to the active loop targets.
-- [ ] 2.4 Lower restricted `for` loops using typed iterable descriptor information.
+- [x] 2.1 Lower `if` and `else` expressions into conditional branches and join blocks.
+- [x] 2.2 Lower `while` and `loop` into explicit header, body, continue, and exit blocks.
+- [x] 2.3 Lower `break` and `continue` into branches to the active loop targets.
+- [x] 2.4 Lower restricted `for` loops using typed iterable descriptor information.
 
 ## 3. Variants And Match
 
-- [ ] 3.1 Lower variant construction into explicit tag and payload LIR representation.
-- [ ] 3.2 Lower variant tag checks and payload extraction operations.
-- [ ] 3.3 Lower match expressions into branch chains or dispatch blocks with wildcard fallback support.
-- [ ] 3.4 Preserve branch result type consistency for value-producing match and conditional expressions.
+- [x] 3.1 Lower variant construction into explicit tag and payload LIR representation.
+- [x] 3.2 Lower variant tag checks and payload extraction operations.
+- [x] 3.3 Lower match expressions into branch chains or dispatch blocks with wildcard fallback support.
+- [x] 3.4 Preserve branch result type consistency for value-producing match and conditional expressions.
 
 ## 4. Verification And Tests
 
-- [ ] 4.1 Run the LIR type checker on control-flow-lowered modules.
-- [ ] 4.2 Add tests for `if`, `while`, `loop`, `break`, `continue`, restricted `for`, variants, and match lowering.
-- [ ] 4.3 Add negative tests for invalid branch result types, invalid loop control placement, and invalid match payload extraction.
+- [x] 4.1 Run the LIR type checker on control-flow-lowered modules.
+- [x] 4.2 Add tests for `if`, `while`, `loop`, `break`, `continue`, restricted `for`, variants, and match lowering.
+- [x] 4.3 Add negative tests for invalid branch result types, invalid loop control placement, and invalid match payload extraction.

--- a/openspec/changes/lower-cosmo0-descriptors-to-lir/tasks.md
+++ b/openspec/changes/lower-cosmo0-descriptors-to-lir/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Descriptor Lowering Model
 
-- [ ] 1.1 Define the mapping from typed descriptor operations to LIR intrinsics or runtime calls.
-- [ ] 1.2 Add descriptor lowering metadata for required argument types, result types, mutability, and backend operation names.
-- [ ] 1.3 Ensure descriptor-lowered LIR remains independent of full standard-library source implementations.
+- [x] 1.1 Define the mapping from typed descriptor operations to LIR intrinsics or runtime calls.
+- [x] 1.2 Add descriptor lowering metadata for required argument types, result types, mutability, and backend operation names.
+- [x] 1.3 Ensure descriptor-lowered LIR remains independent of full standard-library source implementations.
 
 ## 2. Standard Generic Lowering
 
-- [ ] 2.1 Lower `Vec` construction, length, indexing, push, and iteration operations.
-- [ ] 2.2 Lower `Option` and `Result` construction, tag checks, payload access, and match support operations.
-- [ ] 2.3 Lower `Arena` allocation, `Id` construction/usage, arena get, arena get-mutable, and arena length operations.
-- [ ] 2.4 Lower `Map` and `Set` construction, lookup, insertion, key validation results, and deterministic iteration operations.
+- [x] 2.1 Lower `Vec` construction, length, indexing, push, and iteration operations.
+- [x] 2.2 Lower `Option` and `Result` construction, tag checks, payload access, and match support operations.
+- [x] 2.3 Lower `Arena` allocation, `Id` construction/usage, arena get, arena get-mutable, and arena length operations.
+- [x] 2.4 Lower `Map` and `Set` construction, lookup, insertion, key validation results, and deterministic iteration operations.
 
 ## 3. Core Runtime Lowering
 
-- [ ] 3.1 Lower scalar and string helper operations needed by compiler-shaped code.
-- [ ] 3.2 Lower `StringBuilder` append and finish operations.
-- [ ] 3.3 Represent runtime descriptor requirements in LIR so backend emission can include support code exactly where needed.
+- [x] 3.1 Lower scalar and string helper operations needed by compiler-shaped code.
+- [x] 3.2 Lower `StringBuilder` append and finish operations.
+- [x] 3.3 Represent runtime descriptor requirements in LIR so backend emission can include support code exactly where needed.
 
 ## 4. Verification And Tests
 
-- [ ] 4.1 Run the LIR type checker on descriptor-lowered modules.
-- [ ] 4.2 Add tests for each lowered standard generic and runtime descriptor group.
-- [ ] 4.3 Add tests proving descriptor lowering preserves deterministic iteration policy.
-- [ ] 4.4 Add negative tests for unsupported descriptor operations reaching the lowering phase.
+- [x] 4.1 Run the LIR type checker on descriptor-lowered modules.
+- [x] 4.2 Add tests for each lowered standard generic and runtime descriptor group.
+- [x] 4.3 Add tests proving descriptor lowering preserves deterministic iteration policy.
+- [x] 4.4 Add negative tests for unsupported descriptor operations reaching the lowering phase.

--- a/packages/cosmo0/src/main/scala/cosmo0/Lir.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Lir.scala
@@ -42,6 +42,7 @@ final case class LirParam(
     id: LirLocalId,
     name: String,
     valueType: LirTypeRef,
+    mutationAllowed: Boolean = false,
 )
 
 final case class LirLocal(
@@ -49,6 +50,7 @@ final case class LirLocal(
     name: String,
     valueType: LirTypeRef,
     mutable: Boolean = false,
+    mutationAllowed: Boolean = false,
 )
 
 final case class LirFunction(
@@ -74,6 +76,7 @@ final case class LirGlobal(
     valueType: LirTypeRef,
     mutable: Boolean,
     initializer: Option[LirValue] = None,
+    mutationAllowed: Boolean = false,
 ) extends LirDeclaration
 
 final case class LirTypeAliasDecl(
@@ -238,6 +241,13 @@ final case class LirReadVariantTag(
     owner: LirTypeRef,
 ) extends LirOp
 
+final case class LirCheckVariantTag(
+    output: LirLocalId,
+    scrutinee: LirValue,
+    owner: LirTypeRef,
+    variant: String,
+) extends LirOp
+
 final case class LirReadVariantPayload(
     output: LirLocalId,
     scrutinee: LirValue,
@@ -284,16 +294,18 @@ object Lir:
       name: String,
       valueType: SourceType,
       id: String = "",
+      mutationAllowed: Boolean = false,
   ): LirParam =
-    LirParam(localId(stableId(id, name)), name, t(valueType))
+    LirParam(localId(stableId(id, name)), name, t(valueType), mutationAllowed)
 
   def local(
       name: String,
       valueType: SourceType,
       mutable: Boolean = false,
       id: String = "",
+      mutationAllowed: Boolean = false,
   ): LirLocal =
-    LirLocal(localId(stableId(id, name)), name, t(valueType), mutable)
+    LirLocal(localId(stableId(id, name)), name, t(valueType), mutable, mutationAllowed)
 
   def ref(id: String, valueType: SourceType): LirLocalRef =
     LirLocalRef(localId(id), t(valueType))
@@ -433,6 +445,8 @@ object LirDebugRenderer:
         s"$output = variant ${renderType(owner)}::$variant(${renderArgs(payload)})"
       case LirReadVariantTag(output, scrutinee, owner) =>
         s"$output = variant_tag ${renderValue(scrutinee)}: ${renderType(owner)}"
+      case LirCheckVariantTag(output, scrutinee, owner, variant) =>
+        s"$output = variant_is ${renderValue(scrutinee)}: ${renderType(owner)}::$variant"
       case LirReadVariantPayload(output, scrutinee, variant, index, valueType) =>
         s"$output = variant_payload ${renderValue(scrutinee)}.$variant[$index]: ${renderType(valueType)}"
 

--- a/packages/cosmo0/src/main/scala/cosmo0/LirLowerer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirLowerer.scala
@@ -5,10 +5,11 @@ import scala.collection.mutable.ListBuffer
 
 object LirLowerer:
   def apply(): LirLowerer =
-    new LirLowerer(LirTypeChecker())
+    new LirLowerer(LirTypeChecker(), StandardGenericDescriptors.all)
 
 final class LirLowerer(
     checker: LirTypeChecker,
+    descriptors: Map[String, StandardGenericDescriptor] = StandardGenericDescriptors.all,
 ):
   def lower(module: TypedModule): Result[LirModule] =
     val state = State(module)
@@ -87,6 +88,7 @@ final class LirLowerer(
       id: LirLocalId,
       valueType: SourceType,
       mutable: Boolean,
+      mutationAllowed: Boolean,
   )
 
   private final class FunctionBuilder(
@@ -94,20 +96,36 @@ final class LirLowerer(
       context: DeclContext,
       report: (String, String, SourceSpan) => Unit,
   ):
+    private final class OpenBlock(val label: LirLabel):
+      val operations: ListBuffer[LirOp] = ListBuffer.empty
+      var terminator: Option[LirTerminator] = None
+
+    private final case class LoopTargets(
+        breakTarget: LirLabel,
+        continueTarget: LirLabel,
+    )
+
+    private sealed trait PatternCondition
+    private case object AlwaysPattern extends PatternCondition
+    private final case class ConditionalPattern(condition: LirValue) extends PatternCondition
+
     private val scopes = mutable.ArrayBuffer.empty[mutable.LinkedHashMap[String, Binding]]
     private val localOrdinals = mutable.LinkedHashMap.empty[String, Int]
+    private val labelOrdinals = mutable.LinkedHashMap.empty[String, Int]
     private val localBuffer = ListBuffer.empty[LirLocal]
-    private val operations = ListBuffer.empty[LirOp]
-    private var sealedTerminator: Option[LirTerminator] = None
+    private val blockBuffer = ListBuffer.empty[OpenBlock]
+    private val loopStack = mutable.ArrayBuffer.empty[LoopTargets]
     private var tempIndex = 0
+    private var current: OpenBlock = newBlock(Lir.label("entry"))
 
     scopes += mutable.LinkedHashMap.empty[String, Binding]
 
     val params: List[LirParam] =
       function.params.map { param =>
         val id = nextLocalId(param.name)
-        bind(Binding(param.name, id, param.valueType, mutable = false))
-        LirParam(id, param.name, Lir.t(param.valueType))
+        val mutationAllowed = mutationCapability(param.valueType)
+        bind(Binding(param.name, id, param.valueType, mutable = false, mutationAllowed))
+        LirParam(id, param.name, Lir.t(param.valueType), mutationAllowed)
       }
 
     def lower(): LirFunction =
@@ -130,7 +148,13 @@ final class LirLowerer(
         params,
         Lir.t(function.returnType),
         localBuffer.toList.sortBy(_.id.value),
-        List(LirBlock(Lir.label("entry"), operations.toList, sealedTerminator.getOrElse(LirUnreachable()))),
+        blockBuffer.toList.map(block =>
+          LirBlock(
+            block.label,
+            block.operations.toList,
+            block.terminator.getOrElse(LirUnreachable()),
+          ),
+        ),
         owner = function.owner.flatMap(context.typeId),
         sourceSignature = Some(function.signature),
       )
@@ -175,7 +199,7 @@ final class LirLowerer(
               None
             else
               for receiver <- lowerExpr(select.receiver) yield
-                val output = declareTemp(select.valueType)
+                val output = declareTemp(select.valueType, mutationAllowed = Some(select.mutationAllowed))
                 emit(LirFieldGet(output.id, receiver, select.field, Lir.t(select.valueType)))
                 LirLocalRef(output.id, Lir.t(output.valueType))
 
@@ -206,35 +230,25 @@ final class LirLowerer(
             unsupported(value, s"type constructor ${value.constructedType.display}")
             None
           case value: TypedVariantConstructorExpr =>
-            unsupported(value, s"variant constructor ${value.owner.display}::${value.variant}")
-            None
+            lowerVariantValue(value)
           case value: TypedUnary =>
-            unsupported(value, s"unary operator ${value.op}")
-            None
+            lowerUnary(value)
           case value: TypedBinary =>
-            unsupported(value, s"binary operator ${value.op}")
-            None
+            lowerBinary(value)
           case value: TypedIf =>
-            unsupported(value, "if expression")
-            None
+            lowerIf(value)
           case value: TypedLoop =>
-            unsupported(value, "loop expression")
-            None
+            lowerLoop(value)
           case value: TypedWhile =>
-            unsupported(value, "while expression")
-            None
+            lowerWhile(value)
           case value: TypedFor =>
-            unsupported(value, "for expression")
-            None
+            lowerFor(value)
           case value: TypedMatch =>
-            unsupported(value, "match expression")
-            None
+            lowerMatch(value)
           case value: TypedBreak =>
-            unsupported(value, "break expression")
-            None
+            lowerBreak(value)
           case value: TypedContinue =>
-            unsupported(value, "continue expression")
-            None
+            lowerContinue(value)
 
     private def lowerName(name: TypedName): Option[LirValue] =
       name.path.parts match
@@ -272,50 +286,463 @@ final class LirLowerer(
       call.callee match
         case name: TypedName if name.path.parts.length == 1 =>
           val args = call.args.flatMap(lowerExpr)
-          if args.length != call.args.length then return None
-          val calleeName = name.path.parts.head
-          context.functionId(None, calleeName) match
-            case Some(id) =>
-              emit(
-                LirDirectCall(
-                  output.map(_.id),
-                  id,
-                  args,
-                  LirCallableSignature.fromSource(call.signature),
-                ),
-              )
-              callResult(output, call.valueType)
-            case None =>
-              unsupported(call, s"call to non-function value ${name.path.text}")
-              None
+          if args.length != call.args.length then None
+          else
+            val calleeName = name.path.parts.head
+            context.functionId(None, calleeName) match
+              case Some(id) =>
+                emit(
+                  LirDirectCall(
+                    output.map(_.id),
+                    id,
+                    args,
+                    LirCallableSignature.fromSource(call.signature),
+                  ),
+                )
+                callResult(output, call.valueType)
+              case None =>
+                unsupported(call, s"call to non-function value ${name.path.text}")
+                None
 
         case select: TypedSelect =>
           lowerExpr(select.receiver) match
             case Some(receiver) =>
               val args = call.args.flatMap(lowerExpr)
-              if args.length != call.args.length then return None
-              emit(
-                LirLoweredMethodCall(
-                  output.map(_.id),
-                  receiver,
-                  select.field,
-                  args,
-                  LirCallableSignature.fromSource(call.signature),
-                ),
-              )
-              callResult(output, call.valueType)
+              if args.length != call.args.length then None
+              else
+                descriptorRefForMethod(receiver.valueType.source, select.field) match
+                  case Some(descriptor) =>
+                    emit(
+                      LirDescriptorIntrinsic(
+                        output.map(_.id),
+                        descriptor,
+                        select.field,
+                        receiver :: args,
+                        Some(Lir.t(call.valueType)),
+                      ),
+                    )
+                    callResult(output, call.valueType)
+                  case None if isDescriptorBacked(receiver.valueType.source) =>
+                    unsupportedDescriptor(call, descriptorName(receiver.valueType.source).getOrElse("<unknown>"), select.field)
+                    None
+                  case None =>
+                    emit(
+                      LirLoweredMethodCall(
+                        output.map(_.id),
+                        receiver,
+                        select.field,
+                        args,
+                        LirCallableSignature.fromSource(call.signature),
+                      ),
+                    )
+                    callResult(output, call.valueType)
             case None =>
               None
 
         case constructor: TypedVariantConstructorExpr =>
-          unsupported(constructor, s"variant constructor ${constructor.owner.display}::${constructor.variant}")
-          None
+          val args = call.args.flatMap(lowerExpr)
+          if args.length != call.args.length then None
+          else
+            output match
+              case Some(binding) =>
+                emit(
+                  LirConstructVariant(
+                    binding.id,
+                    Lir.t(constructor.owner),
+                    constructor.variant,
+                    args,
+                  ),
+                )
+                callResult(output, call.valueType)
+              case None =>
+                report(
+                  "cosmo0.lir.lower.invalid-variant-constructor",
+                  s"variant constructor ${constructor.owner.display}::${constructor.variant} has no LIR output",
+                  constructor.span,
+                )
+                None
         case constructor: TypedTypeConstructorExpr =>
-          unsupported(constructor, s"type constructor ${constructor.constructedType.display}")
-          None
+          val args = call.args.flatMap(lowerExpr)
+          if args.length != call.args.length then None
+          else lowerDescriptorConstructor(constructor, output, args, call.valueType)
         case other =>
           unsupported(other, "indirect function call")
           None
+
+    private def lowerDescriptorConstructor(
+        constructor: TypedTypeConstructorExpr,
+        output: Option[Binding],
+        args: List[LirValue],
+        valueType: SourceType,
+    ): Option[LirValue] =
+      descriptorRefForConstructor(constructor.constructedType) match
+        case Some(descriptor) =>
+          emit(
+            LirDescriptorIntrinsic(
+              output.map(_.id),
+              descriptor,
+              "<init>",
+              args,
+              Some(Lir.t(valueType)),
+            ),
+          )
+          callResult(output, valueType)
+        case None =>
+          unsupportedDescriptor(constructor, descriptorName(constructor.constructedType).getOrElse(constructor.constructedType.display), "<init>")
+          None
+
+    private def lowerUnary(value: TypedUnary): Option[LirValue] =
+      val opName =
+        value.op match
+          case "!" => Some("not")
+          case "-" => Some("neg")
+          case _   => None
+      opName match
+        case Some(name) =>
+          lowerExpr(value.expr).flatMap { arg =>
+            descriptorRefForValue(arg.valueType.source, name) match
+              case Some(descriptor) =>
+                val output = declareTemp(value.valueType)
+                emit(
+                  LirDescriptorIntrinsic(
+                    Some(output.id),
+                    descriptor,
+                    name,
+                    List(arg),
+                    Some(Lir.t(value.valueType)),
+                  ),
+                )
+                Some(LirLocalRef(output.id, Lir.t(output.valueType)))
+              case None =>
+                unsupportedDescriptor(value, descriptorName(arg.valueType.source).getOrElse(arg.valueType.display), name)
+                None
+          }
+        case None =>
+          unsupported(value, s"unary operator ${value.op}")
+          None
+
+    private def lowerBinary(value: TypedBinary): Option[LirValue] =
+      val opName =
+        value.op match
+          case "+"          => Some("add")
+          case "-"          => Some("sub")
+          case "*"          => Some("mul")
+          case "/"          => Some("div")
+          case "%"          => Some("mod")
+          case "=="         => Some("eq")
+          case "!="         => Some("ne")
+          case "<"          => Some("lt")
+          case "<="         => Some("le")
+          case ">"          => Some("gt")
+          case ">="         => Some("ge")
+          case "and" | "&&" => Some("and")
+          case "or" | "||"  => Some("or")
+          case _            => None
+      opName match
+        case Some(name) =>
+          for
+            left <- lowerExpr(value.left)
+            right <- lowerExpr(value.right)
+            result <- lowerDescriptorBinary(value, name, left, right)
+          yield result
+        case None =>
+          unsupported(value, s"binary operator ${value.op}")
+          None
+
+    private def lowerDescriptorBinary(
+        value: TypedBinary,
+        name: String,
+        left: LirValue,
+        right: LirValue,
+    ): Option[LirValue] =
+      descriptorRefForValue(left.valueType.source, name) match
+        case Some(descriptor) =>
+          val output = declareTemp(value.valueType)
+          emit(
+            LirDescriptorIntrinsic(
+              Some(output.id),
+              descriptor,
+              name,
+              List(left, right),
+              Some(Lir.t(value.valueType)),
+            ),
+          )
+          Some(LirLocalRef(output.id, Lir.t(output.valueType)))
+        case None =>
+          unsupportedDescriptor(value, descriptorName(left.valueType.source).getOrElse(left.valueType.display), name)
+          None
+
+    private def lowerVariantValue(constructor: TypedVariantConstructorExpr): Option[LirValue] =
+      SourceType.dealias(constructor.valueType) match
+        case SourceType.Function(_, _) =>
+          unsupported(constructor, s"unapplied variant constructor ${constructor.owner.display}::${constructor.variant}")
+          None
+        case SourceType.Unit | SourceType.Never =>
+          Some(LirUnitValue)
+        case _ =>
+          val output = declareTemp(constructor.valueType)
+          emit(
+            LirConstructVariant(
+              output.id,
+              Lir.t(constructor.owner),
+              constructor.variant,
+              Nil,
+            ),
+          )
+          Some(LirLocalRef(output.id, Lir.t(output.valueType)))
+
+    private def lowerIf(value: TypedIf): Option[LirValue] =
+      lowerExpr(value.cond) match
+        case Some(condition) =>
+          val group = nextLabelGroup("if")
+          val thenLabel = numberedLabel(group, 0, "then")
+          val elseLabel = numberedLabel(group, 1, "else")
+          val joinLabel = numberedLabel(group, 2, "join")
+          val resultSlot = joinOutput(value.valueType)
+
+          terminate(
+            LirCondBranch(
+              condition,
+              thenLabel,
+              value.elseBranch.fold(joinLabel)(_ => elseLabel),
+            ),
+          )
+
+          startBlock(thenLabel)
+          val thenResult = lowerExpr(value.thenBranch)
+          val thenFallsThrough =
+            finishStructuredBranch(resultSlot, thenResult, joinLabel, value.thenBranch.span)
+
+          val elseFallsThrough =
+            value.elseBranch match
+              case Some(elseExpr) =>
+                startBlock(elseLabel)
+                val elseResult = lowerExpr(elseExpr)
+                finishStructuredBranch(resultSlot, elseResult, joinLabel, elseExpr.span)
+              case None =>
+                true
+
+          if thenFallsThrough || elseFallsThrough then
+            startBlock(joinLabel)
+            structuredResult(resultSlot)
+          else None
+        case None =>
+          None
+
+    private def lowerLoop(value: TypedLoop): Option[LirValue] =
+      val group = nextLabelGroup("loop")
+      val headerLabel = numberedLabel(group, 0, "header")
+      val bodyLabel = numberedLabel(group, 1, "body")
+      val continueLabel = numberedLabel(group, 2, "continue")
+      val exitLabel = numberedLabel(group, 3, "exit")
+
+      terminate(LirBranch(headerLabel))
+      startBlock(headerLabel)
+      terminate(LirBranch(bodyLabel))
+
+      startBlock(bodyLabel)
+      withLoop(LoopTargets(exitLabel, continueLabel)) {
+        lowerExpr(value.body)
+        if !isTerminated then terminate(LirBranch(continueLabel))
+      }
+
+      startBlock(continueLabel)
+      terminate(LirBranch(headerLabel))
+
+      startBlock(exitLabel)
+      Some(LirUnitValue)
+
+    private def lowerWhile(value: TypedWhile): Option[LirValue] =
+      val group = nextLabelGroup("while")
+      val headerLabel = numberedLabel(group, 0, "header")
+      val bodyLabel = numberedLabel(group, 1, "body")
+      val continueLabel = numberedLabel(group, 2, "continue")
+      val exitLabel = numberedLabel(group, 3, "exit")
+
+      terminate(LirBranch(headerLabel))
+      startBlock(headerLabel)
+      lowerExpr(value.cond) match
+        case Some(condition) =>
+          terminate(LirCondBranch(condition, bodyLabel, exitLabel))
+        case None =>
+          if !isTerminated then
+            report(
+              "cosmo0.lir.lower.missing-condition",
+              "while condition did not produce a LIR value",
+              value.cond.span,
+            )
+            terminate(LirErrorExit("cosmo0.lir.lower.missing-condition", Some("while")))
+
+      startBlock(bodyLabel)
+      withLoop(LoopTargets(exitLabel, continueLabel)) {
+        lowerExpr(value.body)
+        if !isTerminated then terminate(LirBranch(continueLabel))
+      }
+
+      startBlock(continueLabel)
+      terminate(LirBranch(headerLabel))
+
+      startBlock(exitLabel)
+      Some(LirUnitValue)
+
+    private def lowerFor(value: TypedFor): Option[LirValue] =
+      val iterAndDescriptor =
+        lowerExpr(value.iter).flatMap(iterValue =>
+          iterableDescriptor(iterValue.valueType.source, value.itemType, value.span).map(iterValue -> _),
+        )
+      iterAndDescriptor match
+        case None =>
+          None
+        case Some((iterValue, descriptor)) =>
+          lowerForLoop(value, iterValue, descriptor)
+
+    private def lowerForLoop(
+        value: TypedFor,
+        iterValue: LirValue,
+        descriptor: LirDescriptorRef,
+    ): Option[LirValue] =
+      val group = nextLabelGroup("for")
+      val headerLabel = numberedLabel(group, 0, "header")
+      val bodyLabel = numberedLabel(group, 1, "body")
+      val continueLabel = numberedLabel(group, 2, "continue")
+      val exitLabel = numberedLabel(group, 3, "exit")
+      val itemBinding = declareLocal(value.name, value.itemType, mutable = false)
+
+      terminate(LirBranch(headerLabel))
+      startBlock(headerLabel)
+      val hasNext = declareTemp(SourceType.Bool)
+      emit(
+        LirDescriptorIntrinsic(
+          Some(hasNext.id),
+          descriptor,
+          "iter_has_next",
+          List(iterValue),
+          Some(Lir.t(SourceType.Bool)),
+        ),
+      )
+      terminate(
+        LirCondBranch(
+          LirLocalRef(hasNext.id, Lir.t(SourceType.Bool)),
+          bodyLabel,
+          exitLabel,
+        ),
+      )
+
+      startBlock(bodyLabel)
+      withLoop(LoopTargets(exitLabel, continueLabel)) {
+        withScope {
+          bind(itemBinding)
+          emit(
+            LirDescriptorIntrinsic(
+              Some(itemBinding.id),
+              descriptor,
+              "iter_next",
+              List(iterValue),
+              Some(Lir.t(value.itemType)),
+            ),
+          )
+          lowerExpr(value.body)
+          if !isTerminated then terminate(LirBranch(continueLabel))
+        }
+      }
+
+      startBlock(continueLabel)
+      terminate(LirBranch(headerLabel))
+
+      startBlock(exitLabel)
+      Some(LirUnitValue)
+
+    private def lowerMatch(value: TypedMatch): Option[LirValue] =
+      lowerExpr(value.scrutinee) match
+        case Some(scrutinee) =>
+          lowerMatchWithScrutinee(value, scrutinee)
+        case None =>
+          None
+
+    private def lowerMatchWithScrutinee(
+        value: TypedMatch,
+        scrutinee: LirValue,
+    ): Option[LirValue] =
+      val group = nextLabelGroup("match")
+      val armLabels = value.arms.zipWithIndex.map { case (_, index) =>
+        numberedLabel(group, 10 + index, s"arm$index")
+      }
+      val defaultLabel = numberedLabel(group, 80, "default")
+      val joinLabel = numberedLabel(group, 90, "join")
+      val resultSlot = joinOutput(value.valueType)
+      var needsDefault = true
+      var chainOpen = true
+
+      value.arms.zip(armLabels).zipWithIndex.foreach { case ((arm, armLabel), index) =>
+        if chainOpen then
+          patternCondition(arm.pattern, scrutinee) match
+            case Some(AlwaysPattern) =>
+              terminate(LirBranch(armLabel))
+              needsDefault = false
+              chainOpen = false
+            case Some(ConditionalPattern(condition)) =>
+              val falseTarget =
+                if index == value.arms.length - 1 then defaultLabel
+                else numberedLabel(group, index + 1, "test")
+              terminate(LirCondBranch(condition, armLabel, falseTarget))
+              if index == value.arms.length - 1 then chainOpen = false
+              else startBlock(falseTarget)
+            case None =>
+              if !isTerminated then
+                terminate(LirErrorExit("cosmo0.lir.lower.unsupported-pattern", Some("match")))
+              needsDefault = false
+              chainOpen = false
+      }
+
+      if value.arms.isEmpty && !isTerminated then
+        terminate(LirBranch(defaultLabel))
+
+      var anyFallthrough = false
+      value.arms.zip(armLabels).foreach { case (arm, armLabel) =>
+        startBlock(armLabel)
+        val armResult = withScope {
+          bindPattern(arm.pattern, scrutinee)
+          arm.body.flatMap(lowerExpr).orElse(Some(LirUnitValue))
+        }
+        val fallsThrough =
+          finishStructuredBranch(resultSlot, armResult, joinLabel, arm.span)
+        anyFallthrough = anyFallthrough || fallsThrough
+      }
+
+      if needsDefault then
+        startBlock(defaultLabel)
+        terminate(LirErrorExit("cosmo0.lir.lower.non-exhaustive-match", Some(function.name)))
+
+      if anyFallthrough then
+        startBlock(joinLabel)
+        structuredResult(resultSlot)
+      else None
+
+    private def lowerBreak(value: TypedBreak): Option[LirValue] =
+      loopStack.lastOption match
+        case Some(targets) =>
+          terminate(LirBranch(targets.breakTarget))
+        case None =>
+          report(
+            "cosmo0.lir.lower.invalid-break",
+            "break can only be lowered inside a loop",
+            value.span,
+          )
+          terminate(LirErrorExit("cosmo0.lir.lower.invalid-break", Some(function.name)))
+      None
+
+    private def lowerContinue(value: TypedContinue): Option[LirValue] =
+      loopStack.lastOption match
+        case Some(targets) =>
+          terminate(LirBranch(targets.continueTarget))
+        case None =>
+          report(
+            "cosmo0.lir.lower.invalid-continue",
+            "continue can only be lowered inside a loop",
+            value.span,
+          )
+          terminate(LirErrorExit("cosmo0.lir.lower.invalid-continue", Some(function.name)))
+      None
 
     private def lowerAssign(assign: TypedAssign): Unit =
       if assign.op != "=" then
@@ -377,20 +804,69 @@ final class LirLowerer(
         case None =>
           Some(LirUnitValue)
 
+    private def joinOutput(valueType: SourceType): Option[Binding] =
+      SourceType.dealias(valueType) match
+        case SourceType.Unit | SourceType.Never =>
+          None
+        case _ =>
+          Some(declareTemp(valueType, mutable = true))
+
+    private def structuredResult(output: Option[Binding]): Option[LirValue] =
+      output match
+        case Some(binding) =>
+          Some(LirLocalRef(binding.id, Lir.t(binding.valueType)))
+        case None =>
+          Some(LirUnitValue)
+
+    private def finishStructuredBranch(
+        output: Option[Binding],
+        result: Option[LirValue],
+        joinLabel: LirLabel,
+        span: SourceSpan,
+    ): Boolean =
+      if isTerminated then false
+      else
+        var canBranch = true
+        output match
+          case Some(binding) =>
+            result match
+              case Some(value) =>
+                emit(LirAssign(LirLocalPlace(binding.id, Lir.t(binding.valueType)), value))
+              case None =>
+                report(
+                  "cosmo0.lir.lower.missing-branch-value",
+                  s"structured expression did not produce ${binding.valueType.display}",
+                  span,
+                )
+                terminate(LirErrorExit("cosmo0.lir.lower.missing-branch-value", Some(function.name)))
+                canBranch = false
+          case None =>
+        if canBranch && !isTerminated then
+          terminate(LirBranch(joinLabel))
+          true
+        else false
+
     private def declareLocal(
         name: String,
         valueType: SourceType,
         mutable: Boolean,
     ): Binding =
       val id = nextLocalId(name)
-      val binding = Binding(name, id, valueType, mutable)
+      val binding = Binding(name, id, valueType, mutable, mutationCapability(valueType))
       localBuffer += localFor(binding)
       binding
 
-    private def declareTemp(valueType: SourceType): Binding =
+    private def declareTemp(
+        valueType: SourceType,
+        mutable: Boolean = false,
+        mutationAllowed: Option[Boolean] = None,
+    ): Binding =
       val name = s"tmp$tempIndex"
       tempIndex += 1
-      declareLocal(name, valueType, mutable = false)
+      val id = nextLocalId(name)
+      val binding = Binding(name, id, valueType, mutable, mutationAllowed.getOrElse(mutationCapability(valueType)))
+      localBuffer += localFor(binding)
+      binding
 
     private def nextLocalId(name: String): LirLocalId =
       val base = stablePart(name)
@@ -400,7 +876,7 @@ final class LirLowerer(
       else Lir.localId(s"${base}_$ordinal")
 
     private def localFor(binding: Binding): LirLocal =
-      LirLocal(binding.id, binding.name, Lir.t(binding.valueType), binding.mutable)
+      LirLocal(binding.id, binding.name, Lir.t(binding.valueType), binding.mutable, binding.mutationAllowed)
 
     private def bind(binding: Binding): Unit =
       scopes.last.update(binding.name, binding)
@@ -413,19 +889,184 @@ final class LirLowerer(
       try body
       finally scopes.remove(scopes.length - 1)
 
+    private def withLoop[A](targets: LoopTargets)(body: => A): A =
+      loopStack += targets
+      try body
+      finally loopStack.remove(loopStack.length - 1)
+
     private def emit(op: LirOp): Unit =
-      if !isTerminated then operations += op
+      if !isTerminated then current.operations += op
 
     private def terminate(terminator: LirTerminator): Unit =
-      if sealedTerminator.isEmpty then sealedTerminator = Some(terminator)
+      if current.terminator.isEmpty then current.terminator = Some(terminator)
 
     private def isTerminated: Boolean =
-      sealedTerminator.nonEmpty
+      current.terminator.nonEmpty
+
+    private def newBlock(label: LirLabel): OpenBlock =
+      val block = new OpenBlock(label)
+      blockBuffer += block
+      block
+
+    private def startBlock(label: LirLabel): Unit =
+      current = newBlock(label)
+
+    private def nextLabelGroup(prefix: String): String =
+      val base = stablePart(prefix)
+      val ordinal = labelOrdinals.getOrElse(base, 0)
+      labelOrdinals.update(base, ordinal + 1)
+      s"$base$ordinal"
+
+    private def numberedLabel(group: String, index: Int, suffix: String): LirLabel =
+      Lir.label(s"${group}_${"%02d".format(index)}_${stablePart(suffix)}")
+
+    private def descriptorRefForConstructor(valueType: SourceType): Option[LirDescriptorRef] =
+      descriptorRefFor(valueType).filter { descriptor =>
+        descriptors.get(descriptor.name).exists(_.constructor("<init>").nonEmpty)
+      }
+
+    private def descriptorRefForMethod(
+        valueType: SourceType,
+        method: String,
+    ): Option[LirDescriptorRef] =
+      descriptorRefFor(valueType).filter { descriptor =>
+        descriptors.get(descriptor.name).exists(_.method(method).nonEmpty)
+      }
+
+    private def descriptorRefForValue(
+        valueType: SourceType,
+        operation: String,
+    ): Option[LirDescriptorRef] =
+      descriptorRefFor(valueType).filter { descriptor =>
+        descriptors.get(descriptor.name).exists(_.method(operation).nonEmpty)
+      }
+
+    private def descriptorRefFor(valueType: SourceType): Option[LirDescriptorRef] =
+      SourceType.dealias(valueType) match
+        case SourceType.Ref(target, _) =>
+          descriptorRefFor(target)
+        case SourceType.Standard(name, args) if descriptors.get(name).exists(_.arity == args.length) =>
+          Some(LirDescriptorRef(name, args.map(Lir.t)))
+        case SourceType.Builtin(name) if descriptors.get(name).exists(_.arity == 0) =>
+          Some(LirDescriptorRef(name))
+        case _ =>
+          None
+
+    private def isDescriptorBacked(valueType: SourceType): Boolean =
+      descriptorRefFor(valueType).nonEmpty
+
+    private def descriptorName(valueType: SourceType): Option[String] =
+      SourceType.dealias(valueType) match
+        case SourceType.Ref(target, _)     => descriptorName(target)
+        case SourceType.Standard(name, _)  => Some(name)
+        case SourceType.Builtin(name)      => Some(name)
+        case _                             => None
+
+    private def iterableDescriptor(
+        valueType: SourceType,
+        itemType: SourceType,
+        span: SourceSpan,
+    ): Option[LirDescriptorRef] =
+      SourceType.dealias(valueType) match
+        case SourceType.Standard(name @ ("Vec" | "Set" | "Arena"), item :: Nil) =>
+          if !SourceType.same(item, itemType) then
+            report(
+              "cosmo0.lir.lower.invalid-iterator",
+              s"for loop item type ${itemType.display} does not match ${valueType.display} item ${item.display}",
+              span,
+            )
+          Some(LirDescriptorRef(name, List(Lir.t(item))))
+        case SourceType.Standard("Map", key :: value :: Nil) =>
+          if !SourceType.same(key, itemType) then
+            report(
+              "cosmo0.lir.lower.invalid-iterator",
+              s"for loop item type ${itemType.display} does not match ${valueType.display} key ${key.display}",
+              span,
+            )
+          Some(LirDescriptorRef("Map", List(Lir.t(key), Lir.t(value))))
+        case other =>
+          report(
+            "cosmo0.lir.lower.invalid-iterator",
+            s"type ${other.display} is not a descriptor-backed iterable",
+            span,
+          )
+          None
+
+    private def patternCondition(
+        pattern: TypedPattern,
+        scrutinee: LirValue,
+    ): Option[PatternCondition] =
+      pattern match
+        case _: TypedWildcardPattern =>
+          Some(AlwaysPattern)
+        case _: TypedBindingPattern =>
+          Some(AlwaysPattern)
+        case TypedVariantPattern(constructor: TypedVariantConstructorExpr, _, valueType, _) =>
+          val output = declareTemp(SourceType.Bool)
+          emit(
+            LirCheckVariantTag(
+              output.id,
+              scrutinee,
+              Lir.t(valueType),
+              constructor.variant,
+            ),
+          )
+          Some(ConditionalPattern(LirLocalRef(output.id, Lir.t(SourceType.Bool))))
+        case value: TypedVariantPattern =>
+          unsupportedPattern(value, "variant pattern with non-constructor head")
+          None
+        case value =>
+          unsupportedPattern(value, "literal pattern")
+          None
+
+    private def bindPattern(pattern: TypedPattern, scrutinee: LirValue): Unit =
+      pattern match
+        case TypedWildcardPattern(_, _) =>
+        case TypedBindingPattern(name, valueType, _) =>
+          val binding = declareLocal(name, valueType, mutable = false)
+          bind(binding)
+          emit(LirAllocLocal(localFor(binding), Some(scrutinee)))
+        case TypedVariantPattern(constructor: TypedVariantConstructorExpr, args, _, _) =>
+          args.zipWithIndex.foreach { case (arg, index) =>
+            arg match
+              case TypedWildcardPattern(_, _) =>
+              case TypedBindingPattern(name, valueType, _) =>
+                val binding = declareLocal(name, valueType, mutable = false)
+                bind(binding)
+                emit(
+                  LirReadVariantPayload(
+                    binding.id,
+                    scrutinee,
+                    constructor.variant,
+                    index,
+                    Lir.t(valueType),
+                  ),
+                )
+              case other =>
+                unsupportedPattern(other, "nested or literal variant payload pattern")
+          }
+        case value: TypedVariantPattern =>
+          unsupportedPattern(value, "variant pattern with non-constructor head")
+        case _ =>
+
+    private def unsupportedPattern(pattern: TypedPattern, construct: String): Unit =
+      report(
+        "cosmo0.lir.lower.unsupported-pattern",
+        s"match lowering does not support $construct yet",
+        pattern.span,
+      )
 
     private def unsupported(node: TypedNode, construct: String): Unit =
       report(
         "cosmo0.lir.lower.unsupported-expression",
         s"declaration lowering does not support $construct yet",
+        node.span,
+      )
+
+    private def unsupportedDescriptor(node: TypedNode, descriptor: String, operation: String): Unit =
+      report(
+        "cosmo0.lir.lower.unsupported-descriptor",
+        s"descriptor $descriptor has no lowerable operation $operation",
         node.span,
       )
 
@@ -469,6 +1110,7 @@ final class LirLowerer(
               Lir.t(value.valueType),
               mutable = value.kind == UntypedValueKind.Var,
               initializer = value.init.flatMap(staticValue),
+              mutationAllowed = mutationCapability(value.valueType),
             ),
           )
 
@@ -554,6 +1196,12 @@ final class LirLowerer(
         message,
         Some(span),
       )
+
+  private def mutationCapability(valueType: SourceType): Boolean =
+    SourceType.dealias(valueType) match
+      case SourceType.Ref(_, mutable)          => mutable
+      case SourceType.Never | SourceType.Error => false
+      case _                                   => true
 
   private def moduleName(source: SourceFile): String =
     val raw =

--- a/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
@@ -30,6 +30,7 @@ final class LirTypeChecker(
       name: String,
       valueType: LirTypeRef,
       mutable: Boolean,
+      mutationAllowed: Boolean,
       param: Boolean,
   )
 
@@ -227,10 +228,10 @@ final class LirTypeChecker(
 
     private def buildLocalEnv(function: LirFunction): Map[LirLocalId, LocalInfo] =
       val params = function.params.map { param =>
-        LocalInfo(param.id, param.name, param.valueType, mutable = false, param = true)
+        LocalInfo(param.id, param.name, param.valueType, mutable = false, param.mutationAllowed, param = true)
       }
       val locals = function.locals.map { local =>
-        LocalInfo(local.id, local.name, local.valueType, local.mutable, param = false)
+        LocalInfo(local.id, local.name, local.valueType, local.mutable, local.mutationAllowed, param = false)
       }
       (params ++ locals)
         .groupBy(_.id)
@@ -322,6 +323,8 @@ final class LirTypeChecker(
             defineKnown(output, defined, env)
           case LirReadVariantTag(output, _, _) =>
             defineKnown(output, defined, env)
+          case LirCheckVariantTag(output, _, _, _) =>
+            defineKnown(output, defined, env)
           case LirReadVariantPayload(output, _, _, _, _) =>
             defineKnown(output, defined, env)
         }
@@ -358,7 +361,11 @@ final class LirTypeChecker(
                   "cosmo0.lir.invalid-local",
                   s"${env.function.id} cannot allocate parameter ${local.id}",
                 )
-              if info.name != local.name || !sameType(info.valueType, local.valueType) || info.mutable != local.mutable then
+              if info.name != local.name ||
+                  !sameType(info.valueType, local.valueType) ||
+                  info.mutable != local.mutable ||
+                  info.mutationAllowed != local.mutationAllowed
+              then
                 error(
                   "cosmo0.lir.invalid-local",
                   s"${env.function.id} allocates ${local.id} with metadata that does not match the function local declaration",
@@ -515,6 +522,20 @@ final class LirTypeChecker(
             )
           defineOutput(output, LirTypeRef(SourceType.I32), env, defined, s"variant_tag ${owner.display}")
 
+        case LirCheckVariantTag(output, scrutinee, owner, variant) =>
+          checkValue(scrutinee, env, defined)
+          if !sameSourceType(SourceType.deref(scrutinee.valueType.source), owner.source) then
+            error(
+              "cosmo0.lir.assignment-mismatch",
+              s"${env.function.id} checks variant tag for ${owner.display} from ${scrutinee.valueType.display}",
+            )
+          if !variantNames(owner, env).contains(variant) then
+            error(
+              "cosmo0.lir.invalid-variant",
+              s"${env.function.id} checks missing variant ${owner.display}::$variant",
+            )
+          defineOutput(output, LirTypeRef(SourceType.Bool), env, defined, s"variant_is ${owner.display}::$variant")
+
         case LirReadVariantPayload(output, scrutinee, variant, index, valueType) =>
           checkValue(scrutinee, env, defined)
           val owner = LirTypeRef(SourceType.deref(scrutinee.valueType.source))
@@ -544,6 +565,8 @@ final class LirTypeChecker(
     ): Option[ExpectedCallable] =
       SourceType.dealias(SourceType.deref(receiver.valueType.source)) match
         case owner: SourceType.Standard =>
+          descriptorMethod(owner, method, receiver.valueType)
+        case owner: SourceType.Builtin =>
           descriptorMethod(owner, method, receiver.valueType)
         case SourceType.User(name) =>
           env.declarations.typesByName.get(name).flatMap { ty =>
@@ -585,9 +608,9 @@ final class LirTypeChecker(
           )
           None
         case Some(info) =>
-          val owner: SourceType.Standard =
-            SourceType.Standard(descriptor.name, descriptor.args.map(_.source))
-          info.method(name) match
+          val owner =
+            descriptorOwnerType(descriptor)
+          syntheticDescriptorOperation(descriptor, name).orElse(info.method(name) match
             case Some(callable) =>
               val signature = callable.instantiate(owner, syntheticSpan)
               val params = LirTypeRef(owner) :: signature.params.map(param => LirTypeRef(param.valueType))
@@ -613,13 +636,62 @@ final class LirTypeChecker(
                     s"descriptor ${descriptor.name} has no operation $name",
                   )
                   None
+          )
+
+    private def syntheticDescriptorOperation(
+        descriptor: LirDescriptorRef,
+        name: String,
+    ): Option[ExpectedCallable] =
+      descriptor.name match
+        case "Vec" | "Set" | "Arena" if descriptor.args.length == 1 =>
+          val owner = LirTypeRef(descriptorOwnerType(descriptor))
+          val itemType = descriptor.args.head
+          name match
+            case "iter_has_next" =>
+              Some(
+                ExpectedCallable(
+                  LirCallableSignature(List(owner), LirTypeRef(SourceType.Bool)),
+                  receiverMutable = false,
+                ),
+              )
+            case "iter_next" =>
+              Some(
+                ExpectedCallable(
+                  LirCallableSignature(List(owner), itemType),
+                  receiverMutable = false,
+                ),
+              )
+            case _ =>
+              None
+        case "Map" if descriptor.args.length == 2 =>
+          val owner = LirTypeRef(descriptorOwnerType(descriptor))
+          val keyType = descriptor.args.head
+          name match
+            case "iter_has_next" =>
+              Some(
+                ExpectedCallable(
+                  LirCallableSignature(List(owner), LirTypeRef(SourceType.Bool)),
+                  receiverMutable = false,
+                ),
+              )
+            case "iter_next" =>
+              Some(
+                ExpectedCallable(
+                  LirCallableSignature(List(owner), keyType),
+                  receiverMutable = false,
+                ),
+              )
+            case _ =>
+              None
+        case _ =>
+          None
 
     private def descriptorMethod(
-        owner: SourceType.Standard,
+        owner: SourceType,
         method: String,
         receiverType: LirTypeRef,
     ): Option[ExpectedCallable] =
-      descriptors.get(owner.name).flatMap(_.method(method)).map { callable =>
+      descriptorName(owner).flatMap(name => descriptors.get(name).flatMap(_.method(method))).map { callable =>
         val signature = callable.instantiate(owner, syntheticSpan)
         ExpectedCallable(
           LirCallableSignature(signature.params.map(param => LirTypeRef(param.valueType)), LirTypeRef(signature.returnType), Some(signature)),
@@ -961,11 +1033,24 @@ final class LirTypeChecker(
         case _ =>
           None
 
+    private def descriptorOwnerType(descriptor: LirDescriptorRef): SourceType =
+      SourceType.scalar(descriptor.name).filter(_ => descriptor.args.isEmpty).getOrElse {
+        SourceType.Standard(descriptor.name, descriptor.args.map(_.source))
+      }
+
+    private def descriptorName(ownerType: SourceType): Option[String] =
+      SourceType.dealias(ownerType) match
+        case SourceType.Standard(name, _) => Some(name)
+        case SourceType.Builtin(name)     => Some(name)
+        case _                            => None
+
     private def mutableValue(value: LirValue, env: FunctionEnv): Boolean =
       SourceType.refMutable(value.valueType.source).contains(true) ||
         (value match
-          case LirLocalRef(id, _)  => env.locals.get(id).exists(_.mutable)
-          case LirGlobalRef(id, _) => env.declarations.globals.get(id).exists(_.mutable)
+          case LirLocalRef(id, _) =>
+            env.locals.get(id).exists(info => info.mutable || info.mutationAllowed)
+          case LirGlobalRef(id, _) =>
+            env.declarations.globals.get(id).exists(global => global.mutable || global.mutationAllowed)
           case _                   => false
         )
 

--- a/packages/cosmo0/src/main/scala/cosmo0/SourceTyper.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/SourceTyper.scala
@@ -441,10 +441,14 @@ final class SourceTyper(
                 symbol.mutationAllowed,
               )
             case None =>
-              classConstructor(name, node.span) match
+              classConstructor(name, node.span).orElse(descriptorConstructor(name, node.span)) match
                 case Some(signature) =>
-                  val valueType = signature.functionType
-                  ExprInfo(TypedName(node.path, valueType, false, false, node.span), false, false)
+                  val callee = descriptorOwner(name) match
+                    case Some(owner) if SourceType.same(signature.returnType, owner) =>
+                      TypedTypeConstructorExpr(owner, signature.functionType, node.span)
+                    case _ =>
+                      TypedName(node.path, signature.functionType, false, false, node.span)
+                  ExprInfo(callee, false, false)
                 case None =>
                   error(
                     "cosmo0.type.unresolved-name",
@@ -495,35 +499,21 @@ final class SourceTyper(
 
       val receiver = expr(node.receiver, scope, None, context)
       SourceType.dealias(receiver.expr.valueType) match
-        case owner @ SourceType.Standard(name, _) =>
-          standardGenerics.get(name).flatMap(_.method(node.field)) match
-            case Some(method) =>
-              val signature = method.instantiate(owner, node.span)
-              ExprInfo(
-                TypedSelect(
-                  receiver.expr,
-                  node.field,
-                  signature.functionType,
-                  mutableBinding = false,
-                  mutationAllowed = false,
-                  node.span,
-                ),
-                mutableBinding = false,
-                mutationAllowed = false,
-              )
-            case None =>
-              invalidField(node.field, receiver.expr.valueType, node.span)
-        case SourceType.Ref(owner @ SourceType.Standard(name, _), _) =>
-          standardGenerics.get(name).flatMap(_.method(node.field)) match
-            case Some(method) =>
-              val signature = method.instantiate(owner, node.span)
-              ExprInfo(
-                TypedSelect(receiver.expr, node.field, signature.functionType, false, false, node.span),
-                false,
-                false,
-              )
-            case None =>
-              invalidField(node.field, receiver.expr.valueType, node.span)
+        case owner if descriptorMethod(owner, node.field, node.span).nonEmpty =>
+          val method = descriptorMethod(owner, node.field, node.span).get
+          val signature = method.instantiate(normalizeDescriptorOwner(owner), node.span)
+          ExprInfo(
+            TypedSelect(
+              receiver.expr,
+              node.field,
+              signature.functionType,
+              mutableBinding = false,
+              mutationAllowed = false,
+              node.span,
+            ),
+            mutableBinding = false,
+            mutationAllowed = false,
+          )
         case ty =>
           classInfoFor(ty) match
             case Some(cls) =>
@@ -676,10 +666,15 @@ final class SourceTyper(
                 context,
               )
             case None =>
-              classConstructor(calleeName, name.span) match
+              classConstructor(calleeName, name.span).orElse(descriptorConstructor(calleeName, name.span)) match
                 case Some(signature) =>
+                  val callee = descriptorOwner(calleeName) match
+                    case Some(owner) if SourceType.same(signature.returnType, owner) =>
+                      TypedTypeConstructorExpr(owner, signature.functionType, name.span)
+                    case _ =>
+                      TypedName(name.path, signature.functionType, false, false, name.span)
                   callWithSignature(
-                    TypedName(name.path, signature.functionType, false, false, name.span),
+                    callee,
                     signature,
                     node.args,
                     node.span,
@@ -720,38 +715,18 @@ final class SourceTyper(
 
       val receiver = expr(select.receiver, scope, None, context)
       SourceType.dealias(receiver.expr.valueType) match
-        case owner @ SourceType.Standard(name, _) =>
-          standardGenerics.get(name).flatMap(_.method(select.field)) match
-            case Some(method) =>
-              val signature = method.instantiate(owner, select.span)
-              checkReceiverMutation(receiver, signature, select.span)
-              callWithSignature(
-                TypedSelect(receiver.expr, select.field, signature.functionType, false, false, select.span),
-                signature,
-                args,
-                span,
-                scope,
-                context,
-              )
-            case None =>
-              val selected = selectExpr(select, scope, context)
-              callFunctionValue(selected, args, span, scope, context)
-        case SourceType.Ref(owner @ SourceType.Standard(name, _), _) =>
-          standardGenerics.get(name).flatMap(_.method(select.field)) match
-            case Some(method) =>
-              val signature = method.instantiate(owner, select.span)
-              checkReceiverMutation(receiver, signature, select.span)
-              callWithSignature(
-                TypedSelect(receiver.expr, select.field, signature.functionType, false, false, select.span),
-                signature,
-                args,
-                span,
-                scope,
-                context,
-              )
-            case None =>
-              val selected = selectExpr(select, scope, context)
-              callFunctionValue(selected, args, span, scope, context)
+        case owner if descriptorMethod(owner, select.field, select.span).nonEmpty =>
+          val method = descriptorMethod(owner, select.field, select.span).get
+          val signature = method.instantiate(normalizeDescriptorOwner(owner), select.span)
+          checkReceiverMutation(receiver, signature, select.span)
+          callWithSignature(
+            TypedSelect(receiver.expr, select.field, signature.functionType, false, false, select.span),
+            signature,
+            args,
+            span,
+            scope,
+            context,
+          )
         case ty =>
           classInfoFor(ty) match
             case Some(cls) =>
@@ -1016,6 +991,7 @@ final class SourceTyper(
       val iter = expr(node.iter, scope, None, context)
       val itemType = SourceType.dealias(iter.expr.valueType) match
         case SourceType.Standard("Vec" | "Set" | "Arena", item :: Nil) => item
+        case SourceType.Standard("Map", key :: _ :: Nil)               => key
         case other =>
           error(
             "cosmo0.type.invalid-iterator",
@@ -1200,6 +1176,46 @@ final class SourceTyper(
         case SourceType.User(name) =>
           classes.get(name).flatMap(_.variants.get(variant)).map(_.signature(name))
         case _ => None
+
+    private def descriptorConstructor(
+        name: String,
+        span: SourceSpan,
+    ): Option[CallableSignature] =
+      descriptorOwner(name).flatMap(owner =>
+        standardGenerics.get(name).flatMap(_.constructor("<init>")).map(_.instantiate(owner, span)),
+      )
+
+    private def descriptorMethod(
+        ownerType: SourceType,
+        methodName: String,
+        span: SourceSpan,
+    ): Option[DescriptorCallable] =
+      val owner = normalizeDescriptorOwner(ownerType)
+      descriptorName(owner).flatMap(name =>
+        standardGenerics.get(name).filter(_.arity == descriptorArity(owner)).flatMap(_.method(methodName)),
+      )
+
+    private def descriptorOwner(name: String): Option[SourceType] =
+      standardGenerics.get(name).filter(_.arity == 0).flatMap { _ =>
+        SourceType.scalar(name)
+      }
+
+    private def normalizeDescriptorOwner(ownerType: SourceType): SourceType =
+      SourceType.dealias(ownerType) match
+        case SourceType.Ref(target, _) => SourceType.dealias(target)
+        case other                     => other
+
+    private def descriptorName(ownerType: SourceType): Option[String] =
+      normalizeDescriptorOwner(ownerType) match
+        case SourceType.Standard(name, _) => Some(name)
+        case SourceType.Builtin(name)     => Some(name)
+        case _                            => None
+
+    private def descriptorArity(ownerType: SourceType): Int =
+      normalizeDescriptorOwner(ownerType) match
+        case SourceType.Standard(_, args) => args.length
+        case SourceType.Builtin(_)        => 0
+        case _                            => -1
 
     private def classConstructor(
         name: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/SourceTypes.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/SourceTypes.scala
@@ -32,6 +32,7 @@ object SourceType:
   val I32: SourceType = Builtin("i32")
   val Usize: SourceType = Builtin("usize")
   val String: SourceType = Builtin("String")
+  val StringBuilder: SourceType = Builtin("StringBuilder")
   val Char: SourceType = Builtin("Char")
   val Byte: SourceType = Builtin("u8")
   val F64: SourceType = Builtin("f64")
@@ -53,6 +54,7 @@ object SourceType:
       "Byte" -> Byte,
       "Char" -> Char,
       "String" -> String,
+      "StringBuilder" -> StringBuilder,
       "str" -> String,
       "f32" -> Builtin("f32"),
       "f64" -> F64,
@@ -163,13 +165,17 @@ final case class DescriptorCallable(
     returnType: SourceTypeTemplate,
     receiverMutable: Boolean = false,
 ):
-  def instantiate(owner: SourceType.Standard, span: SourceSpan): CallableSignature =
+  def instantiate(owner: SourceType, span: SourceSpan): CallableSignature =
+    val typeArgs =
+      SourceType.dealias(owner) match
+        case SourceType.Standard(_, args) => args
+        case _                            => Nil
     CallableSignature(
       name,
       params.map(param =>
-        CallableParam(param.name, param.valueType.instantiate(owner.args), span),
+        CallableParam(param.name, param.valueType.instantiate(typeArgs), span),
       ),
-      returnType.instantiate(owner.args),
+      returnType.instantiate(typeArgs),
       Some(CallableReceiver(owner, receiverMutable)),
     )
 
@@ -191,8 +197,15 @@ object StandardGenericDescriptors:
   private val UnitT = SourceTypeTemplate.Concrete(SourceType.Unit)
   private val BoolT = SourceTypeTemplate.Concrete(SourceType.Bool)
   private val UsizeT = SourceTypeTemplate.Concrete(SourceType.Usize)
+  private val StringT = SourceTypeTemplate.Concrete(SourceType.String)
+  private val StringBuilderT = SourceTypeTemplate.Concrete(SourceType.StringBuilder)
+  private val CharT = SourceTypeTemplate.Concrete(SourceType.Char)
+  private val ByteT = SourceTypeTemplate.Concrete(SourceType.Byte)
 
   val all: Map[String, StandardGenericDescriptor] =
+    (standardGenericDescriptors ++ runtimeDescriptors).map(descriptor => descriptor.name -> descriptor).toMap
+
+  private def standardGenericDescriptors: List[StandardGenericDescriptor] =
     List(
       descriptor(
         "Vec",
@@ -203,6 +216,7 @@ object StandardGenericDescriptors:
           call("get", List(param("index", UsizeT)), T),
           call("set", List(param("index", UsizeT), param("value", T)), UnitT, receiverMutable = true),
           call("size", Nil, UsizeT),
+          call("len", Nil, UsizeT),
           call("is_empty", Nil, BoolT),
         ),
       ),
@@ -246,6 +260,14 @@ object StandardGenericDescriptors:
             List(param("id", SourceTypeTemplate.Standard("Id", List(T)))),
             SourceTypeTemplate.Ref(T, mutable = false),
           ),
+          call(
+            "get_mut",
+            List(param("id", SourceTypeTemplate.Standard("Id", List(T)))),
+            SourceTypeTemplate.Ref(T, mutable = true),
+            receiverMutable = true,
+          ),
+          call("size", Nil, UsizeT),
+          call("len", Nil, UsizeT),
         ),
       ),
       descriptor("Id", 1, constructors = Nil, methods = Nil),
@@ -263,6 +285,9 @@ object StandardGenericDescriptors:
           ),
           call("contains", List(param("key", T)), BoolT),
           call("contains_key", List(param("key", T)), BoolT),
+          call("size", Nil, UsizeT),
+          call("len", Nil, UsizeT),
+          call("is_empty", Nil, BoolT),
         ),
       ),
       descriptor(
@@ -272,6 +297,9 @@ object StandardGenericDescriptors:
         methods = List(
           call("insert", List(param("value", T)), UnitT, receiverMutable = true),
           call("contains", List(param("value", T)), BoolT),
+          call("size", Nil, UsizeT),
+          call("len", Nil, UsizeT),
+          call("is_empty", Nil, BoolT),
         ),
       ),
       descriptor(
@@ -294,14 +322,107 @@ object StandardGenericDescriptors:
         ),
         methods = List(
           call("get", Nil, SourceTypeTemplate.Ref(T, mutable = false)),
+          call("get_mut", Nil, SourceTypeTemplate.Ref(T, mutable = true), receiverMutable = true),
         ),
       ),
       descriptor("Ref", 1, constructors = Nil, methods = Nil),
       descriptor("RefMut", 1, constructors = Nil, methods = Nil),
-    ).map(descriptor => descriptor.name -> descriptor).toMap
+    )
+
+  private def runtimeDescriptors: List[StandardGenericDescriptor] =
+    List(
+      descriptor(
+        "Bool",
+        0,
+        constructors = Nil,
+        methods = List(
+          call("not", Nil, BoolT),
+          call("and", List(param("right", BoolT)), BoolT),
+          call("or", List(param("right", BoolT)), BoolT),
+          call("eq", List(param("right", BoolT)), BoolT),
+          call("ne", List(param("right", BoolT)), BoolT),
+        ),
+      ),
+      descriptor(
+        "Char",
+        0,
+        constructors = Nil,
+        methods = comparableMethods(CharT),
+      ),
+      descriptor(
+        "String",
+        0,
+        constructors = Nil,
+        methods = List(
+          call("size", Nil, UsizeT),
+          call("len", Nil, UsizeT),
+          call("is_empty", Nil, BoolT),
+          call("slice", List(param("start", UsizeT), param("end", UsizeT)), StringT),
+          call("char_at", List(param("index", UsizeT)), CharT),
+          call("byte_at", List(param("index", UsizeT)), ByteT),
+          call("concat", List(param("right", StringT)), StringT),
+          call("eq", List(param("right", StringT)), BoolT),
+          call("ne", List(param("right", StringT)), BoolT),
+        ),
+      ),
+      descriptor(
+        "StringBuilder",
+        0,
+        constructors = List(call("<init>", Nil, StringBuilderT)),
+        methods = List(
+          call("append", List(param("value", StringT)), UnitT, receiverMutable = true),
+          call("append_char", List(param("value", CharT)), UnitT, receiverMutable = true),
+          call("clear", Nil, UnitT, receiverMutable = true),
+          call("finish", Nil, StringT),
+        ),
+      ),
+    ) ++ numericDescriptors
+
+  private def numericDescriptors: List[StandardGenericDescriptor] =
+    List(
+      SourceType.Builtin("i8"),
+      SourceType.Builtin("i16"),
+      SourceType.I32,
+      SourceType.Builtin("i64"),
+      SourceType.Byte,
+      SourceType.Builtin("u16"),
+      SourceType.Builtin("u32"),
+      SourceType.Builtin("u64"),
+      SourceType.Usize,
+      SourceType.Builtin("f32"),
+      SourceType.F64,
+    ).map { valueType =>
+      val template = SourceTypeTemplate.Concrete(valueType)
+      descriptor(
+        valueType.display,
+        0,
+        constructors = Nil,
+        methods = numericMethods(template),
+      )
+    }
 
   def get(name: String): Option[StandardGenericDescriptor] =
     all.get(name)
+
+  private def numericMethods(valueType: SourceTypeTemplate): List[DescriptorCallable] =
+    List(
+      call("neg", Nil, valueType),
+      call("add", List(param("right", valueType)), valueType),
+      call("sub", List(param("right", valueType)), valueType),
+      call("mul", List(param("right", valueType)), valueType),
+      call("div", List(param("right", valueType)), valueType),
+      call("mod", List(param("right", valueType)), valueType),
+    ) ++ comparableMethods(valueType)
+
+  private def comparableMethods(valueType: SourceTypeTemplate): List[DescriptorCallable] =
+    List(
+      call("eq", List(param("right", valueType)), BoolT),
+      call("ne", List(param("right", valueType)), BoolT),
+      call("lt", List(param("right", valueType)), BoolT),
+      call("le", List(param("right", valueType)), BoolT),
+      call("gt", List(param("right", valueType)), BoolT),
+      call("ge", List(param("right", valueType)), BoolT),
+    )
 
   private def descriptor(
       name: String,

--- a/packages/cosmo0/src/test/scala/cosmo0/LirLowererTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/LirLowererTests.scala
@@ -110,14 +110,11 @@ class LirLowererTests extends munit.FunSuite:
       s"missing source typing diagnostic in ${result.diagnostics.map(_.code)}",
     )
 
-  test("lower reports unsupported typed constructs with source spans"):
+  test("lower reports unsupported non-control typed constructs with source spans"):
     val result = Cosmo0().lower(
-      """def choose(flag: Bool): i32 = {
-        |  if (flag) {
-        |    1
-        |  } else {
-        |    2
-        |  }
+      """def bump(): Unit = {
+        |  var count: i32 = 0;
+        |  count += 1
         |}
         |""".stripMargin,
     )
@@ -130,6 +127,282 @@ class LirLowererTests extends munit.FunSuite:
       s"missing lowering diagnostic in ${result.diagnostics.map(_.code)}",
     )
     assert(result.diagnostics.exists(_.span.nonEmpty))
+
+  test("lowers if expressions into checked branch and join blocks"):
+    val result = Cosmo0().lower(
+      """def choose(flag: Bool): i32 = {
+        |  if (flag) {
+        |    1
+        |  } else {
+        |    2
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+
+    val rendered = LirDebugRenderer.renderModule(result.value.get.lir)
+    assert(rendered.contains("cond_branch %flag ? ^if0_00_then : ^if0_01_else"))
+    assert(rendered.contains("assign %tmp0 = 1:i32"))
+    assert(rendered.contains("assign %tmp0 = 2:i32"))
+    assert(rendered.contains("^if0_02_join:\n      return %tmp0"))
+
+  test("lowers while, loop, break, continue, and descriptor-backed for loops"):
+    val result = Cosmo0().lower(
+      """def spin(keep: Bool): Unit = {
+        |  while (keep) {
+        |    continue
+        |  }
+        |}
+        |
+        |def once(): Unit = {
+        |  loop {
+        |    break
+        |  }
+        |}
+        |
+        |def each(items: Vec[i32]): Unit = {
+        |  for (item in items) {
+        |    item;
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+
+    val rendered = LirDebugRenderer.renderModule(result.value.get.lir)
+    assert(rendered.contains("cond_branch %keep ? ^while0_01_body : ^while0_03_exit"))
+    assert(rendered.contains("^while0_01_body:\n      branch ^while0_02_continue"))
+    assert(rendered.contains("^loop0_01_body:\n      branch ^loop0_03_exit"))
+    assert(rendered.contains("%tmp0 = descriptor Vec[i32]::iter_has_next(%items) -> Bool"))
+    assert(rendered.contains("%item = descriptor Vec[i32]::iter_next(%items) -> i32"))
+
+  test("lowers descriptor constructors and standard generic methods to intrinsics"):
+    val result = Cosmo0().lower(
+      """class Node {}
+        |
+        |def use(
+        |  set: Set[i32],
+        |  map: Map[String, i32],
+        |  arena: Arena[Node],
+        |  fallback: Node
+        |): Unit = {
+        |  val local = Vec[i32]();
+        |  local.push(1);
+        |  local.set(0, 2);
+        |  val item = local.get(0);
+        |  val count = local.size();
+        |  val length = local.len();
+        |  val previous = map.get("key");
+        |  map.insert("key", item);
+        |  set.insert(item);
+        |  val seen = set.contains(item);
+        |  val node_id = arena.alloc(fallback);
+        |  val node = arena.get(node_id);
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+
+    val rendered = LirDebugRenderer.renderModule(result.value.get.lir)
+    assert(rendered.contains("descriptor Vec[i32]::<init>() -> Vec[i32]"))
+    assert(rendered.contains("descriptor Vec[i32]::push(%local, 1:i32) -> Unit"))
+    assert(rendered.contains("descriptor Vec[i32]::set(%local, 0:usize, 2:i32) -> Unit"))
+    assert(rendered.contains("descriptor Vec[i32]::get(%local, 0:usize) -> i32"))
+    assert(rendered.contains("descriptor Vec[i32]::size(%local) -> usize"))
+    assert(rendered.contains("descriptor Vec[i32]::len(%local) -> usize"))
+    assert(rendered.contains("descriptor Map[String, i32]::get(%map, \"key\") -> Option[i32]"))
+    assert(rendered.contains("descriptor Map[String, i32]::insert(%map, \"key\", %item) -> Option[i32]"))
+    assert(rendered.contains("descriptor Set[i32]::insert(%set, %item) -> Unit"))
+    assert(rendered.contains("descriptor Set[i32]::contains(%set, %item) -> Bool"))
+    assert(rendered.contains("descriptor Arena[Node]::alloc(%arena, %fallback) -> Id[Node]"))
+    assert(rendered.contains("descriptor Arena[Node]::get(%arena, %node_id) -> &Node"))
+
+  test("lowers scalar, string, and string builder helpers to descriptor intrinsics"):
+    val result = Cosmo0().lower(
+      """def build_text(left: i32, right: i32, text: String): String = {
+        |  var builder = StringBuilder();
+        |  builder.append(text);
+        |  builder.append("!");
+        |  val sum = left + right;
+        |  if (sum > 0 and text.size() > 0) {
+        |    builder.finish()
+        |  } else {
+        |    "empty"
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+
+    val rendered = LirDebugRenderer.renderModule(result.value.get.lir)
+    assert(rendered.contains("descriptor StringBuilder::<init>() -> StringBuilder"))
+    assert(rendered.contains("descriptor StringBuilder::append(%builder, %text) -> Unit"))
+    assert(rendered.contains("descriptor StringBuilder::append(%builder, \"!\") -> Unit"))
+    assert(rendered.contains("descriptor i32::add(%left, %right) -> i32"))
+    assert(rendered.contains("descriptor i32::gt(%sum, 0:i32) -> Bool"))
+    assert(rendered.contains("descriptor String::size(%text) -> usize"))
+    assert(rendered.contains("descriptor usize::gt("))
+    assert(rendered.contains("descriptor Bool::and("))
+    assert(rendered.contains("descriptor StringBuilder::finish(%builder) -> String"))
+
+  test("lowers map and set for loops through deterministic descriptor iteration"):
+    val result = Cosmo0().lower(
+      """def walk(values: Map[String, i32], seen: Set[String]): Unit = {
+        |  for (key in values) {
+        |    key;
+        |  }
+        |  for (item in seen) {
+        |    item;
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+
+    val rendered = LirDebugRenderer.renderModule(result.value.get.lir)
+    assert(rendered.contains("descriptor Map[String, i32]::iter_has_next(%values) -> Bool"))
+    assert(rendered.contains("descriptor Map[String, i32]::iter_next(%values) -> String"))
+    assert(rendered.contains("descriptor Set[String]::iter_has_next(%seen) -> Bool"))
+    assert(rendered.contains("descriptor Set[String]::iter_next(%seen) -> String"))
+
+  test("lowers variant construction and match expressions into tag checks and payload reads"):
+    val result = Cosmo0().lower(
+      """def some(value: i32): Option[i32] = {
+        |  Option[i32]::Some(value)
+        |}
+        |
+        |def none(): Option[i32] = {
+        |  Option[i32]::None
+        |}
+        |
+        |def unpack(value: Option[i32]): i32 = {
+        |  value match {
+        |    case Option[i32]::Some(item) => {
+        |      item
+        |    }
+        |    case Option[i32]::None => {
+        |      0
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"lowering failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+
+    val rendered = LirDebugRenderer.renderModule(result.value.get.lir)
+    assert(rendered.contains("%tmp0 = variant Option[i32]::Some(%value)"))
+    assert(rendered.contains("%tmp0 = variant Option[i32]::None()"))
+    assert(rendered.contains("variant_is %value: Option[i32]::Some"))
+    assert(rendered.contains("variant_is %value: Option[i32]::None"))
+    assert(rendered.contains("%item = variant_payload %value.Some[0]: i32"))
+    assert(rendered.contains("^match0_90_join:\n      return %tmp0"))
+
+  test("lower reports invalid structured control-flow inputs"):
+    val invalidBreak = Cosmo0().lower("def bad(): Unit = { break }")
+    assertEquals(invalidBreak.phase, Phase.Compile)
+    assertEquals(invalidBreak.status, PhaseStatus.Failed)
+    assert(
+      invalidBreak.diagnostics.exists(_.code == "cosmo0.lir.lower.invalid-break"),
+      s"missing invalid break diagnostic in ${invalidBreak.diagnostics.map(_.code)}",
+    )
+
+    val branchMismatch = Cosmo0().lower(
+      """def bad(flag: Bool): i32 = {
+        |  if (flag) {
+        |    1
+        |  } else {
+        |    true
+        |  }
+        |}
+        |""".stripMargin,
+    )
+    assertEquals(branchMismatch.status, PhaseStatus.Failed)
+    assert(
+      branchMismatch.diagnostics.exists(_.code == "cosmo0.type.branch-mismatch"),
+      s"missing branch mismatch diagnostic in ${branchMismatch.diagnostics.map(_.code)}",
+    )
+
+    val invalidPayload = Cosmo0().lower(
+      """def bad(value: Option[i32]): i32 = {
+        |  value match {
+        |    case Option[i32]::Some(true) => {
+        |      1
+        |    }
+        |    case Option[i32]::None => {
+        |      0
+        |    }
+        |  }
+        |}
+        |""".stripMargin,
+    )
+    assertEquals(invalidPayload.status, PhaseStatus.Failed)
+    assert(
+      invalidPayload.diagnostics.exists(_.code == "cosmo0.type.invalid-match-payload"),
+      s"missing invalid payload diagnostic in ${invalidPayload.diagnostics.map(_.code)}",
+    )
+
+  test("lower reports unsupported descriptor operations that reach lowering"):
+    val source = SourceFile("<typed>", "")
+    val span = source.span(0, 0)
+    val idType = SourceType.Standard("Id", List(SourceType.I32))
+    val badFunction = TypedFunction(
+      "bad",
+      Nil,
+      idType,
+      Some(
+        TypedCall(
+          TypedTypeConstructorExpr(idType, SourceType.Function(Nil, idType), span),
+          Nil,
+          idType,
+          CallableSignature("<init>", Nil, idType),
+          span,
+        ),
+      ),
+      CallableSignature("bad", Nil, idType),
+      None,
+      span,
+    )
+    val module = TypedModule(source, List(badFunction), span)
+
+    val result = LirLowerer().lower(module)
+
+    assertEquals(result.phase, Phase.Compile)
+    assertEquals(result.status, PhaseStatus.Failed)
+    assert(
+      result.diagnostics.exists(_.code == "cosmo0.lir.lower.unsupported-descriptor"),
+      s"missing unsupported descriptor diagnostic in ${result.diagnostics.map(_.code)}",
+    )
 
   test("lowered output is checked before backend emission"):
     val source = SourceFile("<typed>", "")

--- a/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
@@ -12,6 +12,7 @@ class LirTests extends munit.FunSuite:
       rendered,
       """fn @process process(%input input: Token) -> i32 {
         |  local %count count: i32 mut
+        |  local %is_some is_some: Bool
         |  local %labels labels: Vec[String] mut
         |  local %maybe maybe: Option[Token]
         |  local %payload payload: Token
@@ -33,6 +34,7 @@ class LirTests extends munit.FunSuite:
         |    descriptor Vec[String]::push(%labels, "ok") -> Unit
         |    %maybe = variant Option[Token]::Some(%token)
         |    %tag = variant_tag %maybe: Option[Token]
+        |    %is_some = variant_is %maybe: Option[Token]::Some
         |    %payload = variant_payload %maybe.Some[0]: Token
         |    cond_branch true ? ^exit : ^error
         |  ^error:
@@ -226,6 +228,7 @@ class LirTests extends munit.FunSuite:
       Lir.local("token", tokenType, mutable = true),
       Lir.local("labels", stringVecType, mutable = true),
       Lir.local("maybe", optionTokenType),
+      Lir.local("is_some", SourceType.Bool),
       Lir.local("tag", SourceType.I32),
       Lir.local("payload", tokenType),
       Lir.local("tmp", SourceType.Usize),
@@ -279,6 +282,12 @@ class LirTests extends munit.FunSuite:
         Lir.localId("tag"),
         Lir.ref("maybe", optionTokenType),
         Lir.t(optionTokenType),
+      ),
+      LirCheckVariantTag(
+        Lir.localId("is_some"),
+        Lir.ref("maybe", optionTokenType),
+        Lir.t(optionTokenType),
+        "Some",
       ),
       LirReadVariantPayload(
         Lir.localId("payload"),
@@ -434,6 +443,7 @@ class LirTests extends munit.FunSuite:
       Lir.local("token", tokenType, mutable = true),
       Lir.local("labels", stringVecType, mutable = true),
       Lir.local("maybe", optionTokenType),
+      Lir.local("is_some", SourceType.Bool),
       Lir.local("tag", SourceType.I32),
       Lir.local("payload", tokenType),
       Lir.local("tmp", SourceType.Usize),
@@ -492,6 +502,12 @@ class LirTests extends munit.FunSuite:
             Lir.localId("tag"),
             Lir.ref("maybe", optionTokenType),
             Lir.t(optionTokenType),
+          ),
+          LirCheckVariantTag(
+            Lir.localId("is_some"),
+            Lir.ref("maybe", optionTokenType),
+            Lir.t(optionTokenType),
+            "Some",
           ),
           LirReadVariantPayload(
             Lir.localId("payload"),


### PR DESCRIPTION
## Summary
- lower structured control flow in cosmo0 into explicit LIR blocks and branches
- add LIR support for variant tag checks, loop control, and structured expression joins
- lower standard generics and runtime helpers through descriptor-backed intrinsics
- track mutation capability on locals, params, and globals so type checking matches lowered output

## Tests
- expand LIR lowerer coverage for `if`, `while`, `loop`, `break`, `continue`, `for`, variants, match, and descriptor calls
- update LIR rendering tests for variant tag checks and mutation metadata
- add negative coverage for invalid branch results, invalid loop control placement, and unsupported descriptor operations