### PR TITLE
docs: add cosmos language server proposal bundle

### DIFF
--- a/openspec/changes/add-cosmo-package-run-cli/.openspec.yaml
+++ b/openspec/changes/add-cosmo-package-run-cli/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-cosmo-package-run-cli/proposal.md
+++ b/openspec/changes/add-cosmo-package-run-cli/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`cmd/cosmo` can run a single input file, but proposal work and generator work need a package-aware host entrypoint that can execute package-owned tools without ad hoc shell glue.
+
+## What Changes
+
+- Add a package-aware CLI surface centered on `cosmo -p <package> run`.
+- Define how the host locates a package root, resolves the runnable entrypoint, and forwards trailing arguments.
+- Keep package execution a repository tooling feature; it does not change cosmo0 source semantics or stage capability profiles.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo-package-run-cli`: Defines package-aware host execution for repository tools and generators.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will touch `cmd/cosmo/`, package selection plumbing, and contributor docs.
+- Gives later generator and language-server packages a stable invocation contract.
+- Implementation should land before `add-lsp-types-generator-core-subset`.

--- a/openspec/changes/add-cosmo-package-run-cli/tasks.md
+++ b/openspec/changes/add-cosmo-package-run-cli/tasks.md
@@ -1,0 +1,17 @@
+## 1. CLI Surface
+
+- [ ] 1.1 Parse `-p <package>` and `run` as a package-aware command form.
+- [ ] 1.2 Define trailing argument forwarding and working-directory behavior.
+- [ ] 1.3 Define runnable entrypoint resolution for package-owned tools.
+
+## 2. Host Execution
+
+- [ ] 2.1 Load the selected package and compile the runnable target.
+- [ ] 2.2 Execute the compiled target through the existing host runner.
+- [ ] 2.3 Report missing package, missing entrypoint, and compile or run failures clearly.
+
+## 3. Validation
+
+- [ ] 3.1 Add smoke tests for a package-owned runnable target.
+- [ ] 3.2 Add argument forwarding tests.
+- [ ] 3.3 Update contributor docs with the new invocation pattern.

--- a/openspec/changes/add-cosmos-diagnostics-pipeline/.openspec.yaml
+++ b/openspec/changes/add-cosmos-diagnostics-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-cosmos-diagnostics-pipeline/proposal.md
+++ b/openspec/changes/add-cosmos-diagnostics-pipeline/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Diagnostics are the first user-visible outcome of a language server. `packages/cosmoc` already has parser, package, and checker diagnostics, but `packages/cosmos` does not yet convert them into LSP-facing results or publish them on document changes.
+
+## What Changes
+
+- Add a diagnostics pipeline in `packages/cosmos` that drives `packages/cosmoc` analysis for open documents and affected packages.
+- Convert source spans, codes, severities, and messages into the generated LSP diagnostic shapes.
+- Define a first refresh model for open, change, and close events, while leaving hover and other semantic queries to later proposals.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmos-diagnostics-pipeline`: Defines LSP-facing diagnostics generation and publication from `packages/cosmoc` analysis results.
+
+### Modified Capabilities
+
+- `cosmos-workspace-and-documents`: Supplies document snapshots and package sessions consumed by diagnostics.
+- `ls-base-lsp-lifecycle`: Supplies `publishDiagnostics` routing.
+
+## Impact
+
+- Future implementation will extend `packages/cosmos/` and connect existing `packages/cosmoc/` diagnostics to LSP outputs.
+- Delivers the first directly useful editor feature for the Cosmo language server.
+- Implementation should land after `create-cosmos-workspace-and-documents` and before `add-cosmos-hover`.

--- a/openspec/changes/add-cosmos-diagnostics-pipeline/tasks.md
+++ b/openspec/changes/add-cosmos-diagnostics-pipeline/tasks.md
@@ -1,0 +1,21 @@
+## 1. Analysis Entry
+
+- [ ] 1.1 Add `packages/cosmos` analysis entry points over parser, package, and checker stages from `packages/cosmoc`.
+- [ ] 1.2 Define the first refresh boundary for open-document changes.
+
+## 2. Diagnostic Conversion
+
+- [ ] 2.1 Convert spans into LSP ranges.
+- [ ] 2.2 Convert severity, code, and message data into generated diagnostic types.
+- [ ] 2.3 Preserve deterministic ordering for repeated runs.
+
+## 3. Publication
+
+- [ ] 3.1 Publish diagnostics on open, change, and close events.
+- [ ] 3.2 Clear stale diagnostics when documents or packages no longer report them.
+
+## 4. Validation
+
+- [ ] 4.1 Add parser and checker diagnostic fixtures.
+- [ ] 4.2 Add package metadata or module-graph diagnostic fixtures.
+- [ ] 4.3 Add tests for stable diagnostic ordering and clearing behavior.

--- a/openspec/changes/add-cosmos-hover/.openspec.yaml
+++ b/openspec/changes/add-cosmos-hover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-cosmos-hover/proposal.md
+++ b/openspec/changes/add-cosmos-hover/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+After diagnostics, hover is the smallest semantic query that makes the language server feel interactive. Cosmo needs a focused hover slice that can map positions to declarations or inferred types without dragging in broader navigation or completion work.
+
+## What Changes
+
+- Add hover lookup and rendering in `packages/cosmos` over syntax, name-resolution, and type information.
+- Return generated LSP hover content and ranges for supported positions.
+- Keep go-to-definition, references, completion, and semantic tokens out of this slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmos-hover`: Defines position-based hover lookup and rendering for the initial Cosmo language-server slice.
+
+### Modified Capabilities
+
+- `cosmos-workspace-and-documents`: Supplies document snapshots and package sessions consumed by hover.
+- `cosmos-diagnostics-pipeline`: Supplies the first stable analysis path reused by hover.
+
+## Impact
+
+- Future implementation will extend `packages/cosmos/` with position lookup, semantic rendering, and hover request handling.
+- Gives the initial server a focused semantic query without broadening into the full editor feature surface.
+- Implementation should land after `add-cosmos-diagnostics-pipeline` and before `integrate-cosmos-with-vscode`.

--- a/openspec/changes/add-cosmos-hover/tasks.md
+++ b/openspec/changes/add-cosmos-hover/tasks.md
@@ -1,0 +1,20 @@
+## 1. Position Lookup
+
+- [ ] 1.1 Map LSP positions to syntax or semantic nodes within an open document.
+- [ ] 1.2 Choose declaration or inferred-type targets for supported hover positions.
+
+## 2. Rendering
+
+- [ ] 2.1 Render concise deterministic hover markup for declarations and inferred types.
+- [ ] 2.2 Return empty results for unsupported positions instead of partial placeholders.
+
+## 3. Server Wiring
+
+- [ ] 3.1 Expose hover request handling through `packages/cosmos`.
+- [ ] 3.2 Return generated hover result types through `ls-base`.
+
+## 4. Validation
+
+- [ ] 4.1 Add hover fixtures for locals, functions, members, and types.
+- [ ] 4.2 Add unsupported-position tests.
+- [ ] 4.3 Add repeated-run stability tests for rendered hover content.

--- a/openspec/changes/add-ls-base-jsonrpc-core/.openspec.yaml
+++ b/openspec/changes/add-ls-base-jsonrpc-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-ls-base-jsonrpc-core/proposal.md
+++ b/openspec/changes/add-ls-base-jsonrpc-core/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+LSP is layered on JSON-RPC 2.0. Cosmo needs a transport-agnostic core for message envelopes, correlation, and codec behavior before it can add server lifecycle or editor-facing features.
+
+## What Changes
+
+- Add `packages/ls-base` with JSON-RPC message, id, and error models.
+- Add deterministic request, response, and notification codecs plus pending-request tracking.
+- Keep the first slice transport-agnostic and in-memory; stdio or editor process wiring stays out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `ls-base-jsonrpc-core`: Defines the reusable JSON-RPC core consumed by later language-server layers.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will add `packages/ls-base/` with JSON-RPC models, codecs, and session core helpers.
+- Becomes the protocol base for later LSP lifecycle and `packages/cosmos` server work.
+- Implementation should land after `add-lsp-types-generator-core-subset` and before `add-ls-base-lsp-lifecycle`.

--- a/openspec/changes/add-ls-base-jsonrpc-core/tasks.md
+++ b/openspec/changes/add-ls-base-jsonrpc-core/tasks.md
@@ -1,0 +1,21 @@
+## 1. Message Model
+
+- [ ] 1.1 Add JSON-RPC id, request, response, notification, and error message models.
+- [ ] 1.2 Define deterministic handling for malformed envelopes and unsupported batch forms.
+
+## 2. Codec
+
+- [ ] 2.1 Add envelope encoding for outbound requests, responses, and notifications.
+- [ ] 2.2 Add envelope decoding for inbound requests, responses, and notifications.
+- [ ] 2.3 Keep codec behavior deterministic for field ordering and error mapping.
+
+## 3. Session Core
+
+- [ ] 3.1 Add pending-request tracking and response correlation.
+- [ ] 3.2 Add a transport-agnostic in-memory dispatch core.
+
+## 4. Validation
+
+- [ ] 4.1 Add encode and decode tests for each envelope kind.
+- [ ] 4.2 Add request-correlation tests.
+- [ ] 4.3 Add malformed-message tests.

--- a/openspec/changes/add-ls-base-lsp-lifecycle/.openspec.yaml
+++ b/openspec/changes/add-ls-base-lsp-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-ls-base-lsp-lifecycle/proposal.md
+++ b/openspec/changes/add-ls-base-lsp-lifecycle/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+JSON-RPC envelopes alone do not define a usable language server. Cosmo needs a typed LSP lifecycle layer for initialization, shutdown, document routing, and server capability declaration before `packages/cosmos` can serve editors.
+
+## What Changes
+
+- Extend `packages/ls-base` with typed LSP lifecycle handling over the JSON-RPC core.
+- Add `initialize`, `initialized`, `shutdown`, and `exit` flow plus capability declaration and state transitions.
+- Add typed routing for core text-document notifications and `publishDiagnostics`, while leaving transport process wiring for later.
+
+## Capabilities
+
+### New Capabilities
+
+- `ls-base-lsp-lifecycle`: Defines typed LSP lifecycle and document-routing behavior on top of the JSON-RPC core.
+
+### Modified Capabilities
+
+- `ls-base-jsonrpc-core`: Supplies the message and session primitives used by the lifecycle layer.
+
+## Impact
+
+- Future implementation will extend `packages/ls-base/` with lifecycle state, handlers, and document notification routing.
+- Establishes the protocol boundary consumed by the `packages/cosmos` server and VSCode integration.
+- Implementation should land after `add-ls-base-jsonrpc-core` and before `create-cosmos-workspace-and-documents`.

--- a/openspec/changes/add-ls-base-lsp-lifecycle/tasks.md
+++ b/openspec/changes/add-ls-base-lsp-lifecycle/tasks.md
@@ -1,0 +1,20 @@
+## 1. Lifecycle
+
+- [ ] 1.1 Add `initialize`, `initialized`, `shutdown`, and `exit` request or notification handling.
+- [ ] 1.2 Define server capability declaration and lifecycle state transitions.
+
+## 2. Text Document Routing
+
+- [ ] 2.1 Add typed routing for `didOpen`, `didChange`, and `didClose`.
+- [ ] 2.2 Add outbound `publishDiagnostics` support.
+
+## 3. Extensibility
+
+- [ ] 3.1 Add typed request and notification handler registration.
+- [ ] 3.2 Keep transport and process wrapper concerns out of the lifecycle layer.
+
+## 4. Validation
+
+- [ ] 4.1 Add lifecycle transition tests.
+- [ ] 4.2 Add text-document notification routing tests.
+- [ ] 4.3 Add capability shape tests for the initial server slice.

--- a/openspec/changes/add-lsp-types-generator-core-subset/.openspec.yaml
+++ b/openspec/changes/add-lsp-types-generator-core-subset/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-lsp-types-generator-core-subset/proposal.md
+++ b/openspec/changes/add-lsp-types-generator-core-subset/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The official LSP metamodel is too large and change-prone to model by hand. Cosmo needs a deterministic generator that consumes the checked-in `lsprotocol` metamodel and emits the initial protocol types required by the first language-server slice.
+
+## What Changes
+
+- Add `packages/lsp-types` with a checked-in `lsprotocol` metamodel input and a Cosmo generator pipeline.
+- Generate only the initial core session subset needed by server bootstrap: positions, ranges, locations, diagnostics, hover, initialize, shutdown, exit, and core text-document notifications.
+- Keep the first generator slice deterministic and offline; network fetching and full protocol coverage stay out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `lsp-types-generator-core-subset`: Defines deterministic Cosmo generation for the initial LSP metamodel subset.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Future implementation will add `packages/lsp-types/`, checked-in metamodel input, generator sources, and generated outputs.
+- Establishes the type boundary consumed by later `ls-base` and `packages/cosmos` work.
+- Implementation should land after `add-cosmo-package-run-cli` and before `add-ls-base-jsonrpc-core`.

--- a/openspec/changes/add-lsp-types-generator-core-subset/tasks.md
+++ b/openspec/changes/add-lsp-types-generator-core-subset/tasks.md
@@ -1,0 +1,17 @@
+## 1. Metamodel Input
+
+- [ ] 1.1 Check in the `lsprotocol` metamodel input used by the generator.
+- [ ] 1.2 Model references, arrays, maps, unions, and literal object shapes needed by the initial subset.
+- [ ] 1.3 Keep generation deterministic and offline.
+
+## 2. Generated Core Subset
+
+- [ ] 2.1 Emit common data structures such as `Position`, `Range`, `Location`, `Diagnostic`, `MarkupContent`, and `Hover`.
+- [ ] 2.2 Emit the initial session messages for `initialize`, `initialized`, `shutdown`, `exit`, and core text-document notifications.
+- [ ] 2.3 Emit a stable package layout under `packages/lsp-types/`.
+
+## 3. Validation
+
+- [ ] 3.1 Add deterministic regeneration tests or snapshots.
+- [ ] 3.2 Compile the generated package as part of validation.
+- [ ] 3.3 Document how the generator is invoked through `cosmo -p <package> run`.

--- a/openspec/changes/add-rust-ffi-support-library-pipeline/.openspec.yaml
+++ b/openspec/changes/add-rust-ffi-support-library-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-rust-ffi-support-library-pipeline/proposal.md
+++ b/openspec/changes/add-rust-ffi-support-library-pipeline/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`packages/uri-sys` and `packages/ureq-sys` should not each reinvent Rust workspace setup, C ABI conventions, and support-library linking. Cosmo needs one shared pipeline for Rust-backed host capabilities.
+
+## What Changes
+
+- Add a repository-level Rust support-library pipeline for crates under `crates/`.
+- Define common C ABI conventions, artifact naming, and support-library identifiers consumed by Cosmo extern bindings.
+- Define backend and linker integration for `support-library:*` requirements so later Rust-backed packages share one path.
+
+## Capabilities
+
+### New Capabilities
+
+- `rust-ffi-support-library-pipeline`: Defines shared Rust support-library build, ABI, and link integration for Cosmo packages.
+
+### Modified Capabilities
+
+- `cosmo0-extern-abi-hooks`: Records support-library requirements for Rust-backed extern bindings.
+- `cosmo0-cpp-backend`: Consumes support-library artifacts during compile and link orchestration.
+
+## Impact
+
+- Future implementation will add `crates/` workspace scaffolding, Rust build documentation, and backend or linker integration.
+- Keeps later Rust-backed packages focused on domain APIs instead of repeated build glue.
+- Implementation should land before `add-uri-sys` and `add-ureq-sys`.

--- a/openspec/changes/add-rust-ffi-support-library-pipeline/tasks.md
+++ b/openspec/changes/add-rust-ffi-support-library-pipeline/tasks.md
@@ -1,0 +1,20 @@
+## 1. Rust Workspace
+
+- [ ] 1.1 Add repository-level Rust workspace scaffolding for support libraries under `crates/`.
+- [ ] 1.2 Define artifact naming and output layout for Rust-backed support libraries.
+
+## 2. C ABI Contract
+
+- [ ] 2.1 Define shared C ABI conventions for exported Rust functions and value shapes.
+- [ ] 2.2 Define support-library identifiers used by Cosmo extern bindings.
+
+## 3. Backend and Link Integration
+
+- [ ] 3.1 Connect `support-library:*` requirements to build and link steps.
+- [ ] 3.2 Report missing or incompatible support-library artifacts clearly.
+
+## 4. Validation
+
+- [ ] 4.1 Add a minimal Rust-backed support-library smoke test.
+- [ ] 4.2 Add backend or linker tests proving support-library requirements are consumed.
+- [ ] 4.3 Document the shared Rust support-library workflow.

--- a/openspec/changes/add-ureq-sys/.openspec.yaml
+++ b/openspec/changes/add-ureq-sys/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-ureq-sys/proposal.md
+++ b/openspec/changes/add-ureq-sys/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Repository tools and future generators need deterministic blocking HTTP without pulling an async runtime into the first Cosmo tooling stack. A narrow Rust-backed HTTP bridge is enough for controlled fetch workflows.
+
+## What Changes
+
+- Add `packages/ureq-sys` and `crates/ureq-sys` as a Rust-backed wrapper over `ureq` exposed through a C ABI.
+- Expose blocking request construction, headers, status, timeout basics, and body text or bytes retrieval.
+- Keep streaming, cookies, proxy management, and async features out of the first slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `ureq-sys`: Defines the Rust-backed blocking HTTP system package for repository tooling.
+
+### Modified Capabilities
+
+- `rust-ffi-support-library-pipeline`: Supplies the shared ABI and build path used by `ureq-sys`.
+
+## Impact
+
+- Future implementation will add `packages/ureq-sys/`, `crates/ureq-sys/`, and Cosmo declarations over the Rust wrapper.
+- Makes network-backed tooling possible without changing the core language-server critical path.
+- Implementation should land after `add-rust-ffi-support-library-pipeline`; no later proposal in the initial language-server chain depends on it directly.

--- a/openspec/changes/add-ureq-sys/tasks.md
+++ b/openspec/changes/add-ureq-sys/tasks.md
@@ -1,0 +1,15 @@
+## 1. Rust Wrapper
+
+- [ ] 1.1 Add `crates/ureq-sys/` with a C ABI wrapper over blocking `ureq` request execution.
+- [ ] 1.2 Expose request, response, and error shapes needed by narrow tooling workflows.
+
+## 2. Cosmo Surface
+
+- [ ] 2.1 Add `packages/ureq-sys/` declarations for the exported ABI.
+- [ ] 2.2 Add basic request builder, header, timeout, status, and body access APIs.
+
+## 3. Validation
+
+- [ ] 3.1 Add mocked or local HTTP smoke tests.
+- [ ] 3.2 Add deterministic error mapping tests.
+- [ ] 3.3 Add support-library linkage tests through the shared Rust pipeline.

--- a/openspec/changes/add-uri-sys/.openspec.yaml
+++ b/openspec/changes/add-uri-sys/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-uri-sys/proposal.md
+++ b/openspec/changes/add-uri-sys/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The language server and package tooling need reliable URI parsing and normalization for file documents, workspace roots, and LSP document identifiers. Cosmo should reuse a proven implementation instead of hand-rolling URI behavior.
+
+## What Changes
+
+- Add `packages/uri-sys` and `crates/uri-sys` as a Rust-backed wrapper over the `url` crate exposed through a C ABI.
+- Expose parse, display, join, scheme, authority, path, query, and file-URI helper APIs needed by workspace and editor code.
+- Keep broader web-client behavior and unrelated URL utilities out of the first slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `uri-sys`: Defines the Rust-backed URI system package used by workspace and editor infrastructure.
+
+### Modified Capabilities
+
+- `rust-ffi-support-library-pipeline`: Supplies the shared ABI and build path used by `uri-sys`.
+
+## Impact
+
+- Future implementation will add `packages/uri-sys/`, `crates/uri-sys/`, and Cosmo declarations over the Rust wrapper.
+- Unblocks stable URI handling for `packages/cosmos` document and workspace code.
+- Implementation should land after `add-rust-ffi-support-library-pipeline` and before `create-cosmos-workspace-and-documents`.

--- a/openspec/changes/add-uri-sys/tasks.md
+++ b/openspec/changes/add-uri-sys/tasks.md
@@ -1,0 +1,15 @@
+## 1. Rust Wrapper
+
+- [ ] 1.1 Add `crates/uri-sys/` with a C ABI wrapper over the Rust `url` crate.
+- [ ] 1.2 Expose parsing, normalization, joining, and component accessors needed by workspace code.
+
+## 2. Cosmo Surface
+
+- [ ] 2.1 Add `packages/uri-sys/` declarations for the exported ABI.
+- [ ] 2.2 Add file-URI helpers needed by workspace and document infrastructure.
+
+## 3. Validation
+
+- [ ] 3.1 Add parse and normalization tests.
+- [ ] 3.2 Add file path and file URI round-trip tests.
+- [ ] 3.3 Add support-library linkage tests through the shared Rust pipeline.

--- a/openspec/changes/create-cosmos-workspace-and-documents/.openspec.yaml
+++ b/openspec/changes/create-cosmos-workspace-and-documents/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/create-cosmos-workspace-and-documents/proposal.md
+++ b/openspec/changes/create-cosmos-workspace-and-documents/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+A usable language server needs a stable model for workspace roots, package sessions, URIs, and open document snapshots before it can add diagnostics or semantic queries. Those boundaries belong in `packages/cosmos`, not in the editor client.
+
+## What Changes
+
+- Add `packages/cosmos` with workspace, package-session, URI, and open-document infrastructure.
+- Define how document URIs map to package roots, module paths, and cached analysis sessions.
+- Keep diagnostics, hover, and other semantic queries out of this slice so the package boundary stays focused.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmos-workspace-and-documents`: Defines the `packages/cosmos` workspace and document-state foundation for later language-server features.
+
+### Modified Capabilities
+
+- `ls-base-lsp-lifecycle`: Supplies lifecycle and document routing consumed by `packages/cosmos`.
+- `uri-sys`: Supplies stable URI parsing and normalization for document and workspace state.
+
+## Impact
+
+- Future implementation will add `packages/cosmos/` and its initial workspace and document modules.
+- Establishes the package boundary shared by diagnostics, hover, and editor integrations.
+- Implementation should land after `add-ls-base-lsp-lifecycle` and `add-uri-sys`, and before `add-cosmos-diagnostics-pipeline`.

--- a/openspec/changes/create-cosmos-workspace-and-documents/tasks.md
+++ b/openspec/changes/create-cosmos-workspace-and-documents/tasks.md
@@ -1,0 +1,20 @@
+## 1. Package Layout
+
+- [ ] 1.1 Create `packages/cosmos/` with initial workspace, session, and document modules.
+- [ ] 1.2 Define the package layout consumed by later diagnostics and hover work.
+
+## 2. URI and Document Model
+
+- [ ] 2.1 Integrate `uri-sys` for document URI parsing and normalization.
+- [ ] 2.2 Add open, change, and close snapshot storage for text documents.
+
+## 3. Package Selection
+
+- [ ] 3.1 Map documents to package roots and module paths.
+- [ ] 3.2 Cache per-package analysis sessions without adding semantic features yet.
+
+## 4. Validation
+
+- [ ] 4.1 Add workspace fixture tests.
+- [ ] 4.2 Add document lifecycle snapshot tests.
+- [ ] 4.3 Add package-root and module-selection tests.

--- a/openspec/changes/integrate-cosmos-with-vscode/.openspec.yaml
+++ b/openspec/changes/integrate-cosmos-with-vscode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/integrate-cosmos-with-vscode/proposal.md
+++ b/openspec/changes/integrate-cosmos-with-vscode/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The repository already has a VSCode extension shell, but it does not yet launch a Cosmo-authored language-server stack with real diagnostics and hover behavior. A dedicated integration slice is needed so editor wiring does not leak back into core server packages.
+
+## What Changes
+
+- Update `editors/vscode` to launch the `packages/cosmos` server through a host wrapper.
+- Wire document synchronization, diagnostics, and hover through the extension client.
+- Add build, package, and smoke-test coverage for the first VSCode integration slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmos-vscode-integration`: Defines the first VSCode integration path for the Cosmo-authored language server.
+
+### Modified Capabilities
+
+- `ls-base-lsp-lifecycle`: Supplies the client and server lifecycle contract consumed by the extension.
+- `cosmos-diagnostics-pipeline`: Supplies diagnostics shown in the editor.
+- `cosmos-hover`: Supplies hover results shown in the editor.
+
+## Impact
+
+- Future implementation will touch `editors/vscode/`, host wrapper code, build scripts, and editor smoke tests.
+- Keeps process and editor wiring out of the core server packages while making the first end-to-end workflow usable.
+- Implementation should land after `add-cosmos-hover`.

--- a/openspec/changes/integrate-cosmos-with-vscode/tasks.md
+++ b/openspec/changes/integrate-cosmos-with-vscode/tasks.md
@@ -1,0 +1,15 @@
+## 1. Host Wrapper
+
+- [ ] 1.1 Add a VSCode-launched host entry that boots `packages/cosmos`.
+- [ ] 1.2 Keep transport and editor process wiring outside the core server package.
+
+## 2. Editor Client
+
+- [ ] 2.1 Configure document selector, lifecycle startup, and shutdown.
+- [ ] 2.2 Wire diagnostics and hover through the extension client.
+- [ ] 2.3 Add build and packaging hooks for the first integrated server.
+
+## 3. Validation
+
+- [ ] 3.1 Add smoke tests for open, change, diagnostics, and hover flows.
+- [ ] 3.2 Update contributor docs for local VSCode installation and debugging.


### PR DESCRIPTION
## Summary
- add 11 OpenSpec proposals for the Cosmo-authored language server roadmap
- cover package run CLI, generated LSP types, ls-base, Rust support-library plumbing, uri-sys, ureq-sys, cosmos workspace, diagnostics, hover, and VSCode integration
- keep this PR scoped to proposal documents only

## Proposal Execution Order
1. add-cosmo-package-run-cli
2. add-rust-ffi-support-library-pipeline
3. add-ureq-sys
4. add-lsp-types-generator-core-subset
5. add-ls-base-jsonrpc-core
6. add-ls-base-lsp-lifecycle
7. add-uri-sys
8. create-cosmos-workspace-and-documents
9. add-cosmos-diagnostics-pipeline
10. add-cosmos-hover
11. integrate-cosmos-with-vscode

## Notes
- base branch is `remove-archived-specs` instead of `main` so this PR only contains the new proposal bundle
- `add-ureq-sys` is placed before `add-lsp-types-generator-core-subset` because the generator workflow needs network downloads
