### PR TITLE
Add cosmo0 spec docs skeleton

### DIFF
--- a/docs/cosmo0/class.typ
+++ b/docs/cosmo0/class.typ
@@ -1,0 +1,29 @@
+= cosmo0 Classes and Declarations
+
+== Status
+
+This file owns declaration forms accepted by cosmo0. The headings define review ownership; detailed declaration semantics are placeholders for later changes.
+
+== Class Subset
+
+Placeholder for non-generic class declarations, class bodies, member ordering, visibility, and the restrictions that keep cosmo0 classes suitable for bootstrap compilation.
+
+== Fields and Methods
+
+Placeholder for field declarations, method signatures, receiver forms, method bodies, and mutation permissions.
+
+== Constructors
+
+Placeholder for constructor availability, construction syntax, field initialization, and generated or descriptor-backed construction behavior.
+
+== Variants
+
+Placeholder for enum-style case variants, variant payloads, construction, tag checks, and matching support used by the bootstrap subset.
+
+== Imports and Visibility
+
+Placeholder for imports, public declarations, local names, package-level visibility, and any limits on importing implementation-only modules.
+
+== Rejected Declarations
+
+Placeholder for generic classes, generic functions, traits, impls, macros, decorators, and any other declaration forms not accepted by cosmo0.

--- a/docs/cosmo0/class.typ
+++ b/docs/cosmo0/class.typ
@@ -8,6 +8,46 @@ This file owns declaration forms accepted by cosmo0. The headings define review 
 
 Placeholder for non-generic class declarations, class bodies, member ordering, visibility, and the restrictions that keep cosmo0 classes suitable for bootstrap compilation.
 
+== Examples
+
+Accepted declaration shapes:
+
+```cos
+class Diagnostic {
+  val span: Span
+  val message: String
+}
+
+class TokenKind {
+  case Ident
+  case Number
+  case Eof
+}
+
+class Cursor {
+  var offset: usize
+
+  def advance(&mut self): Unit = {
+    self.offset = self.offset + 1
+  }
+}
+```
+
+Rejected declaration shapes until later specs admit them:
+
+```cos
+trait Render {
+  def render(&self): String
+}
+
+class Pair[L, R] {
+  val left: L
+  val right: R
+}
+```
+
+The accepted example shows concrete classes, enum-style variants, a mutable field, and a mutable receiver. The rejected example shows trait and generic class declarations outside the initial subset.
+
 == Fields and Methods
 
 Placeholder for field declarations, method signatures, receiver forms, method bodies, and mutation permissions.

--- a/docs/cosmo0/control-flow.typ
+++ b/docs/cosmo0/control-flow.typ
@@ -1,0 +1,29 @@
+= cosmo0 Control Flow
+
+== Status
+
+This file owns branch, loop, and return forms for cosmo0. The section headings are initial ownership markers.
+
+== Blocks and Sequencing
+
+Placeholder for ordered execution, scope creation, expression statements, and statement/result boundaries.
+
+== If and Else
+
+Placeholder for condition typing, branch typing, required else behavior, and diagnostics for unsupported conditional forms.
+
+== Loops
+
+Placeholder for accepted `loop` and `while` forms, loop body typing, and loop-result restrictions.
+
+== For Iteration
+
+Placeholder for `for` iteration over explicitly supported standard iterable APIs. Iteration over undocumented types is rejected even if an implementation could lower it.
+
+== Break, Continue, and Return
+
+Placeholder for control-transfer validity, target resolution, return typing, and unreachable-code policy.
+
+== Rejected Control Flow
+
+Placeholder for generators, coroutines, async control flow, non-local exits, and other full-language forms outside cosmo0.

--- a/docs/cosmo0/control-flow.typ
+++ b/docs/cosmo0/control-flow.typ
@@ -8,6 +8,44 @@ This file owns branch, loop, and return forms for cosmo0. The section headings a
 
 Placeholder for ordered execution, scope creation, expression statements, and statement/result boundaries.
 
+== Examples
+
+Accepted control-flow shape:
+
+```cos
+def find_eof(tokens: Vec<Token>): usize = {
+  var i: usize = 0
+  while i < tokens.len() {
+    val token = tokens.get(i)
+    if token.kind == TokenKind.Eof {
+      return i
+    }
+    i = i + 1
+  }
+  return tokens.len()
+}
+```
+
+Candidate `for` shape once the owning standard API explicitly admits `Vec<T>` iteration:
+
+```cos
+for token in tokens {
+  if token.kind == TokenKind.Eof {
+    return token.span.start
+  }
+}
+```
+
+Rejected control-flow shape until later specs admit it:
+
+```cos
+async def read_tokens(path: Path): Vec<Token> = {
+  await Fs.read_to_string(path)
+}
+```
+
+The accepted example uses local mutation, `while`, `if`, and `return`. The `for` example is intentionally labeled as capability-dependent because iteration is accepted only for documented standard iterable APIs.
+
 == If and Else
 
 Placeholder for condition typing, branch typing, required else behavior, and diagnostics for unsupported conditional forms.

--- a/docs/cosmo0/expr.typ
+++ b/docs/cosmo0/expr.typ
@@ -1,0 +1,33 @@
+= cosmo0 Expressions
+
+== Status
+
+This file owns expression typing and expression validity for cosmo0. The headings are the initial skeleton; later capability changes fill the rules.
+
+== Literals
+
+Placeholder for accepted unit, boolean, integer, numeric-text, string, byte, char, and aggregate literal behavior.
+
+== Names and Selection
+
+Placeholder for local names, fields, methods, module-qualified names, standard API names, and rejected lookup forms.
+
+== Calls and Construction
+
+Placeholder for function calls, method calls, constructors, variant construction, standard API calls, and call diagnostics.
+
+== Assignment and Mutation
+
+Placeholder for local assignment, field assignment, mutable reference updates, and mutable standard API operations.
+
+== Blocks
+
+Placeholder for block expression typing, sequencing, statement results, local scope, and return-value rules.
+
+== Matches
+
+Placeholder for match expressions over primitive values and supported variants, including wildcard handling and later exhaustiveness policy.
+
+== Rejected Expressions
+
+Placeholder for lambdas, closures, type-level expressions, macros, quotation, reflection, staging, and other full-language expressions outside cosmo0.

--- a/docs/cosmo0/expr.typ
+++ b/docs/cosmo0/expr.typ
@@ -8,6 +8,31 @@ This file owns expression typing and expression validity for cosmo0. The heading
 
 Placeholder for accepted unit, boolean, integer, numeric-text, string, byte, char, and aggregate literal behavior.
 
+== Examples
+
+Accepted expression shapes:
+
+```cos
+val at_end: Bool = cursor.offset == source.len()
+val first: Option<Char> = source.get(0)
+val token = Token(TokenKind.Ident, span, "name")
+
+val tag = token.kind match {
+  case TokenKind.Eof => 0
+  case _ => 1
+}
+```
+
+Rejected expression shapes until later specs admit them:
+
+```cos
+val inc = (x: i32) => x + 1
+val quoted = quote { cursor.offset }
+val lifted = Type(1)
+```
+
+The accepted example uses literals, selection, calls, construction, and a simple match. The rejected example uses a lambda, quotation, and type-level lifting.
+
 == Names and Selection
 
 Placeholder for local names, fields, methods, module-qualified names, standard API names, and rejected lookup forms.

--- a/docs/cosmo0/package.typ
+++ b/docs/cosmo0/package.typ
@@ -8,6 +8,36 @@ This file owns package metadata, source loading, import graphs, module ordering,
 
 Placeholder for package manifest fields, target selection, source-root configuration, and diagnostics for invalid package metadata.
 
+== Examples
+
+Minimal package metadata shape:
+
+```json
+{
+  "name": "cosmo1-stage1-smoke",
+  "version": "0.0.0",
+  "target": "cosmo0",
+  "root": "src"
+}
+```
+
+Source-loading shape for a first-stage package:
+
+```text
+src/source.cos
+src/token.cos
+src/lexer.cos
+```
+
+Import shape that should resolve within the package graph:
+
+```cos
+import source.SourceText
+import token.Token
+```
+
+The exact metadata schema remains a placeholder, but examples show the intended target boundary: a cosmo0 package declares its bootstrap target, discovers source files under a stable root, and resolves imports deterministically.
+
 == Imports and Source Loading
 
 Placeholder for source discovery, import resolution, package-relative module paths, filesystem API dependencies, and source text ownership.

--- a/docs/cosmo0/package.typ
+++ b/docs/cosmo0/package.typ
@@ -1,0 +1,27 @@
+= cosmo0 Packages and Stage Validation
+
+== Status
+
+This file owns package metadata, source loading, import graphs, module ordering, and staged validation behavior for cosmo0.
+
+== Package Metadata
+
+Placeholder for package manifest fields, target selection, source-root configuration, and diagnostics for invalid package metadata.
+
+== Imports and Source Loading
+
+Placeholder for source discovery, import resolution, package-relative module paths, filesystem API dependencies, and source text ownership.
+
+== Module Ordering
+
+Placeholder for deterministic module ordering, import-cycle diagnostics, and package-level check or compile sequencing.
+
+== Stage Validation
+
+Placeholder for validating cosmo1 compiler stages through cosmo0-compiled code. Stage validation should name the required standard and runtime capabilities rather than assuming full Cosmo availability.
+
+== Stage 1 Capability Profile
+
+The Stage 1 package placeholder covers source-file loading, module discovery for the first validation package, stable diagnostic inputs, and deterministic smoke output. Exact acceptance tests are tracked by the OpenSpec change `validate-cosmo1-stage1-through-cosmo0`.
+
+This file will be updated when Stage 1 validation needs package metadata, multi-file loading, or source-root behavior beyond the current placeholder.

--- a/docs/cosmo0/runtime.typ
+++ b/docs/cosmo0/runtime.typ
@@ -1,0 +1,25 @@
+= cosmo0 Runtime and Backend
+
+== Status
+
+This file owns runtime and backend requirements behind cosmo0 source behavior. The headings define initial ownership; detailed runtime contracts are placeholders.
+
+== Primitive Descriptors
+
+Placeholder for descriptor families that implement primitive, standard, or staged runtime behavior. Descriptors are implementation mechanisms unless a source-facing API is specified in `std.typ`.
+
+== Extern ABI Hooks
+
+Placeholder for extern function binding, ABI naming, ownership, error reporting, and restrictions needed by standard APIs.
+
+== Backend Runtime Requirements
+
+Placeholder for runtime support emitted by the C++ backend, including helper declarations, deterministic inclusion, standard container lowering, and unsupported-runtime diagnostics.
+
+== Determinism
+
+Placeholder for stable output ordering, unique runtime support emission, and deterministic behavior across repeated package compiles.
+
+== Descriptor Transition Notes
+
+When a standard API is temporarily descriptor-backed, this file should describe only the backend/runtime obligations. Public API shape and source semantics still belong to `std.typ` and the relevant language owner file.

--- a/docs/cosmo0/runtime.typ
+++ b/docs/cosmo0/runtime.typ
@@ -8,6 +8,28 @@ This file owns runtime and backend requirements behind cosmo0 source behavior. T
 
 Placeholder for descriptor families that implement primitive, standard, or staged runtime behavior. Descriptors are implementation mechanisms unless a source-facing API is specified in `std.typ`.
 
+== Examples
+
+Source-facing call:
+
+```cos
+tokens.push(token)
+```
+
+Possible lowered runtime operation:
+
+```text
+descriptor Vec<Token>::push(%tokens, %token) -> Unit
+```
+
+Extern-backed standard API shape:
+
+```cos
+extern "cosmo0" def fs_read_to_string(path: Path): Result<String, IoError>
+```
+
+The source-facing call belongs to `std.typ` and expression/type owner files. This file owns the lowered descriptor or extern obligations needed to make that call deterministic and portable.
+
 == Extern ABI Hooks
 
 Placeholder for extern function binding, ABI naming, ownership, error reporting, and restrictions needed by standard APIs.

--- a/docs/cosmo0/spec.typ
+++ b/docs/cosmo0/spec.typ
@@ -1,0 +1,52 @@
+= cosmo0 Specification
+
+== Status
+
+This skeleton is the review entry point for the cosmo0 language and runtime model. The subset boundary, document ownership, conformance overview, and sync policy links are normative now. Detailed behavior sections that point to later capability work are placeholders until a future OpenSpec change fills them.
+
+== Subset Boundary
+
+cosmo0 is the bootstrap subset used to compile staged cosmo1 compiler components and the core0 support surface. A conforming cosmo0 implementation accepts only source constructs, standard APIs, runtime hooks, and package behaviors described by this document set or by an accepted OpenSpec change that updates this document set.
+
+The subset is intentionally smaller than full Cosmo. User-defined generic programming, trait solving, type-level evaluation, reflection, staging macros, broad parser-combinator APIs, and arbitrary full-language features are outside cosmo0 until a later spec file admits them.
+
+Source-facing behavior is specified by the `docs/cosmo0/` files. Compiler descriptors, backend intrinsics, and extern hooks are implementation mechanisms unless `runtime.typ` says they are visible capability behavior.
+
+== Document Ownership
+
+- `spec.typ` owns the index, subset boundary, conformance overview, and cross-document policy.
+- `type.typ` owns primitive types, references, aliases, and standard type application.
+- `class.typ` owns class, field, method, constructor, and variant subset rules.
+- `expr.typ` owns expression typing and literal, call, selection, match, and mutation rules.
+- `control-flow.typ` owns accepted branch, loop, and return forms.
+- `std.typ` owns core0 standard interfaces and capability identifiers.
+- `runtime.typ` owns primitive descriptors, extern ABI hooks, and backend runtime requirements.
+- `package.typ` owns package metadata, imports, source loading, module ordering, and stage validation.
+- `testing.typ` owns positive, negative, deterministic, and bug regression test policy.
+
+== Conformance Overview
+
+A cosmo0 implementation conforms to this skeleton when it:
+
+- rejects source outside the documented subset before relying on lowering or backend behavior;
+- reports unsupported constructs with diagnostics that identify the rejected feature area;
+- keeps public source behavior stable through the owning `docs/cosmo0/` file;
+- keeps generated package, module, and runtime output deterministic for repeated inputs;
+- updates specs and regression tests when a bug fix changes intended behavior.
+
+Detailed acceptance criteria for each behavior area belong in the owning file named above. Until such criteria are written, the implementation must not treat an undocumented behavior as a cosmo1 bootstrap requirement.
+
+== Stage 1 Capability Profile
+
+The Stage 1 profile is a placeholder for the source, span, diagnostic, token, lexing, and minimal support APIs needed by cosmo1's first executable compiler slice. The profile will be filled by staged capability changes and is cross-referenced by the OpenSpec change `validate-cosmo1-stage1-through-cosmo0`.
+
+For now, Stage 1 capability ownership is split across:
+
+- `std.typ` for standard API capability identifiers;
+- `runtime.typ` for backend and extern support behind those APIs;
+- `package.typ` for source loading and stage validation expectations;
+- `testing.typ` for acceptance, regression, and sync checks.
+
+== Sync Policy
+
+Bug fixes and staged runtime proposals must follow the policy in `testing.typ`. Future descriptor or standard API proposals must name the changed `docs/cosmo0/` files, or explicitly justify why the change is implementation-only.

--- a/docs/cosmo0/spec.typ
+++ b/docs/cosmo0/spec.typ
@@ -12,6 +12,34 @@ The subset is intentionally smaller than full Cosmo. User-defined generic progra
 
 Source-facing behavior is specified by the `docs/cosmo0/` files. Compiler descriptors, backend intrinsics, and extern hooks are implementation mechanisms unless `runtime.typ` says they are visible capability behavior.
 
+== Examples
+
+Accepted shape for a small bootstrap data type:
+
+```cos
+class Span {
+  val start: usize
+  val end: usize
+}
+
+class Token {
+  val span: Span
+  val text: String
+}
+
+def is_empty(span: Span): Bool = span.start == span.end
+```
+
+Rejected shape until later specs admit user-defined generics and function values:
+
+```cos
+def map_tokens[T](tokens: Vec<Token>, f: Token => T): Vec<T> = {
+  tokens.map(f)
+}
+```
+
+The accepted example is intentionally simple: it uses concrete classes, fields, primitive and standard types, and a non-generic function. The rejected example crosses multiple full-language boundaries at once.
+
 == Document Ownership
 
 - `spec.typ` owns the index, subset boundary, conformance overview, and cross-document policy.

--- a/docs/cosmo0/std.typ
+++ b/docs/cosmo0/std.typ
@@ -8,6 +8,29 @@ This file owns source-facing core0 standard APIs and capability identifiers. The
 
 Standard APIs are the public surface available to cosmo0 source. A backend descriptor, lowered intrinsic, or extern binding may implement a standard API, but the public behavior belongs here and in the related type, expression, runtime, and package files.
 
+== Examples
+
+Placeholder Stage 1 source-facing shape:
+
+```cos
+import core0.text.SourceText
+import core0.result.Result
+
+def load_source(path: Path): Result<SourceText, IoError> = {
+  val text = Fs.read_to_string(path)
+  SourceText.from_string(text)
+}
+```
+
+Implementation detail that should not become source-facing API:
+
+```text
+descriptor String::len(%source_text) -> usize
+descriptor Vec<Token>::push(%tokens, %token) -> Unit
+```
+
+The first example is a shape for future API proposals to refine. The second example names internal descriptor-style operations that may implement standard APIs but should not be the public dependency of cosmo1 source.
+
 == Capability Identifiers
 
 Placeholder for stable core0 capability identifiers such as text, collections, results, arena identifiers, paths, filesystem access, command execution, JSON bridges, numeric literal helpers, deterministic output, and other staged runtime surfaces.

--- a/docs/cosmo0/std.typ
+++ b/docs/cosmo0/std.typ
@@ -1,0 +1,38 @@
+= cosmo0 Standard APIs
+
+== Status
+
+This file owns source-facing core0 standard APIs and capability identifiers. The policy and Stage 1 placeholder are normative now. Specific API signatures are placeholders until later changes add them.
+
+== Ownership
+
+Standard APIs are the public surface available to cosmo0 source. A backend descriptor, lowered intrinsic, or extern binding may implement a standard API, but the public behavior belongs here and in the related type, expression, runtime, and package files.
+
+== Capability Identifiers
+
+Placeholder for stable core0 capability identifiers such as text, collections, results, arena identifiers, paths, filesystem access, command execution, JSON bridges, numeric literal helpers, deterministic output, and other staged runtime surfaces.
+
+Capability identifiers should be named at the smallest useful boundary so Stage 1 can depend on a narrow set without inheriting later compiler features.
+
+== Stage 1 Capability Profile
+
+The Stage 1 profile is a placeholder for APIs needed by source loading, spans, diagnostics, token definitions, and lexing. The profile is intentionally incomplete until staged changes add exact signatures and tests.
+
+The validation plan for Stage 1 is tracked by the OpenSpec change `validate-cosmo1-stage1-through-cosmo0`. Proposals that fill this profile must update this file and the behavior-specific owner files they affect.
+
+== Descriptor-Backed Transition Policy
+
+Descriptor-backed implementation support is transitional unless a standard API explicitly exposes it. Source code should depend on standard capability identifiers, not on descriptor registry details.
+
+Future descriptor/std proposals must name each changed `docs/cosmo0/` file in their design, tasks, or proposal text. If a change only moves implementation internals and does not alter source-facing behavior, it must say that it is implementation-only and explain why no `docs/cosmo0/` file changes.
+
+== Placeholder API Areas
+
+- Text and byte-oriented source access.
+- Collections and fallible result types.
+- Diagnostics, spans, and deterministic output sinks.
+- Paths and source-file loading.
+- JSON and package metadata bridges.
+- Numeric literal preservation and later big-number support.
+- Arena and identifier helpers.
+- Command execution and build integration for later stages.

--- a/docs/cosmo0/testing.typ
+++ b/docs/cosmo0/testing.typ
@@ -8,6 +8,35 @@ This file owns testing policy for the cosmo0 model. The bug/spec sync rule and s
 
 Placeholder for accepted source examples that prove documented cosmo0 behavior works through the intended pipeline.
 
+== Examples
+
+Positive test shape:
+
+```cos
+class Span {
+  val start: usize
+  val end: usize
+}
+
+def empty(span: Span): Bool = span.start == span.end
+```
+
+Negative test shape:
+
+```cos
+def id[T](value: T): T = value
+```
+
+Bug regression checklist shape:
+
+```text
+1. Add the smallest source case that reproduces the bug.
+2. Assert the expected diagnostic or successful output.
+3. Update the owning docs/cosmo0/*.typ file if intended behavior changed.
+```
+
+The positive example should compile once its owning language sections are fully specified. The negative example should be rejected because user-defined generic functions are outside the initial cosmo0 subset.
+
 == Negative Tests
 
 Placeholder for unsupported syntax, type, declaration, expression, control-flow, runtime, and package cases that must be rejected with diagnostics.

--- a/docs/cosmo0/testing.typ
+++ b/docs/cosmo0/testing.typ
@@ -1,0 +1,45 @@
+= cosmo0 Testing and Spec Sync
+
+== Status
+
+This file owns testing policy for the cosmo0 model. The bug/spec sync rule and spec impact review rule are normative now. Concrete test matrices are placeholders until later implementation changes add behavior-specific tests.
+
+== Positive Tests
+
+Placeholder for accepted source examples that prove documented cosmo0 behavior works through the intended pipeline.
+
+== Negative Tests
+
+Placeholder for unsupported syntax, type, declaration, expression, control-flow, runtime, and package cases that must be rejected with diagnostics.
+
+== Determinism Tests
+
+Placeholder for package ordering, runtime support emission, generated code, and diagnostic stability checks.
+
+== Bug Regression Tests
+
+Placeholder for tests added with bug fixes. A regression test should capture the smallest source or model case that would fail if the bug returned.
+
+== Bug/spec Sync Rule
+
+When implementation behavior conflicts with the current cosmo0 docs, first decide whether the implementation or the docs are wrong.
+
+If the implementation is wrong, the fix must add or update a regression test and leave the owning `docs/cosmo0/` file unchanged except for clarifying text.
+
+If the intended behavior is missing or wrong in the docs, the same change must update the owning `docs/cosmo0/` file before cosmo1 source or staged runtime work relies on that behavior. The change must also add tests proving the documented behavior.
+
+Undocumented implementation behavior must not become a cosmo1 bootstrap dependency just because the current compiler accepts it.
+
+== Spec Impact Review Rule
+
+Future descriptor/std proposals must name each changed `docs/cosmo0/` file, or explicitly justify implementation-only status. This applies to descriptor registry changes, standard API changes, extern/runtime hooks, package behavior, and Stage 1 capability updates.
+
+Reviewers should check the proposal, design, and task list for a concrete spec impact statement before accepting staged runtime work. Acceptable statements include a list of updated files such as `docs/cosmo0/std.typ` and `docs/cosmo0/runtime.typ`, or an implementation-only justification that says no source-facing behavior changed.
+
+== Lightweight Skeleton Validation
+
+The lightweight validation command is `node scripts/validateCosmo0Docs.js`. It checks that required `docs/cosmo0/` files exist, that the Stage 1 and sync policy placeholders are present, and that active staged runtime proposals reference their spec impact or implementation-only status.
+
+== Staged Runtime Proposal Guidance
+
+A staged runtime proposal is review-ready only when its tasks show how the spec impact will be validated. That proof can be a docs-only check, a targeted compiler test, or a clear review step tied to the affected `docs/cosmo0/` file.

--- a/docs/cosmo0/type.typ
+++ b/docs/cosmo0/type.typ
@@ -1,0 +1,27 @@
+= cosmo0 Types
+
+== Status
+
+This file is the owner for cosmo0 type syntax and type validity. Section headings are normative ownership markers. Detailed rules are placeholders unless marked otherwise by later OpenSpec changes.
+
+== Primitive Types
+
+Placeholder for scalar and built-in value types accepted by cosmo0, including unit, booleans, integer widths, sizes, bytes, chars, strings, and any other primitive forms admitted by future capability work.
+
+== Reference and Mutability Types
+
+Placeholder for immutable references, mutable references, receiver forms, mutable locals, mutable fields, and the type rules that govern mutation through references.
+
+== Type Aliases
+
+Placeholder for simple type aliases and the limits on alias expansion. User-defined type-level functions and dependent type computation remain outside the subset until explicitly specified.
+
+== Standard Type Application
+
+Placeholder for sealed standard type constructors such as collections, results, arena identifiers, paths, text helpers, and other core0 APIs named by `std.typ`.
+
+Standard type application is source-facing behavior. Temporary descriptor-backed lowering may implement it, but descriptor names do not become public type syntax unless this file or `std.typ` says so.
+
+== Rejected Type Forms
+
+Placeholder for diagnostics covering user-defined generics, trait constraints, higher-kinded types, compile-time type parameters, reflection types, and other full-language type forms that cosmo0 does not accept.

--- a/docs/cosmo0/type.typ
+++ b/docs/cosmo0/type.typ
@@ -8,6 +8,33 @@ This file is the owner for cosmo0 type syntax and type validity. Section heading
 
 Placeholder for scalar and built-in value types accepted by cosmo0, including unit, booleans, integer widths, sizes, bytes, chars, strings, and any other primitive forms admitted by future capability work.
 
+== Examples
+
+Accepted type shapes:
+
+```cos
+type TokenId = Id<Token>
+
+class TokenBuffer {
+  val source: String
+  var tokens: Vec<Token>
+}
+
+def token_text(token: &Token): &String = &token.text
+```
+
+Rejected type shapes until later specs admit them:
+
+```cos
+class Box[T] {
+  val value: T
+}
+
+def IdOf(T: Type) = Id<T>
+```
+
+The accepted example uses a simple alias, concrete standard type application, and an immutable reference. The rejected example uses a user-defined generic class and a type-level function.
+
 == Reference and Mutability Types
 
 Placeholder for immutable references, mutable references, receiver forms, mutable locals, mutable fields, and the type rules that govern mutation through references.

--- a/openspec/changes/model-cosmo0-spec-docs/specs/cosmo0-spec-docs/spec.md
+++ b/openspec/changes/model-cosmo0-spec-docs/specs/cosmo0-spec-docs/spec.md
@@ -14,6 +14,11 @@ The repository SHALL maintain a `docs/cosmo0/` specification skeleton covering t
 - **WHEN** a future cosmo0 change alters source-facing behavior
 - **THEN** reviewers can identify the owning `docs/cosmo0/` file for the affected behavior area
 
+#### Scenario: Boundary examples are present
+
+- **WHEN** reviewers inspect the cosmo0 docs skeleton
+- **THEN** each required `docs/cosmo0/` file includes examples that illustrate accepted, rejected, or placeholder behavior shapes
+
 ### Requirement: cosmo0 Bug Spec Synchronization
 
 The cosmo0 docs SHALL define a bug/spec sync policy requiring behavior-changing fixes to update regression tests and, when intended semantics change, the owning spec file.

--- a/openspec/changes/model-cosmo0-spec-docs/specs/cosmo0-spec-docs/spec.md
+++ b/openspec/changes/model-cosmo0-spec-docs/specs/cosmo0-spec-docs/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: cosmo0 Spec Document Skeleton
+
+The repository SHALL maintain a `docs/cosmo0/` specification skeleton covering the cosmo0 subset boundary, type system, declarations, expressions, control flow, standard APIs, runtime hooks, package behavior, and testing policy.
+
+#### Scenario: Required skeleton files exist
+
+- **WHEN** the cosmo0 docs skeleton validation runs
+- **THEN** `docs/cosmo0/spec.typ`, `type.typ`, `class.typ`, `expr.typ`, `control-flow.typ`, `std.typ`, `runtime.typ`, `package.typ`, and `testing.typ` exist
+
+#### Scenario: Ownership is reviewable
+
+- **WHEN** a future cosmo0 change alters source-facing behavior
+- **THEN** reviewers can identify the owning `docs/cosmo0/` file for the affected behavior area
+
+### Requirement: cosmo0 Bug Spec Synchronization
+
+The cosmo0 docs SHALL define a bug/spec sync policy requiring behavior-changing fixes to update regression tests and, when intended semantics change, the owning spec file.
+
+#### Scenario: Bug fix changes intended behavior
+
+- **WHEN** a compiler bug fix changes intended cosmo0 behavior
+- **THEN** the same change updates the owning `docs/cosmo0/` file and adds regression coverage
+
+#### Scenario: Bug fix restores documented behavior
+
+- **WHEN** a compiler bug fix restores behavior already documented by `docs/cosmo0/`
+- **THEN** the same change adds regression coverage without treating the previous implementation behavior as authoritative
+
+### Requirement: Stage 1 Capability Profile Placeholder
+
+The cosmo0 docs SHALL include a Stage 1 capability profile placeholder for later source loading, diagnostics, token, lexing, standard API, runtime, and package validation requirements.
+
+#### Scenario: Stage 1 validation is cross-referenced
+
+- **WHEN** reviewers inspect the Stage 1 placeholder
+- **THEN** it references the OpenSpec change `validate-cosmo1-stage1-through-cosmo0`
+
+#### Scenario: Stage 1 capability ownership is clear
+
+- **WHEN** a later proposal fills a Stage 1 capability
+- **THEN** the proposal can update the relevant owner files under `docs/cosmo0/`
+
+### Requirement: Staged Runtime Spec Impact Validation
+
+The repository SHALL provide lightweight validation or review guidance proving staged runtime proposals reference their cosmo0 spec impact.
+
+#### Scenario: Skeleton validation checks docs and staged proposals
+
+- **WHEN** the lightweight cosmo0 docs validation runs
+- **THEN** it checks that required docs exist and that active staged runtime proposals reference changed `docs/cosmo0/` files or justify implementation-only status
+
+#### Scenario: Descriptor or std proposal is reviewed
+
+- **WHEN** a future descriptor/std proposal changes source-facing behavior
+- **THEN** the proposal names the changed `docs/cosmo0/` files before relying on that behavior from cosmo1 source

--- a/openspec/changes/model-cosmo0-spec-docs/tasks.md
+++ b/openspec/changes/model-cosmo0-spec-docs/tasks.md
@@ -18,3 +18,8 @@
 
 - [x] 4.1 Add a lightweight validation that required `docs/cosmo0/` files exist.
 - [x] 4.2 Add review or test guidance proving staged runtime proposals reference their spec impact.
+
+## 5. Examples
+
+- [x] 5.1 Add boundary examples to each required `docs/cosmo0/` file.
+- [x] 5.2 Extend lightweight validation to require example sections and fenced example blocks.

--- a/openspec/changes/model-cosmo0-spec-docs/tasks.md
+++ b/openspec/changes/model-cosmo0-spec-docs/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Spec Skeleton
 
-- [ ] 1.1 Create `docs/cosmo0/spec.typ` with the cosmo0 subset boundary and conformance overview.
-- [ ] 1.2 Create `docs/cosmo0/type.typ`, `class.typ`, `expr.typ`, and `control-flow.typ` with initial section headings.
-- [ ] 1.3 Create `docs/cosmo0/std.typ`, `runtime.typ`, `package.typ`, and `testing.typ` with initial section headings.
+- [x] 1.1 Create `docs/cosmo0/spec.typ` with the cosmo0 subset boundary and conformance overview.
+- [x] 1.2 Create `docs/cosmo0/type.typ`, `class.typ`, `expr.typ`, and `control-flow.typ` with initial section headings.
+- [x] 1.3 Create `docs/cosmo0/std.typ`, `runtime.typ`, `package.typ`, and `testing.typ` with initial section headings.
 
 ## 2. Sync Policy
 
-- [ ] 2.1 Document the bug/spec sync rule in `docs/cosmo0/testing.typ`.
-- [ ] 2.2 Document that future descriptor/std proposals must name changed spec files or justify implementation-only status.
+- [x] 2.1 Document the bug/spec sync rule in `docs/cosmo0/testing.typ`.
+- [x] 2.2 Document that future descriptor/std proposals must name changed spec files or justify implementation-only status.
 
 ## 3. Stage 1 Scaffolding
 
-- [ ] 3.1 Add a Stage 1 capability profile placeholder to the relevant cosmo0 docs.
-- [ ] 3.2 Cross-reference `validate-cosmo1-stage1-through-cosmo0` from the Stage 1 profile placeholder.
+- [x] 3.1 Add a Stage 1 capability profile placeholder to the relevant cosmo0 docs.
+- [x] 3.2 Cross-reference `validate-cosmo1-stage1-through-cosmo0` from the Stage 1 profile placeholder.
 
 ## 4. Tests
 
-- [ ] 4.1 Add a lightweight validation that required `docs/cosmo0/` files exist.
-- [ ] 4.2 Add review or test guidance proving staged runtime proposals reference their spec impact.
+- [x] 4.1 Add a lightweight validation that required `docs/cosmo0/` files exist.
+- [x] 4.2 Add review or test guidance proving staged runtime proposals reference their spec impact.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "watch:test": "sbt ~test",
     "compile:dev": "sbt fastLinkJS",
     "cosmo": "node ./cmd/cosmo/main.js",
+    "validate:cosmo0-docs": "node scripts/validateCosmo0Docs.js",
     "docs": "shiroa serve --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ -w . docs/cosmo",
     "build:syntax": "cd editors/vscode && yarn build:syntax",
     "build:vscode": "cd editors/vscode && yarn build:syntax && yarn package",

--- a/scripts/validateCosmo0Docs.js
+++ b/scripts/validateCosmo0Docs.js
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync, readdirSync } from 'fs'
+import { join } from 'path'
+
+const requiredDocs = [
+  'spec.typ',
+  'type.typ',
+  'class.typ',
+  'expr.typ',
+  'control-flow.typ',
+  'std.typ',
+  'runtime.typ',
+  'package.typ',
+  'testing.typ',
+]
+
+const docRoot = join('docs', 'cosmo0')
+const errors = []
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+function requireFile(path) {
+  if (!existsSync(path)) {
+    errors.push(`missing required file: ${path}`)
+    return false
+  }
+  return true
+}
+
+for (const file of requiredDocs) {
+  requireFile(join(docRoot, file))
+}
+
+const requiredSnippets = new Map([
+  [
+    'spec.typ',
+    [
+      'Subset Boundary',
+      'Conformance Overview',
+      'Stage 1 Capability Profile',
+      'validate-cosmo1-stage1-through-cosmo0',
+    ],
+  ],
+  [
+    'std.typ',
+    [
+      'Capability Identifiers',
+      'Stage 1 Capability Profile',
+      'Future descriptor/std proposals must name',
+      'validate-cosmo1-stage1-through-cosmo0',
+    ],
+  ],
+  [
+    'package.typ',
+    [
+      'Stage Validation',
+      'Stage 1 Capability Profile',
+      'validate-cosmo1-stage1-through-cosmo0',
+    ],
+  ],
+  [
+    'testing.typ',
+    [
+      'Bug/spec Sync Rule',
+      'Spec Impact Review Rule',
+      'node scripts/validateCosmo0Docs.js',
+    ],
+  ],
+])
+
+for (const [file, snippets] of requiredSnippets) {
+  const path = join(docRoot, file)
+  if (!existsSync(path)) {
+    continue
+  }
+  const content = read(path)
+  for (const snippet of snippets) {
+    if (!content.includes(snippet)) {
+      errors.push(`${path} must include "${snippet}"`)
+    }
+  }
+}
+
+const changeRoot = join('openspec', 'changes')
+const stagedRuntimeName = /^(add-core0-|add-cosmo0-|narrow-cosmo0-)/
+const specImpactText = /docs\/cosmo0\/[A-Za-z0-9-]+\.typ|implementation-only|implementation only/i
+
+for (const entry of readdirSync(changeRoot, { withFileTypes: true })) {
+  if (!entry.isDirectory() || entry.name === 'archive') {
+    continue
+  }
+  if (!stagedRuntimeName.test(entry.name)) {
+    continue
+  }
+
+  const changeDir = join(changeRoot, entry.name)
+  const parts = []
+  for (const file of ['proposal.md', 'design.md', 'tasks.md']) {
+    const path = join(changeDir, file)
+    if (existsSync(path)) {
+      parts.push(read(path))
+    }
+  }
+
+  const combined = parts.join('\n')
+  if (!specImpactText.test(combined)) {
+    errors.push(
+      `${changeDir} must reference changed docs/cosmo0/*.typ files or justify implementation-only status`,
+    )
+  }
+}
+
+if (errors.length > 0) {
+  console.error('cosmo0 docs validation failed:')
+  for (const error of errors) {
+    console.error(`- ${error}`)
+  }
+  process.exit(1)
+}
+
+console.log(`cosmo0 docs validation passed (${requiredDocs.length} required docs checked)`)

--- a/scripts/validateCosmo0Docs.js
+++ b/scripts/validateCosmo0Docs.js
@@ -32,6 +32,20 @@ for (const file of requiredDocs) {
   requireFile(join(docRoot, file))
 }
 
+for (const file of requiredDocs) {
+  const path = join(docRoot, file)
+  if (!existsSync(path)) {
+    continue
+  }
+  const content = read(path)
+  if (!content.includes('== Examples')) {
+    errors.push(`${path} must include an "== Examples" section`)
+  }
+  if (!content.includes('```')) {
+    errors.push(`${path} must include at least one fenced example block`)
+  }
+}
+
 const requiredSnippets = new Map([
   [
     'spec.typ',
@@ -119,4 +133,4 @@ if (errors.length > 0) {
   process.exit(1)
 }
 
-console.log(`cosmo0 docs validation passed (${requiredDocs.length} required docs checked)`)
+console.log(`cosmo0 docs validation passed (${requiredDocs.length} required docs with examples checked)`)


### PR DESCRIPTION
## Summary

- Add the initial `docs/cosmo0/` specification skeleton across language, std, runtime, package, and testing areas.
- Document cosmo0 spec ownership, Stage 1 capability profile placeholders, and the bug/spec sync policy.
- Add lightweight validation for the required cosmo0 docs and complete the OpenSpec delta for `cosmo0-spec-docs`.

## Validation

- `yarn validate:cosmo0-docs`
- `openspec validate model-cosmo0-spec-docs --strict`
- `openspec status --change model-cosmo0-spec-docs`
- Typst smoke compile for all `docs/cosmo0/*.typ` files into `/tmp/cosmo0-docs-typst`
- `git diff --cached --check`
