### PR TITLE
Add cosmo1 parser self-compile proposal series

### DIFF
--- a/openspec/changes/add-cosmo1-ir-model-verifier/.openspec.yaml
+++ b/openspec/changes/add-cosmo1-ir-model-verifier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/add-cosmo1-ir-model-verifier/README.md
+++ b/openspec/changes/add-cosmo1-ir-model-verifier/README.md
@@ -1,0 +1,3 @@
+# add-cosmo1-ir-model-verifier
+
+Add cosmo1 IR data model, verifier, and deterministic debug rendering.

--- a/openspec/changes/add-cosmo1-ir-model-verifier/design.md
+++ b/openspec/changes/add-cosmo1-ir-model-verifier/design.md
@@ -1,0 +1,27 @@
+## Context
+
+Lowering directly to C++ would hide semantic errors in emission. A small verified IR gives cosmo1 a stable boundary between typed syntax and generated code.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define IR data for parser-source compilation.
+- Verify block, local, call, and return consistency.
+- Render deterministic IR snapshots.
+
+**Non-Goals:**
+
+- Optimization.
+- SSA completeness.
+- Full backend ABI design.
+
+## Decisions
+
+- Use explicit blocks and terminators.
+- Represent locals and temporaries with stable ids.
+- Verify IR before any C++ emission.
+
+## Risks / Trade-offs
+
+- Risk: IR shape changes while lowering grows. Mitigation: keep verifier and renderer close to parser-source requirements and evolve by explicit later proposals.

--- a/openspec/changes/add-cosmo1-ir-model-verifier/proposal.md
+++ b/openspec/changes/add-cosmo1-ir-model-verifier/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+cosmo1 needs a verified IR boundary before lowering can safely feed C++ emission. This change defines the IR data model, verifier, and debug rendering used by the parser self-compile lowering sequence.
+
+## What Changes
+
+- Add cosmo1 IR modules, declarations, functions, blocks, locals, values, operations, and terminators.
+- Add an IR verifier for structural and type consistency.
+- Add deterministic IR debug rendering for fixtures.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-ir-model-verifier`: Defines cosmo1 IR data, verification, and debug rendering.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will introduce IR modules under `packages/cosmoc/src/ir`.
+- Lowering and C++ emission proposals depend on this IR contract.

--- a/openspec/changes/add-cosmo1-ir-model-verifier/specs/cosmo1-ir-model-verifier/spec.md
+++ b/openspec/changes/add-cosmo1-ir-model-verifier/specs/cosmo1-ir-model-verifier/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Cosmo1 IR Model
+
+cosmo1 SHALL define an IR model with modules, declarations, functions, blocks, locals, values, operations, and terminators sufficient for parser self-compile lowering.
+
+#### Scenario: Function IR is representable
+
+- **WHEN** cosmo1 represents a parser-source function
+- **THEN** the IR contains parameters, locals, ordered blocks, operations, and a terminator for each block
+
+### Requirement: IR Verification
+
+cosmo1 SHALL verify IR structure before C++ emission.
+
+#### Scenario: Invalid IR is rejected
+
+- **WHEN** IR has missing blocks, invalid local use, invalid call shape, or return type mismatch
+- **THEN** the verifier reports diagnostics and prevents emission
+
+#### Scenario: IR debug output is deterministic
+
+- **WHEN** equivalent verified IR is rendered repeatedly
+- **THEN** the debug output is stable for snapshot tests

--- a/openspec/changes/add-cosmo1-ir-model-verifier/tasks.md
+++ b/openspec/changes/add-cosmo1-ir-model-verifier/tasks.md
@@ -1,0 +1,14 @@
+## 1. IR Data
+
+- [ ] 1.1 Add IR module, declaration, function, block, local, value, operation, and terminator data.
+- [ ] 1.2 Add stable ids for declarations, locals, and blocks.
+
+## 2. Verification
+
+- [ ] 2.1 Verify block structure and terminators.
+- [ ] 2.2 Verify local definitions, call arguments, and return types.
+
+## 3. Rendering
+
+- [ ] 3.1 Add deterministic IR debug renderer.
+- [ ] 3.2 Add positive and negative verifier fixtures.

--- a/openspec/changes/add-cosmo1-name-resolution/.openspec.yaml
+++ b/openspec/changes/add-cosmo1-name-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/add-cosmo1-name-resolution/README.md
+++ b/openspec/changes/add-cosmo1-name-resolution/README.md
@@ -1,0 +1,3 @@
+# add-cosmo1-name-resolution
+
+Add cosmo1 symbol interning, scopes, and name resolution for parser self-compile.

--- a/openspec/changes/add-cosmo1-name-resolution/design.md
+++ b/openspec/changes/add-cosmo1-name-resolution/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The parser self-compile source uses top-level helpers, class methods, fields, parameters, locals, and `self`. A stable resolver avoids duplicating lookup logic in the type checker.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Intern symbols deterministically.
+- Collect definitions from syntax.
+- Resolve names and member lookup inputs for the parser subset.
+
+**Non-Goals:**
+
+- Trait resolution.
+- General overload resolution.
+- Macro or staged name lookup.
+
+## Decisions
+
+- Separate declaration collection from expression name resolution.
+- Represent fields and methods as definitions owned by class definitions.
+- Treat unresolved names as diagnostics, not lowering-time failures.
+
+## Risks / Trade-offs
+
+- Risk: member lookup overlaps with type checking. Mitigation: resolver records candidate definitions while type checking validates receiver type and call shape.

--- a/openspec/changes/add-cosmo1-name-resolution/proposal.md
+++ b/openspec/changes/add-cosmo1-name-resolution/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Type checking `parser.cos` requires every name, field, method, parameter, local, and supported qualified path to resolve to a stable definition. This change adds the name resolution layer consumed by the type-checking sequence.
+
+## What Changes
+
+- Add symbol interning and definition ids.
+- Add scopes for modules, classes, functions, blocks, parameters, and locals.
+- Resolve parser-source names, fields, methods, and supported qualified paths.
+- Report duplicate and unresolved-name diagnostics.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-name-resolution`: Defines symbol interning, scopes, definition collection, and name resolution for parser self-compile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend `packages/cosmoc/src/names`.
+- Establishes the resolved identifiers consumed by type checking and lowering.

--- a/openspec/changes/add-cosmo1-name-resolution/specs/cosmo1-name-resolution/spec.md
+++ b/openspec/changes/add-cosmo1-name-resolution/specs/cosmo1-name-resolution/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Symbol And Definition Resolution
+
+cosmo1 SHALL resolve parser-source declarations, names, fields, methods, parameters, locals, and supported qualified paths to stable identifiers before type checking.
+
+#### Scenario: Parser names resolve
+
+- **WHEN** cosmo1 resolves the supported `parser.cos` source subset
+- **THEN** top-level functions, classes, methods, fields, parameters, locals, and `self` references resolve to stable definition identifiers
+
+#### Scenario: Invalid name is diagnosed
+
+- **WHEN** a parser-source reference cannot be resolved
+- **THEN** cosmo1 reports an unresolved-name diagnostic with the reference span
+
+### Requirement: Duplicate Definitions
+
+cosmo1 SHALL reject duplicate definitions in the same scope.
+
+#### Scenario: Duplicate name is rejected
+
+- **WHEN** two definitions introduce the same name into one scope
+- **THEN** cosmo1 reports a duplicate-definition diagnostic before type checking

--- a/openspec/changes/add-cosmo1-name-resolution/tasks.md
+++ b/openspec/changes/add-cosmo1-name-resolution/tasks.md
@@ -1,0 +1,16 @@
+## 1. Symbols And Definitions
+
+- [ ] 1.1 Add symbol interning and definition id data.
+- [ ] 1.2 Collect top-level, class, method, field, parameter, and local definitions.
+
+## 2. Scopes
+
+- [ ] 2.1 Build module, class, function, and block scopes.
+- [ ] 2.2 Resolve names and supported qualified paths against scopes.
+
+## 3. Diagnostics
+
+- [ ] 3.1 Report duplicate definitions.
+- [ ] 3.2 Report unresolved names with spans.
+- [ ] 3.3 Add parser-source resolver fixtures.
+

--- a/openspec/changes/add-cosmo1-native-parser-ast-output/.openspec.yaml
+++ b/openspec/changes/add-cosmo1-native-parser-ast-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/add-cosmo1-native-parser-ast-output/README.md
+++ b/openspec/changes/add-cosmo1-native-parser-ast-output/README.md
@@ -1,0 +1,3 @@
+# add-cosmo1-native-parser-ast-output
+
+Add native cosmo1 parser output for the supported parser.cos source subset.

--- a/openspec/changes/add-cosmo1-native-parser-ast-output/design.md
+++ b/openspec/changes/add-cosmo1-native-parser-ast-output/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The current parser library can determine whether a source is accepted, but downstream cosmo1 stages need syntax nodes. The first parser milestone should therefore produce a minimal but structured tree for the exact constructs exercised by `parser.cos`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce syntax data for the `parser.cos` subset.
+- Preserve a simple parser surface that can still be compiled through cosmo0.
+- Emit enough structure for declaration collection and type-expression resolution.
+
+**Non-Goals:**
+
+- Full Cosmo parser parity.
+- Rich error recovery or IDE-quality diagnostics.
+- JSON AST bridge support.
+
+## Decisions
+
+- Start with parser-source acceptance constructs instead of all existing Scala parser nodes.
+- Represent unsupported constructs explicitly as errors or missing nodes rather than silently accepting them.
+- Keep tokenization and parsing boundaries simple enough for cosmo0 compilation.
+
+## Risks / Trade-offs
+
+- Risk: parser output shape changes during later syntax arena work. Mitigation: keep this proposal focused on node kinds and acceptance fixtures, not final storage layout.

--- a/openspec/changes/add-cosmo1-native-parser-ast-output/proposal.md
+++ b/openspec/changes/add-cosmo1-native-parser-ast-output/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`parser.cos` is currently usable as a cosmo0-compiled Boolean parser library, but cosmo1 needs native syntax output before later semantic stages can type-check or lower it. This change starts the self-compile path by making the parser produce structured syntax for the subset used by `packages/cosmoc/src/parser.cos`.
+
+## What Changes
+
+- Add a native parser output slice for the `parser.cos` acceptance subset.
+- Replace Boolean-only parser acceptance as the self-compile milestone boundary with syntax-producing parser behavior.
+- Keep the first syntax output focused on declarations, types, class members, blocks, calls, selection, assignment, `if`, `while`, and returns used by `parser.cos`.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-native-parser-ast-output`: Defines native cosmo1 parser output for the supported `parser.cos` source subset.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will touch `packages/cosmoc/src/parser.cos` or a successor syntax parser module.
+- Does not require full Cosmo parsing, parser recovery, staging, traits, user generics, or macro syntax.

--- a/openspec/changes/add-cosmo1-native-parser-ast-output/specs/cosmo1-native-parser-ast-output/spec.md
+++ b/openspec/changes/add-cosmo1-native-parser-ast-output/specs/cosmo1-native-parser-ast-output/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Native Parser Produces Syntax
+
+cosmo1 SHALL parse the supported `packages/cosmoc/src/parser.cos` subset into structured syntax nodes rather than only returning a Boolean accepted or rejected result.
+
+#### Scenario: Parser source produces declarations
+
+- **WHEN** cosmo1 parses the supported `parser.cos` source subset
+- **THEN** the parser output contains syntax nodes for top-level classes, functions, type aliases, values, class members, method parameters, type annotations, and method bodies
+
+#### Scenario: Parser output covers required expressions
+
+- **WHEN** parser output includes function and method bodies
+- **THEN** it represents blocks, locals, assignments, calls, selections, binary and unary operations, `if`, `while`, and `return` nodes used by `parser.cos`
+
+#### Scenario: Unsupported syntax remains out of scope
+
+- **WHEN** source uses full-language features outside the `parser.cos` subset
+- **THEN** this parser slice may reject the source or produce explicit unsupported syntax diagnostics without adding full-language support

--- a/openspec/changes/add-cosmo1-native-parser-ast-output/tasks.md
+++ b/openspec/changes/add-cosmo1-native-parser-ast-output/tasks.md
@@ -1,0 +1,15 @@
+## 1. Parser Output Model
+
+- [ ] 1.1 Define the initial syntax node kinds required by `parser.cos`.
+- [ ] 1.2 Add parser result data that carries a syntax root and diagnostics.
+
+## 2. Parser Implementation
+
+- [ ] 2.1 Parse top-level class, function, type alias, value, and class member forms into syntax nodes.
+- [ ] 2.2 Parse parser-body expressions into syntax nodes for blocks, calls, selection, assignment, conditionals, loops, and returns.
+
+## 3. Validation
+
+- [ ] 3.1 Add parser fixtures proving the supported `parser.cos` subset produces syntax.
+- [ ] 3.2 Add negative fixtures for unsupported full-language constructs.
+

--- a/openspec/changes/add-cosmo1-package-module-graph/.openspec.yaml
+++ b/openspec/changes/add-cosmo1-package-module-graph/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/add-cosmo1-package-module-graph/README.md
+++ b/openspec/changes/add-cosmo1-package-module-graph/README.md
@@ -1,0 +1,3 @@
+# add-cosmo1-package-module-graph
+
+Add cosmo1 package metadata loading, source selection, imports, and module graph planning for parser self-compile.

--- a/openspec/changes/add-cosmo1-package-module-graph/design.md
+++ b/openspec/changes/add-cosmo1-package-module-graph/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`parser.cos` can be validated as a single source first, but cosmo1 eventually needs package metadata and import ordering. This proposal establishes the package boundary early without requiring full package self-hosting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Load the package metadata needed by cosmo1 validation slices.
+- Resolve listed source files and imports deterministically.
+- Report missing import and cycle diagnostics.
+
+**Non-Goals:**
+
+- Full package manager behavior.
+- Linker or artifact writing.
+- Full `packages/cosmoc` self-hosting.
+
+## Decisions
+
+- Support explicit source lists before recursive package scanning.
+- Use deterministic topological ordering.
+- Keep import validation independent from type checking.
+
+## Risks / Trade-offs
+
+- Risk: package graph work arrives before the single-file parser path needs it. Mitigation: keep implementation small and allow single-file validation to bypass package metadata until ready.

--- a/openspec/changes/add-cosmo1-package-module-graph/proposal.md
+++ b/openspec/changes/add-cosmo1-package-module-graph/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The parser self-compile path needs a way to select source files and resolve imports before semantic analysis can run. This change defines cosmo1 package metadata loading and module graph behavior at the narrow boundary needed for `parser.cos`.
+
+## What Changes
+
+- Add package metadata loading for cosmo1 validation slices.
+- Define source selection and module ordering for parser self-compile inputs.
+- Add import edge and module graph diagnostics for missing modules and cycles.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-package-module-graph`: Defines package metadata, source selection, imports, and module graph behavior for parser self-compile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend `packages/cosmoc/src/package` modules.
+- Enables single-file parser self-compile first while preserving a path to package validation.

--- a/openspec/changes/add-cosmo1-package-module-graph/specs/cosmo1-package-module-graph/spec.md
+++ b/openspec/changes/add-cosmo1-package-module-graph/specs/cosmo1-package-module-graph/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Package Source Selection
+
+cosmo1 SHALL load package metadata and select source files needed by parser self-compile validation.
+
+#### Scenario: Explicit source list is loaded
+
+- **WHEN** package metadata lists source files for a cosmo1 validation slice
+- **THEN** cosmo1 loads those sources in deterministic source-root-relative form
+
+### Requirement: Module Graph Diagnostics
+
+cosmo1 SHALL build an import graph and report missing imports or cycles before semantic checking.
+
+#### Scenario: Import order is deterministic
+
+- **WHEN** modules import other modules without cycles
+- **THEN** cosmo1 orders dependencies before importing modules
+
+#### Scenario: Invalid graph is rejected
+
+- **WHEN** an import is missing or an import cycle exists
+- **THEN** cosmo1 reports a module graph diagnostic and does not run name resolution for that package graph

--- a/openspec/changes/add-cosmo1-package-module-graph/tasks.md
+++ b/openspec/changes/add-cosmo1-package-module-graph/tasks.md
@@ -1,0 +1,16 @@
+## 1. Metadata
+
+- [ ] 1.1 Define cosmo1 package metadata fields needed for validation slices.
+- [ ] 1.2 Load explicit source lists from package metadata.
+
+## 2. Graph
+
+- [ ] 2.1 Extract import edges from syntax declarations.
+- [ ] 2.2 Build deterministic module order for acyclic graphs.
+- [ ] 2.3 Report missing import and cycle diagnostics.
+
+## 3. Validation
+
+- [ ] 3.1 Add single-source parser validation wiring.
+- [ ] 3.2 Add package graph fixtures for valid, missing-import, and cycle cases.
+

--- a/openspec/changes/add-cosmo1-type-model/.openspec.yaml
+++ b/openspec/changes/add-cosmo1-type-model/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/add-cosmo1-type-model/README.md
+++ b/openspec/changes/add-cosmo1-type-model/README.md
@@ -1,0 +1,3 @@
+# add-cosmo1-type-model
+
+Add cosmo1-owned type model data needed before type checking parser.cos.

--- a/openspec/changes/add-cosmo1-type-model/design.md
+++ b/openspec/changes/add-cosmo1-type-model/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The parser self-compile subset uses primitive types, user classes, function signatures, references, and `Unit`/`Bool`/`String`/`usize`/`u8`. A small type model should support those without importing full Cosmo type-system complexity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define stable type ids and type constructors.
+- Compare and display types deterministically.
+- Provide diagnostic data for later type-checking failures.
+
+**Non-Goals:**
+
+- User-defined generic checking.
+- Trait solving.
+- Compile-time `Type` values.
+
+## Decisions
+
+- Keep type equality structural for parser-source types.
+- Model references directly in cosmo1 type data.
+- Reserve error and never types for later control-flow and recovery.
+
+## Risks / Trade-offs
+
+- Risk: type model grows toward full Cosmo too early. Mitigation: only include forms required by current parser-source acceptance and future proposals must add new forms explicitly.

--- a/openspec/changes/add-cosmo1-type-model/proposal.md
+++ b/openspec/changes/add-cosmo1-type-model/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+cosmo1 needs its own type data before it can type-check `parser.cos` independently from the Scala cosmo0 typer. This change establishes the type representation used by later declaration and expression checking proposals.
+
+## What Changes
+
+- Add cosmo1-owned type ids and type storage.
+- Represent primitives, user classes, function types, references, never/error types, and display names.
+- Add type comparison and diagnostic foundations.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-type-model`: Defines cosmo1-owned type data required by parser self-compile type checking.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will introduce cosmo1 type modules under `packages/cosmoc/src/types`.
+- Does not add full generic solving, trait constraints, or type-level evaluation.

--- a/openspec/changes/add-cosmo1-type-model/specs/cosmo1-type-model/spec.md
+++ b/openspec/changes/add-cosmo1-type-model/specs/cosmo1-type-model/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Cosmo1 Type Data
+
+cosmo1 SHALL define type data for primitive types, user class types, function types, reference types, never/error types, and stable type identifiers needed by parser self-compile.
+
+#### Scenario: Parser primitive types are represented
+
+- **WHEN** cosmo1 creates types for the parser-source subset
+- **THEN** it can represent `Unit`, `Bool`, `String`, `usize`, `u8`, and other primitive types used by `parser.cos`
+
+#### Scenario: User and callable types are represented
+
+- **WHEN** cosmo1 models parser classes and functions
+- **THEN** it can represent user class types, function parameter and return types, immutable references, and mutable references
+
+### Requirement: Type Comparison And Display
+
+cosmo1 SHALL compare and display parser-source types deterministically.
+
+#### Scenario: Type diagnostics can render names
+
+- **WHEN** a later type-checking stage reports a mismatch
+- **THEN** the expected and actual cosmo1 types have stable display text

--- a/openspec/changes/add-cosmo1-type-model/tasks.md
+++ b/openspec/changes/add-cosmo1-type-model/tasks.md
@@ -1,0 +1,14 @@
+## 1. Type Data
+
+- [ ] 1.1 Add type ids and type storage.
+- [ ] 1.2 Add primitive, user, function, reference, never, and error type forms.
+
+## 2. Operations
+
+- [ ] 2.1 Add deterministic type comparison.
+- [ ] 2.2 Add deterministic type display.
+- [ ] 2.3 Add type diagnostic data structures.
+
+## 3. Validation
+
+- [ ] 3.1 Add unit fixtures for parser-source primitive, class, function, and reference types.

--- a/openspec/changes/complete-cosmo1-syntax-arenas-spans/.openspec.yaml
+++ b/openspec/changes/complete-cosmo1-syntax-arenas-spans/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/complete-cosmo1-syntax-arenas-spans/README.md
+++ b/openspec/changes/complete-cosmo1-syntax-arenas-spans/README.md
@@ -1,0 +1,3 @@
+# complete-cosmo1-syntax-arenas-spans
+
+Complete syntax arenas, declaration and type-expression nodes, and spans for parser self-compile input.

--- a/openspec/changes/complete-cosmo1-syntax-arenas-spans/design.md
+++ b/openspec/changes/complete-cosmo1-syntax-arenas-spans/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The current syntax arena experiment is too small for parser self-compile. Later compiler stages need stable node ids, repeatable traversal, and spans for diagnostics.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Store syntax nodes in cosmo1-owned arenas.
+- Preserve spans on nodes that can produce diagnostics.
+- Provide deterministic debug output for fixture tests.
+
+**Non-Goals:**
+
+- Final full-language AST shape.
+- Serialization format stability.
+- Incremental parsing support.
+
+## Decisions
+
+- Use arena ids for syntax references instead of raw pointers.
+- Keep expression, type-expression, declaration, and member id spaces explicit.
+- Require spans on every accepted parser-source node.
+
+## Risks / Trade-offs
+
+- Risk: additional node ids add boilerplate early. Mitigation: keep helper constructors and debug rendering small and test-focused.

--- a/openspec/changes/complete-cosmo1-syntax-arenas-spans/proposal.md
+++ b/openspec/changes/complete-cosmo1-syntax-arenas-spans/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Syntax output needs stable identities and spans before name resolution, type checking, diagnostics, and lowering can share a common representation. This change completes the arena-backed syntax model needed by the parser self-compile path.
+
+## What Changes
+
+- Add arena-backed syntax identifiers for declarations, expressions, type expressions, parameters, and class members.
+- Attach source spans to syntax nodes needed by diagnostics.
+- Define stable accessors and debug rendering for parser self-compile fixtures.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-syntax-arenas-spans`: Defines arena-backed syntax storage and span coverage for parser self-compile input.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend `packages/cosmoc/src/syntax/ast.cos` and related source/span helpers.
+- Establishes the syntax contract consumed by resolution and type checking proposals.

--- a/openspec/changes/complete-cosmo1-syntax-arenas-spans/specs/cosmo1-syntax-arenas-spans/spec.md
+++ b/openspec/changes/complete-cosmo1-syntax-arenas-spans/specs/cosmo1-syntax-arenas-spans/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Arena Backed Syntax
+
+cosmo1 SHALL store parser self-compile syntax in arenas with stable identifiers for declarations, class members, parameters, type expressions, and expressions.
+
+#### Scenario: Syntax ids are stable
+
+- **WHEN** the same supported `parser.cos` source is parsed repeatedly
+- **THEN** equivalent syntax nodes receive deterministic traversal order and stable debug output
+
+#### Scenario: Syntax references use ids
+
+- **WHEN** a syntax node refers to another syntax node
+- **THEN** the reference uses an arena-backed syntax identifier rather than a raw pointer
+
+### Requirement: Syntax Spans
+
+cosmo1 SHALL attach source spans to syntax nodes used by parser self-compile diagnostics.
+
+#### Scenario: Diagnostic node has span
+
+- **WHEN** resolution or type checking reports a diagnostic for a parser-source syntax node
+- **THEN** the diagnostic can identify the source span carried by that node

--- a/openspec/changes/complete-cosmo1-syntax-arenas-spans/tasks.md
+++ b/openspec/changes/complete-cosmo1-syntax-arenas-spans/tasks.md
@@ -1,0 +1,15 @@
+## 1. Arena Data
+
+- [ ] 1.1 Add syntax arenas and ids for declarations, members, params, type expressions, and expressions.
+- [ ] 1.2 Add constructors and accessors for parser-source syntax nodes.
+
+## 2. Span Coverage
+
+- [ ] 2.1 Preserve spans for top-level declarations, members, params, types, and expressions.
+- [ ] 2.2 Add diagnostics helpers that read spans from syntax ids.
+
+## 3. Validation
+
+- [ ] 3.1 Add deterministic syntax debug rendering tests.
+- [ ] 3.2 Add parser-source fixture tests that assert required nodes carry spans.
+

--- a/openspec/changes/emit-cosmo1-parser-self-compile-cpp/.openspec.yaml
+++ b/openspec/changes/emit-cosmo1-parser-self-compile-cpp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/emit-cosmo1-parser-self-compile-cpp/README.md
+++ b/openspec/changes/emit-cosmo1-parser-self-compile-cpp/README.md
@@ -1,0 +1,3 @@
+# emit-cosmo1-parser-self-compile-cpp
+
+Emit deterministic C++ for verified parser IR and validate parser.cos self-compile.

--- a/openspec/changes/emit-cosmo1-parser-self-compile-cpp/design.md
+++ b/openspec/changes/emit-cosmo1-parser-self-compile-cpp/design.md
@@ -1,0 +1,27 @@
+## Context
+
+cosmo0 already emits C++ for `parser.cos`. This proposal requires cosmo1 to do the same through its own syntax, resolution, type-checking, and lowering pipeline.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit deterministic C++ from verified parser IR.
+- Validate generated C++ with the configured C++ toolchain.
+- Prove the cosmo0-compiled cosmo1 pipeline can compile `parser.cos`.
+
+**Non-Goals:**
+
+- Linker/build-system integration.
+- Runtime fixture execution beyond generated C++ acceptance unless explicitly added.
+- Full `packages/cosmoc` package self-hosting.
+
+## Decisions
+
+- Use verified IR as the only input to C++ emission.
+- Keep symbol naming deterministic.
+- Reuse parser-required runtime conventions before introducing broader cosmo1 runtime metadata.
+
+## Risks / Trade-offs
+
+- Risk: C++ emission duplicates cosmo0 backend behavior. Mitigation: target the parser self-compile subset first and keep the emitter contract tied to cosmo1 IR, not cosmo0 internals.

--- a/openspec/changes/emit-cosmo1-parser-self-compile-cpp/proposal.md
+++ b/openspec/changes/emit-cosmo1-parser-self-compile-cpp/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Verified parser IR only proves the middle pipeline. The self-compile milestone is complete when a cosmo0-compiled cosmo1 pipeline emits deterministic C++ for `parser.cos` and the configured C++ toolchain accepts it.
+
+## What Changes
+
+- Add deterministic C++ emission from verified parser IR.
+- Emit parser classes, fields, methods, functions, references, control flow, primitive operations, and string runtime calls.
+- Add end-to-end parser self-compile validation and repeated-output determinism checks.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-parser-self-compile-cpp-emission`: Defines C++ emission and end-to-end validation for parser self-compile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will add cosmo1 C++ emission modules.
+- This proposal completes the first parser self-compile milestone, but not full compiler self-hosting or linker integration.

--- a/openspec/changes/emit-cosmo1-parser-self-compile-cpp/specs/cosmo1-parser-self-compile-cpp-emission/spec.md
+++ b/openspec/changes/emit-cosmo1-parser-self-compile-cpp/specs/cosmo1-parser-self-compile-cpp-emission/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Parser IR Emits C++
+
+cosmo1 SHALL emit deterministic C++ from verified parser IR for `packages/cosmoc/src/parser.cos`.
+
+#### Scenario: Parser C++ is emitted
+
+- **WHEN** verified parser IR is passed to the cosmo1 C++ emitter
+- **THEN** the output contains C++ definitions for parser classes, fields, methods, top-level functions, references, primitive operations, string runtime calls, and control flow
+
+#### Scenario: Emission is deterministic
+
+- **WHEN** the same verified parser IR is emitted repeatedly
+- **THEN** the generated C++ output is byte-for-byte stable
+
+### Requirement: Parser Self-Compile Validation
+
+cosmo1 SHALL validate the end-to-end parser self-compile path through generated C++ acceptance.
+
+#### Scenario: Parser self-compile succeeds
+
+- **WHEN** a cosmo0-compiled cosmo1 pipeline compiles `packages/cosmoc/src/parser.cos`
+- **THEN** generated C++ is accepted by the configured C++ toolchain and repeated runs produce deterministic output

--- a/openspec/changes/emit-cosmo1-parser-self-compile-cpp/tasks.md
+++ b/openspec/changes/emit-cosmo1-parser-self-compile-cpp/tasks.md
@@ -1,0 +1,11 @@
+## 1. C++ Emitter
+
+- [ ] 1.1 Emit C++ type declarations for parser classes and fields.
+- [ ] 1.2 Emit C++ functions and methods from verified parser IR.
+- [ ] 1.3 Emit references, primitive operations, string operations, and control flow.
+
+## 2. Validation
+
+- [ ] 2.1 Add generated C++ syntax acceptance validation with the configured C++ toolchain.
+- [ ] 2.2 Add end-to-end validation for cosmo0-compiled cosmo1 compiling `packages/cosmoc/src/parser.cos`.
+- [ ] 2.3 Add repeated-run deterministic output validation.

--- a/openspec/changes/lower-cosmo1-basic-expressions-to-ir/.openspec.yaml
+++ b/openspec/changes/lower-cosmo1-basic-expressions-to-ir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/lower-cosmo1-basic-expressions-to-ir/README.md
+++ b/openspec/changes/lower-cosmo1-basic-expressions-to-ir/README.md
@@ -1,0 +1,3 @@
+# lower-cosmo1-basic-expressions-to-ir
+
+Lower basic typed expressions into cosmo1 IR.

--- a/openspec/changes/lower-cosmo1-basic-expressions-to-ir/design.md
+++ b/openspec/changes/lower-cosmo1-basic-expressions-to-ir/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The parser-source IR path needs stable local and temporary handling. Lowering simple expressions first lets later proposals add members and branches without reworking local allocation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lower basic typed expressions to verifier-accepted IR.
+- Allocate locals and temporaries deterministically.
+- Preserve return and assignment semantics.
+
+**Non-Goals:**
+
+- Field and method lowering.
+- Branch and loop lowering.
+- C++ emission.
+
+## Decisions
+
+- Use explicit temporary locals for intermediate expression results.
+- Lower direct calls only when the callee is already resolved.
+- Require every produced function body to pass the IR verifier.
+
+## Risks / Trade-offs
+
+- Risk: temporary-heavy IR is verbose. Mitigation: favor clarity and verifier simplicity before optimization.

--- a/openspec/changes/lower-cosmo1-basic-expressions-to-ir/proposal.md
+++ b/openspec/changes/lower-cosmo1-basic-expressions-to-ir/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Basic typed expressions need deterministic IR lowering before parser-specific members and control flow are introduced. This change lowers the expression core used by later IR proposals.
+
+## What Changes
+
+- Lower literals, local declarations, names, assignment, returns, direct calls, arithmetic, comparison, equality, temporary locals, and block sequencing.
+- Verify lowered IR with the cosmo1 IR verifier.
+- Keep field/method lowering and control-flow lowering for later slices.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-basic-expression-lowering`: Defines lowering of basic typed expressions into cosmo1 IR.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend cosmo1 lowering modules.
+- Provides reusable lowering utilities for member and control-flow slices.

--- a/openspec/changes/lower-cosmo1-basic-expressions-to-ir/specs/cosmo1-basic-expression-lowering/spec.md
+++ b/openspec/changes/lower-cosmo1-basic-expressions-to-ir/specs/cosmo1-basic-expression-lowering/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Basic Expression Lowering
+
+cosmo1 SHALL lower basic typed parser-source expressions into verifier-accepted IR.
+
+#### Scenario: Simple body lowers
+
+- **WHEN** a typed function body contains literals, locals, names, assignment, direct calls, arithmetic, comparison, equality, or returns
+- **THEN** cosmo1 lowers the body into IR operations and terminators that pass verification
+
+#### Scenario: Lowering is deterministic
+
+- **WHEN** equivalent typed expression input is lowered repeatedly
+- **THEN** local ids, temporary ids, block order, and debug output are stable

--- a/openspec/changes/lower-cosmo1-basic-expressions-to-ir/tasks.md
+++ b/openspec/changes/lower-cosmo1-basic-expressions-to-ir/tasks.md
@@ -1,0 +1,14 @@
+## 1. Local Lowering
+
+- [ ] 1.1 Lower local declarations and local references.
+- [ ] 1.2 Allocate deterministic temporary locals.
+
+## 2. Expression Lowering
+
+- [ ] 2.1 Lower literals, assignment, direct calls, arithmetic, comparison, and equality.
+- [ ] 2.2 Lower explicit returns and block sequencing.
+
+## 3. Validation
+
+- [ ] 3.1 Add IR verifier fixtures for simple parser-source functions.
+

--- a/openspec/changes/lower-cosmo1-declarations-to-ir/.openspec.yaml
+++ b/openspec/changes/lower-cosmo1-declarations-to-ir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/lower-cosmo1-declarations-to-ir/README.md
+++ b/openspec/changes/lower-cosmo1-declarations-to-ir/README.md
@@ -1,0 +1,3 @@
+# lower-cosmo1-declarations-to-ir
+
+Lower cosmo1 declarations and signatures into verified IR declarations.

--- a/openspec/changes/lower-cosmo1-declarations-to-ir/design.md
+++ b/openspec/changes/lower-cosmo1-declarations-to-ir/design.md
@@ -1,0 +1,27 @@
+## Context
+
+IR lowering should first prove that the typed module shape can be represented independently from body lowering. This mirrors compiler structure and makes symbol stability testable early.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lower classes, fields, functions, methods, params, and receiver metadata.
+- Produce stable IR declaration ordering and names.
+- Keep body lowering separate.
+
+**Non-Goals:**
+
+- Expression lowering.
+- C++ emission.
+- Optimization.
+
+## Decisions
+
+- Use typed declaration ids as inputs to stable IR symbol generation.
+- Emit placeholder bodies only where needed by the verifier.
+- Preserve method ownership explicitly in IR.
+
+## Risks / Trade-offs
+
+- Risk: placeholder bodies can mask later body-lowering issues. Mitigation: tests in this proposal assert declaration shape only and later proposals replace placeholders.

--- a/openspec/changes/lower-cosmo1-declarations-to-ir/proposal.md
+++ b/openspec/changes/lower-cosmo1-declarations-to-ir/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+After the IR model exists, cosmo1 needs to lower typed declarations and signatures before expression bodies can be lowered. This change maps parser-source classes, fields, methods, functions, parameters, receivers, and return types into IR declarations.
+
+## What Changes
+
+- Lower typed class and field declarations to IR type declarations.
+- Lower top-level functions and methods to IR function declarations.
+- Preserve receiver metadata, parameter order, return types, and stable symbols.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-declaration-lowering`: Defines lowering from typed declarations to cosmo1 IR declarations.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend `packages/cosmoc/src/ir/lower.cos` or equivalent.
+- Function bodies may remain placeholder IR until later lowering proposals.

--- a/openspec/changes/lower-cosmo1-declarations-to-ir/specs/cosmo1-declaration-lowering/spec.md
+++ b/openspec/changes/lower-cosmo1-declarations-to-ir/specs/cosmo1-declaration-lowering/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Declaration Lowering
+
+cosmo1 SHALL lower typed parser-source declarations and signatures into cosmo1 IR declarations before expression body lowering.
+
+#### Scenario: Parser classes lower to IR
+
+- **WHEN** typed parser-source class declarations are lowered
+- **THEN** IR type declarations contain class names, fields, field types, and stable declaration ids
+
+#### Scenario: Parser functions lower to IR
+
+- **WHEN** typed parser-source functions and methods are lowered
+- **THEN** IR function declarations contain stable symbols, parameters, receiver metadata, return types, and owner information for methods

--- a/openspec/changes/lower-cosmo1-declarations-to-ir/tasks.md
+++ b/openspec/changes/lower-cosmo1-declarations-to-ir/tasks.md
@@ -1,0 +1,15 @@
+## 1. Type Declarations
+
+- [ ] 1.1 Lower classes to IR type declarations.
+- [ ] 1.2 Lower fields and field types into IR field records.
+
+## 2. Function Declarations
+
+- [ ] 2.1 Lower top-level function signatures to IR functions.
+- [ ] 2.2 Lower methods with owner and receiver metadata.
+- [ ] 2.3 Generate stable IR symbols.
+
+## 3. Validation
+
+- [ ] 3.1 Add IR declaration fixtures for `ParserState` and parser helper functions.
+

--- a/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/.openspec.yaml
+++ b/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/README.md
+++ b/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/README.md
@@ -1,0 +1,3 @@
+# lower-cosmo1-members-intrinsics-to-ir
+
+Lower member access, method calls, String intrinsics, and primitive operations into cosmo1 IR.

--- a/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/design.md
+++ b/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/design.md
@@ -1,0 +1,27 @@
+## Context
+
+Most parser-source operations are member-oriented: `self.offset`, `self.source`, `self.advance()`, `self.source.slice(...)`, and helper calls such as `is_space(...)`. These operations need concrete IR forms before control flow can lower the full file.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lower field reads and writes.
+- Lower method calls with explicit receiver passing.
+- Lower parser-required `String` and primitive intrinsic operations.
+
+**Non-Goals:**
+
+- Dynamic dispatch.
+- General std library lowering.
+- Generic intrinsic expansion beyond parser needs.
+
+## Decisions
+
+- Lower resolved methods as direct IR calls with receiver values.
+- Represent string operations as known intrinsic or runtime-backed IR operations.
+- Require prior type checking to reject invalid member shapes.
+
+## Risks / Trade-offs
+
+- Risk: intrinsic operation names become backend API prematurely. Mitigation: scope intrinsic names to parser-required operations and keep C++ emission responsible for final runtime spelling.

--- a/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/proposal.md
+++ b/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`parser.cos` cannot lower without field access, field assignment, method calls, receiver passing, `String` intrinsics, and primitive helper operations. This change adds the member and intrinsic lowering layer.
+
+## What Changes
+
+- Lower field get and field set operations.
+- Lower resolved method calls with receiver arguments.
+- Lower parser-required `String` intrinsics and primitive operations.
+- Lower top-level helper calls used by `parser.cos`.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-member-intrinsic-lowering`: Defines lowering of member access, method calls, intrinsics, and helper calls into cosmo1 IR.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend lowering and IR operation coverage.
+- Does not add trait dispatch, overload resolution, or arbitrary std APIs.

--- a/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/specs/cosmo1-member-intrinsic-lowering/spec.md
+++ b/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/specs/cosmo1-member-intrinsic-lowering/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Member Lowering
+
+cosmo1 SHALL lower field access, field assignment, and resolved method calls from typed parser-source expressions into IR.
+
+#### Scenario: Field operations lower
+
+- **WHEN** typed parser-source expressions read or write class fields
+- **THEN** cosmo1 emits IR field get or field set operations with verified receiver and value types
+
+#### Scenario: Method calls lower
+
+- **WHEN** typed parser-source expressions call resolved methods
+- **THEN** cosmo1 emits direct IR calls with receiver passing and verified argument types
+
+### Requirement: Intrinsic Lowering
+
+cosmo1 SHALL lower parser-required `String`, primitive, and helper operations into IR.
+
+#### Scenario: String operation lowers
+
+- **WHEN** typed parser-source expressions call required `String` operations
+- **THEN** cosmo1 emits verifier-accepted IR representing those operations for later C++ emission

--- a/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/tasks.md
+++ b/openspec/changes/lower-cosmo1-members-intrinsics-to-ir/tasks.md
@@ -1,0 +1,16 @@
+## 1. Members
+
+- [ ] 1.1 Lower field get operations.
+- [ ] 1.2 Lower field set operations.
+- [ ] 1.3 Lower resolved method calls with explicit receivers.
+
+## 2. Intrinsics
+
+- [ ] 2.1 Lower parser-required `String` intrinsics.
+- [ ] 2.2 Lower primitive numeric and boolean operations.
+- [ ] 2.3 Lower parser helper calls.
+
+## 3. Validation
+
+- [ ] 3.1 Add IR fixtures for representative `ParserState` member methods.
+

--- a/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/.openspec.yaml
+++ b/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/README.md
+++ b/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/README.md
@@ -1,0 +1,3 @@
+# lower-cosmo1-parser-control-flow-to-ir
+
+Lower parser.cos control flow into complete verified cosmo1 IR.

--- a/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/design.md
+++ b/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/design.md
@@ -1,0 +1,27 @@
+## Context
+
+After basic and member lowering, control flow is the remaining barrier to full parser-source IR. The output should be deterministic and pass the verifier before C++ emission begins.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lower conditionals, loops, returns, and short-circuit boolean operators.
+- Produce complete verified IR for `parser.cos`.
+- Keep labels stable for tests.
+
+**Non-Goals:**
+
+- CFG optimization.
+- Pattern matching.
+- Exception or effect lowering.
+
+## Decisions
+
+- Use explicit condition, body, else, merge, and exit blocks.
+- Generate labels with deterministic counters.
+- Treat already-terminated blocks conservatively.
+
+## Risks / Trade-offs
+
+- Risk: nested return lowering creates unreachable blocks. Mitigation: verifier allows well-formed unreachable blocks only when they have explicit terminators.

--- a/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/proposal.md
+++ b/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The parser source relies on nested `if`/`else`, `while`, early returns, and short-circuit boolean operations. This change completes verified IR lowering for the whole `parser.cos` type-checked module.
+
+## What Changes
+
+- Lower `if`, `else`, `while`, nested returns, and short-circuit `and`/`or`.
+- Generate deterministic block labels.
+- Validate complete verified IR for `packages/cosmoc/src/parser.cos`.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-parser-control-flow-lowering`: Defines parser-source control-flow lowering and complete verified parser IR.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Completes the lowering sequence needed before C++ emission.
+- Does not introduce optimization, exception handling, or general pattern-match lowering.

--- a/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/specs/cosmo1-parser-control-flow-lowering/spec.md
+++ b/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/specs/cosmo1-parser-control-flow-lowering/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Parser Control Flow Lowering
+
+cosmo1 SHALL lower parser-source `if`, `else`, `while`, nested returns, and short-circuit boolean expressions into verified IR.
+
+#### Scenario: Branches and loops lower
+
+- **WHEN** typed parser-source control flow is lowered
+- **THEN** cosmo1 emits deterministic IR blocks, conditional branches, loop edges, merge blocks, and terminators
+
+#### Scenario: Short circuit lowers
+
+- **WHEN** typed parser-source expressions use `and` or `or`
+- **THEN** cosmo1 lowers them with control flow that preserves short-circuit semantics
+
+### Requirement: Complete Parser IR
+
+cosmo1 SHALL produce verified IR for the complete supported `packages/cosmoc/src/parser.cos` source.
+
+#### Scenario: Parser IR verifies
+
+- **WHEN** cosmo1 lowers the type-checked parser source
+- **THEN** the resulting IR passes the cosmo1 IR verifier and renders deterministic debug output

--- a/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/tasks.md
+++ b/openspec/changes/lower-cosmo1-parser-control-flow-to-ir/tasks.md
@@ -1,0 +1,17 @@
+## 1. Control Flow
+
+- [ ] 1.1 Lower `if` and `else` expressions.
+- [ ] 1.2 Lower `while` loops.
+- [ ] 1.3 Lower nested early returns.
+
+## 2. Boolean Flow
+
+- [ ] 2.1 Lower short-circuit `and`.
+- [ ] 2.2 Lower short-circuit `or`.
+- [ ] 2.3 Generate deterministic labels.
+
+## 3. Validation
+
+- [ ] 3.1 Add complete `parser.cos` verified IR fixture.
+- [ ] 3.2 Add repeated lowering determinism tests.
+

--- a/openspec/changes/resolve-cosmo1-declarations-and-types/.openspec.yaml
+++ b/openspec/changes/resolve-cosmo1-declarations-and-types/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/resolve-cosmo1-declarations-and-types/README.md
+++ b/openspec/changes/resolve-cosmo1-declarations-and-types/README.md
@@ -1,0 +1,3 @@
+# resolve-cosmo1-declarations-and-types
+
+Resolve cosmo1 declarations, class members, aliases, annotations, and self receiver types.

--- a/openspec/changes/resolve-cosmo1-declarations-and-types/design.md
+++ b/openspec/changes/resolve-cosmo1-declarations-and-types/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The type checker needs a complete signature table before expression checking. `parser.cos` uses classes with fields and methods, top-level functions, aliases, explicit parameter annotations, and `&self`/`&mut self`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Build typed declaration signatures.
+- Resolve type annotations and aliases.
+- Validate method receiver shape.
+
+**Non-Goals:**
+
+- Function body type checking.
+- Generic substitution.
+- Trait method lookup.
+
+## Decisions
+
+- Resolve declaration signatures before any expression body.
+- Keep class field and method signatures available by class definition id.
+- Treat invalid receiver types as declaration diagnostics.
+
+## Risks / Trade-offs
+
+- Risk: aliases can create cycles. Mitigation: include alias cycle diagnostics in this declaration-resolution slice.

--- a/openspec/changes/resolve-cosmo1-declarations-and-types/proposal.md
+++ b/openspec/changes/resolve-cosmo1-declarations-and-types/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+After the type model exists, cosmo1 must resolve declarations and explicit type expressions before checking function bodies. This change creates the semantic signature layer for the `parser.cos` self-compile target.
+
+## What Changes
+
+- Resolve top-level declarations, class members, fields, methods, aliases, parameters, and return annotations.
+- Resolve primitive, user, function, and reference type expressions used by `parser.cos`.
+- Validate `self` receiver forms before body checking.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-declaration-type-resolution`: Defines declaration and type-expression resolution for parser self-compile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend `packages/cosmoc/src/types` and consume name-resolution output.
+- Function bodies remain out of scope for this slice.

--- a/openspec/changes/resolve-cosmo1-declarations-and-types/specs/cosmo1-declaration-type-resolution/spec.md
+++ b/openspec/changes/resolve-cosmo1-declarations-and-types/specs/cosmo1-declaration-type-resolution/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Declaration Signatures
+
+cosmo1 SHALL resolve parser-source declaration signatures before expression body type checking.
+
+#### Scenario: Parser declarations resolve
+
+- **WHEN** cosmo1 resolves declarations from the supported `parser.cos` subset
+- **THEN** it records top-level function, class, field, method, value, alias, parameter, receiver, and return-type signatures
+
+#### Scenario: Function bodies are deferred
+
+- **WHEN** declaration signatures are resolved
+- **THEN** function and method bodies do not need to be type checked by this capability
+
+### Requirement: Type Expression Resolution
+
+cosmo1 SHALL resolve primitive, user, alias, function, immutable reference, and mutable reference type expressions needed by `parser.cos`.
+
+#### Scenario: Unknown type is rejected
+
+- **WHEN** a type annotation names an unknown type
+- **THEN** cosmo1 reports an unknown-type diagnostic with the type expression span

--- a/openspec/changes/resolve-cosmo1-declarations-and-types/tasks.md
+++ b/openspec/changes/resolve-cosmo1-declarations-and-types/tasks.md
@@ -1,0 +1,15 @@
+## 1. Declaration Collection
+
+- [ ] 1.1 Collect top-level declarations and class members into signature records.
+- [ ] 1.2 Record fields, methods, parameters, return types, and aliases.
+
+## 2. Type Resolution
+
+- [ ] 2.1 Resolve primitive, user, alias, and reference type expressions.
+- [ ] 2.2 Validate `self`, `&self`, and `&mut self` receiver types.
+- [ ] 2.3 Diagnose unknown type names and alias cycles.
+
+## 3. Validation
+
+- [ ] 3.1 Add fixtures for resolved `ParserState` and top-level helper signatures.
+

--- a/openspec/changes/typecheck-cosmo1-basic-expressions/.openspec.yaml
+++ b/openspec/changes/typecheck-cosmo1-basic-expressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/typecheck-cosmo1-basic-expressions/README.md
+++ b/openspec/changes/typecheck-cosmo1-basic-expressions/README.md
@@ -1,0 +1,3 @@
+# typecheck-cosmo1-basic-expressions
+
+Type-check basic cosmo1 expressions required by parser.cos.

--- a/openspec/changes/typecheck-cosmo1-basic-expressions/design.md
+++ b/openspec/changes/typecheck-cosmo1-basic-expressions/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`parser.cos` contains many simple statements and expressions. Checking them before method calls and control flow gives the type checker a stable core.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Type-check local bindings and simple expressions.
+- Enforce assignment and return type compatibility.
+- Produce typed expression output.
+
+**Non-Goals:**
+
+- Field access and methods.
+- `if`/`while` flow typing.
+- Short-circuit lowering.
+
+## Decisions
+
+- Treat blocks as scoped sequences with a final expression type.
+- Require `var` for assignment targets where mutation is needed.
+- Keep arithmetic and comparison limited to primitive parser-source types.
+
+## Risks / Trade-offs
+
+- Risk: return checking without control flow is incomplete. Mitigation: this slice checks explicit return expressions and leaves path completeness to the control-flow proposal.

--- a/openspec/changes/typecheck-cosmo1-basic-expressions/proposal.md
+++ b/openspec/changes/typecheck-cosmo1-basic-expressions/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Once declaration signatures exist, cosmo1 can start checking simple expression bodies. This slice establishes basic expression typing before member access, method calls, and control flow are added.
+
+## What Changes
+
+- Type-check literals, local declarations, names, blocks, assignments, returns, arithmetic, comparison, equality, and simple mismatch diagnostics.
+- Produce typed expression data for later lowering.
+- Keep member lookup, method calls, and full control flow for later proposals.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-basic-expression-typechecking`: Defines basic expression type checking for parser self-compile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend `packages/cosmoc/src/types/check.cos` or equivalent.
+- Establishes typed expression data consumed by later checking and lowering.

--- a/openspec/changes/typecheck-cosmo1-basic-expressions/specs/cosmo1-basic-expression-typechecking/spec.md
+++ b/openspec/changes/typecheck-cosmo1-basic-expressions/specs/cosmo1-basic-expression-typechecking/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Basic Expression Typing
+
+cosmo1 SHALL type-check basic parser-source expressions and produce typed expression data for later compiler stages.
+
+#### Scenario: Simple expressions are typed
+
+- **WHEN** cosmo1 checks literals, names, locals, blocks, assignments, returns, arithmetic, comparison, and equality expressions
+- **THEN** it assigns each accepted expression a cosmo1 type
+
+#### Scenario: Type mismatch is diagnosed
+
+- **WHEN** an expression type is not assignable to the expected type
+- **THEN** cosmo1 reports a type mismatch diagnostic with expected and actual type display text
+
+### Requirement: Local Mutation Rules
+
+cosmo1 SHALL enforce mutation rules for basic local assignment.
+
+#### Scenario: Immutable local assignment is rejected
+
+- **WHEN** source assigns to an immutable local binding
+- **THEN** cosmo1 reports an assignment diagnostic before lowering

--- a/openspec/changes/typecheck-cosmo1-basic-expressions/tasks.md
+++ b/openspec/changes/typecheck-cosmo1-basic-expressions/tasks.md
@@ -1,0 +1,15 @@
+## 1. Typed Expressions
+
+- [ ] 1.1 Add typed expression data for literals, names, locals, blocks, assignments, returns, and binary/unary operations.
+- [ ] 1.2 Add scope handling for block-local bindings.
+
+## 2. Type Rules
+
+- [ ] 2.1 Check assignment compatibility and immutable local assignment.
+- [ ] 2.2 Check primitive arithmetic, comparison, and equality operators.
+- [ ] 2.3 Check explicit return expression compatibility.
+
+## 3. Validation
+
+- [ ] 3.1 Add positive and negative fixtures for basic parser-source expressions.
+

--- a/openspec/changes/typecheck-cosmo1-members-calls-self/.openspec.yaml
+++ b/openspec/changes/typecheck-cosmo1-members-calls-self/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/typecheck-cosmo1-members-calls-self/README.md
+++ b/openspec/changes/typecheck-cosmo1-members-calls-self/README.md
@@ -1,0 +1,3 @@
+# typecheck-cosmo1-members-calls-self
+
+Type-check fields, methods, calls, self receivers, String intrinsics, and boolean operators required by parser.cos.

--- a/openspec/changes/typecheck-cosmo1-members-calls-self/design.md
+++ b/openspec/changes/typecheck-cosmo1-members-calls-self/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The parser source uses `self.offset`, `self.source.len()`, `self.current_byte()`, `is_space(...)`, and mutable receiver methods. These rules are the main difference between toy expression checking and parser-source checking.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate fields and method calls against resolved class definitions.
+- Validate receiver mutability.
+- Provide parser-required `String` intrinsic signatures.
+
+**Non-Goals:**
+
+- Trait dispatch.
+- User overload sets.
+- Generic method inference.
+
+## Decisions
+
+- Resolve methods to concrete function definitions before lowering.
+- Treat `String` intrinsics as compiler-known standard signatures for this slice.
+- Check `and`/`or` as Bool operators while leaving short-circuit lowering to IR work.
+
+## Risks / Trade-offs
+
+- Risk: standard intrinsic modeling leaks into full std design. Mitigation: include only parser-required signatures and require future proposals for additional APIs.

--- a/openspec/changes/typecheck-cosmo1-members-calls-self/proposal.md
+++ b/openspec/changes/typecheck-cosmo1-members-calls-self/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`parser.cos` is dominated by field access, method calls, receiver mutation, top-level helpers, and `String` intrinsics. This change completes the member and call rules needed before full parser-source type checking.
+
+## What Changes
+
+- Type-check field access and field assignment.
+- Type-check method selection, method calls, top-level function calls, and receiver mutability.
+- Add the `String` intrinsic signatures used by the parser source.
+- Type-check boolean `and`/`or` expressions.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-member-call-typechecking`: Defines member, call, receiver, intrinsic, and boolean operator checking for parser self-compile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will extend member lookup and call checking in cosmo1 type-checking modules.
+- No general overload resolution or trait dispatch is introduced.

--- a/openspec/changes/typecheck-cosmo1-members-calls-self/specs/cosmo1-member-call-typechecking/spec.md
+++ b/openspec/changes/typecheck-cosmo1-members-calls-self/specs/cosmo1-member-call-typechecking/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Member And Call Typing
+
+cosmo1 SHALL type-check field access, field assignment, method calls, top-level calls, and receiver mutability for the parser self-compile subset.
+
+#### Scenario: Parser member access is typed
+
+- **WHEN** source accesses or assigns a parser class field
+- **THEN** cosmo1 validates the receiver type, field existence, field type, and mutation permission
+
+#### Scenario: Parser calls are typed
+
+- **WHEN** source calls a method or top-level helper used by `parser.cos`
+- **THEN** cosmo1 validates the callee, argument count, argument types, receiver type, receiver mutability, and return type
+
+### Requirement: Parser String Intrinsics
+
+cosmo1 SHALL provide type signatures for the `String` operations used by `parser.cos`.
+
+#### Scenario: String intrinsic is typed
+
+- **WHEN** source calls parser-required string operations such as `len`, `slice`, or `byte_at`
+- **THEN** cosmo1 assigns the descriptor-defined parameter and return types without requiring full standard library compilation

--- a/openspec/changes/typecheck-cosmo1-members-calls-self/tasks.md
+++ b/openspec/changes/typecheck-cosmo1-members-calls-self/tasks.md
@@ -1,0 +1,17 @@
+## 1. Members
+
+- [ ] 1.1 Type-check field access and field assignment.
+- [ ] 1.2 Enforce field mutation through mutable receivers.
+
+## 2. Calls
+
+- [ ] 2.1 Type-check top-level function calls.
+- [ ] 2.2 Type-check method selection and method calls.
+- [ ] 2.3 Enforce receiver mutability for `&self` and `&mut self`.
+
+## 3. Intrinsics
+
+- [ ] 3.1 Add parser-required `String` intrinsic signatures.
+- [ ] 3.2 Type-check boolean `and` and `or`.
+- [ ] 3.3 Add fixtures for `ParserState` member and call patterns.
+

--- a/openspec/changes/typecheck-cosmo1-parser-control-flow/.openspec.yaml
+++ b/openspec/changes/typecheck-cosmo1-parser-control-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/typecheck-cosmo1-parser-control-flow/README.md
+++ b/openspec/changes/typecheck-cosmo1-parser-control-flow/README.md
@@ -1,0 +1,3 @@
+# typecheck-cosmo1-parser-control-flow
+
+Type-check parser.cos control flow, early returns, nested scopes, and full parser source acceptance.

--- a/openspec/changes/typecheck-cosmo1-parser-control-flow/design.md
+++ b/openspec/changes/typecheck-cosmo1-parser-control-flow/design.md
@@ -1,0 +1,27 @@
+## Context
+
+`parser.cos` uses nested `if`/`else`, `while`, early `return`, and blocks with local variables. This proposal validates complete parser-source function bodies after basic and member expression typing exist.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Type-check conditionals and loops.
+- Validate function return compatibility for parser methods and helpers.
+- Produce complete typed output for `parser.cos`.
+
+**Non-Goals:**
+
+- Exhaustiveness checking.
+- Dataflow optimization.
+- Exception or effect typing.
+
+## Decisions
+
+- Require `Bool` conditions for `if` and `while`.
+- Treat `while` expressions as `Unit` for parser self-compile.
+- Track early returns enough to avoid false missing-return diagnostics.
+
+## Risks / Trade-offs
+
+- Risk: return analysis becomes complex. Mitigation: implement conservative parser-source path checks and keep full control-flow analysis for later.

--- a/openspec/changes/typecheck-cosmo1-parser-control-flow/proposal.md
+++ b/openspec/changes/typecheck-cosmo1-parser-control-flow/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The final type-checking slice must prove that cosmo1 can type-check complete `parser.cos` bodies. Control flow, nested scopes, early returns, and return compatibility are the remaining type-checking features needed by that source.
+
+## What Changes
+
+- Type-check `if`, `else`, `while`, nested block scopes, early returns, and function return compatibility.
+- Add minimal never/unreachable handling needed for early return paths.
+- Add complete `parser.cos` type-check acceptance fixtures.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo1-parser-control-flow-typechecking`: Defines parser-source control-flow type checking and complete `parser.cos` type-check acceptance.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Completes the type-checking sequence for the parser self-compile source.
+- Does not add match exhaustiveness, exceptions, closures, or full flow-sensitive typing.

--- a/openspec/changes/typecheck-cosmo1-parser-control-flow/specs/cosmo1-parser-control-flow-typechecking/spec.md
+++ b/openspec/changes/typecheck-cosmo1-parser-control-flow/specs/cosmo1-parser-control-flow-typechecking/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Parser Control Flow Typing
+
+cosmo1 SHALL type-check `if`, `else`, `while`, nested scopes, early returns, and function return compatibility for the supported `parser.cos` source subset.
+
+#### Scenario: Conditions require Bool
+
+- **WHEN** source uses `if` or `while`
+- **THEN** cosmo1 requires the condition expression to have type `Bool`
+
+#### Scenario: Returns match function type
+
+- **WHEN** source returns from a function or method
+- **THEN** cosmo1 validates that the returned expression is assignable to the declared return type
+
+### Requirement: Parser Source Type-Checks
+
+cosmo1 SHALL accept complete type checking of `packages/cosmoc/src/parser.cos` after the preceding type-checking slices exist.
+
+#### Scenario: Parser source accepted by type checker
+
+- **WHEN** cosmo1 type-checks the supported `parser.cos` source
+- **THEN** the result is a deterministic typed module suitable for lowering

--- a/openspec/changes/typecheck-cosmo1-parser-control-flow/tasks.md
+++ b/openspec/changes/typecheck-cosmo1-parser-control-flow/tasks.md
@@ -1,0 +1,16 @@
+## 1. Control Flow Rules
+
+- [ ] 1.1 Type-check `if` and `else` expressions.
+- [ ] 1.2 Type-check `while` loops as parser-source control flow.
+- [ ] 1.3 Track nested block scopes and early returns.
+
+## 2. Return Compatibility
+
+- [ ] 2.1 Validate function and method body return compatibility.
+- [ ] 2.2 Add conservative missing-return diagnostics for parser-source functions.
+
+## 3. Validation
+
+- [ ] 3.1 Add full `packages/cosmoc/src/parser.cos` type-check fixture.
+- [ ] 3.2 Add negative fixtures for bad conditions and return mismatches.
+


### PR DESCRIPTION
## Summary

- replace the single roadmap change with 15 independent OpenSpec proposals for the parser self-compile milestone
- cover native syntax, syntax arenas/spans, package graph, name resolution, type model, declaration/type resolution, expression type checking, member/call checking, control-flow checking, IR model, declaration lowering, expression lowering, member/intrinsic lowering, control-flow lowering, and C++ self-compile emission
- keep each proposal scoped to the current packages/cosmoc/src/parser.cos acceptance boundary and defer full-language features

## Validation

- openspec validate --changes --strict --no-interactive
  - all 15 new changes pass
  - existing unrelated in-progress changes add-cosmo0-staged-runtime-capabilities and validate-cosmo1-stage1-through-cosmo0 still fail strict validation