### PR TITLE
Add VSCode LSP follow-up proposals

### DIFF
--- a/openspec/changes/add-cosmos-definition-references/.openspec.yaml
+++ b/openspec/changes/add-cosmos-definition-references/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/add-cosmos-definition-references/proposal.md
+++ b/openspec/changes/add-cosmos-definition-references/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Cosmos hover already performs position-based semantic lookup, but the language server does not expose go-to-definition or find-references. Editor users need those navigation features for local declarations, members, parameters, locals, functions, and supported types.
+
+## What Changes
+
+- Add Cosmos semantic navigation helpers for `textDocument/definition` and `textDocument/references`.
+- Reuse the existing parser, name-resolution, declaration-resolution, and expression-checking path used by hover where possible.
+- Extend `ls-base` capability declaration and request registration for definition and references providers.
+- Wire the generated VSCode host and extension smoke tests so VSCode can send definition/reference requests to the server.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmos-definition-references`: Defines initial position-based go-to-definition and references support for supported symbols in open document snapshots.
+
+### Modified Capabilities
+
+- `ls-base-lsp-lifecycle`: Advertises and registers definition/reference request support.
+- `cosmos-vscode-integration`: Routes VSCode definition/reference requests to the Cosmos host.
+
+## Impact
+
+- Future implementation will add a Cosmos LSP navigation module and tests, likely alongside or shared with hover lookup helpers.
+- Initial scope is deterministic navigation for supported symbols in the current open document snapshot; package-wide closed-file indexing can be proposed separately.
+- The VSCode host wrapper will need `textDocument/definition` and `textDocument/references` dispatch and initialize capabilities.

--- a/openspec/changes/add-cosmos-definition-references/specs/cosmos-definition-references/spec.md
+++ b/openspec/changes/add-cosmos-definition-references/specs/cosmos-definition-references/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Position-Based Definition Lookup
+
+`packages/cosmos` SHALL map an LSP text-document position in an open document snapshot to the definition location for supported Cosmo symbols.
+
+#### Scenario: Reference resolves to declaration
+
+- **WHEN** a definition request targets a supported local, parameter, function, member, or type reference
+- **THEN** Cosmos returns an LSP location for the declaration that defines the target symbol
+- **AND** the location URI is the analyzed document URI
+- **AND** the range covers the declaration identifier
+
+#### Scenario: Declaration resolves to itself
+
+- **WHEN** a definition request targets the identifier at a supported declaration site
+- **THEN** Cosmos returns that declaration's own LSP location
+
+#### Scenario: Unsupported positions are empty
+
+- **WHEN** a definition request targets whitespace, punctuation, a closed document snapshot, a parse-failed document, or a symbol kind not supported by the current analysis path
+- **THEN** Cosmos returns an empty definition result
+
+### Requirement: Position-Based References Lookup
+
+`packages/cosmos` SHALL map an LSP text-document position in an open document snapshot to deterministic references for the same supported symbol within that snapshot.
+
+#### Scenario: References include declaration when requested
+
+- **WHEN** a references request targets a supported symbol
+- **AND** the request context has `includeDeclaration` set to true
+- **THEN** Cosmos returns the declaration location and all supported reference locations in deterministic source order
+
+#### Scenario: References exclude declaration when requested
+
+- **WHEN** a references request targets a supported symbol
+- **AND** the request context has `includeDeclaration` set to false
+- **THEN** Cosmos returns supported reference locations without the declaration location
+
+#### Scenario: Unsupported references are empty
+
+- **WHEN** a references request targets whitespace, punctuation, a closed document snapshot, a parse-failed document, or a symbol kind not supported by the current analysis path
+- **THEN** Cosmos returns an empty references array
+
+### Requirement: Navigation JSON Rendering
+
+Cosmos SHALL render definition and references responses as deterministic LSP JSON using zero-based ranges.
+
+#### Scenario: Location JSON is stable
+
+- **WHEN** the same definition or references lookup is evaluated repeatedly against the same document snapshot
+- **THEN** the generated JSON is byte-for-byte stable
+- **AND** locations are ordered by URI, start line, start character, end line, and end character
+
+### Requirement: Navigation Server Wiring
+
+`packages/cosmos` SHALL expose definition and references response helpers that interoperate with the `ls-base` JSON-RPC server lifecycle.
+
+#### Scenario: Navigation capabilities can be enabled
+
+- **WHEN** Cosmos enables semantic navigation on an `ls-base` server
+- **THEN** the server advertises definition and references support
+- **AND** `textDocument/definition` and `textDocument/references` are registered as handled request methods

--- a/openspec/changes/add-cosmos-definition-references/specs/cosmos-vscode-integration/spec.md
+++ b/openspec/changes/add-cosmos-definition-references/specs/cosmos-vscode-integration/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: VSCode Semantic Navigation Uses Cosmos
+
+The VSCode integration SHALL route go-to-definition and find-references requests for Cosmo documents to the Cosmos language-server host.
+
+#### Scenario: Initialize advertises navigation
+
+- **WHEN** the VSCode-launched Cosmos host responds to `initialize`
+- **THEN** the server capabilities include definition provider support
+- **AND** the server capabilities include references provider support
+
+#### Scenario: Definition request flows through host
+
+- **WHEN** VSCode sends `textDocument/definition` for a supported Cosmo identifier
+- **THEN** the host responds with the Cosmos definition location result
+
+#### Scenario: References request flows through host
+
+- **WHEN** VSCode sends `textDocument/references` for a supported Cosmo identifier
+- **THEN** the host responds with the Cosmos references location result

--- a/openspec/changes/add-cosmos-definition-references/specs/ls-base-lsp-lifecycle/spec.md
+++ b/openspec/changes/add-cosmos-definition-references/specs/ls-base-lsp-lifecycle/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: LSP Capability Declaration
+
+`packages/ls-base` SHALL expose a deterministic initial server capability declaration for lifecycle initialization.
+
+#### Scenario: Initial capability JSON is stable
+
+- **WHEN** the initialize result is encoded
+- **THEN** it includes text-document synchronization with open/close support
+- **AND** it includes incremental text-document change support
+- **AND** it includes hover, definition, and references provider fields
+- **AND** its field ordering is deterministic
+
+#### Scenario: Hover capability can be enabled
+
+- **WHEN** hover support is enabled on the LSP server
+- **THEN** the server records that hover is available in its capability declaration
+- **AND** `textDocument/hover` is registered as a handled request method
+
+#### Scenario: Definition capability can be enabled
+
+- **WHEN** definition support is enabled on the LSP server
+- **THEN** the server records that definition is available in its capability declaration
+- **AND** `textDocument/definition` is registered as a handled request method
+
+#### Scenario: References capability can be enabled
+
+- **WHEN** references support is enabled on the LSP server
+- **THEN** the server records that references are available in its capability declaration
+- **AND** `textDocument/references` is registered as a handled request method

--- a/openspec/changes/add-cosmos-definition-references/tasks.md
+++ b/openspec/changes/add-cosmos-definition-references/tasks.md
@@ -1,0 +1,25 @@
+## 1. Cosmos Navigation
+
+- [ ] 1.1 Add position-based definition lookup for supported identifiers using the existing semantic analysis path.
+- [ ] 1.2 Add references lookup for supported identifiers in the current open document snapshot.
+- [ ] 1.3 Render deterministic LSP `Location` JSON with URI and zero-based ranges.
+- [ ] 1.4 Return empty results for whitespace, punctuation, closed documents, parse failures, and unsupported symbols.
+
+## 2. LSP Lifecycle
+
+- [ ] 2.1 Extend `LspServerCapabilities` with definition and references provider flags.
+- [ ] 2.2 Add enable helpers that register `textDocument/definition` and `textDocument/references`.
+- [ ] 2.3 Update lifecycle tests for deterministic initialize JSON and handler registration.
+
+## 3. VSCode Host Integration
+
+- [ ] 3.1 Advertise `definitionProvider` and `referencesProvider` in the VSCode-launched host initialize result.
+- [ ] 3.2 Dispatch `textDocument/definition` and `textDocument/references` through the host wrapper.
+- [ ] 3.3 Add smoke tests for definition and references requests against a document with local, parameter, function, member, and type references.
+
+## 4. Validation
+
+- [ ] 4.1 Verify declaration-name lookup returns the declaration's own location.
+- [ ] 4.2 Verify reference-name lookup returns the target declaration location for definition requests.
+- [ ] 4.3 Verify references honor `includeDeclaration`.
+- [ ] 4.4 Verify repeated lookup returns byte-for-byte stable JSON ordering.

--- a/openspec/changes/add-vscode-lsp-output-channel/.openspec.yaml
+++ b/openspec/changes/add-vscode-lsp-output-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/add-vscode-lsp-output-channel/proposal.md
+++ b/openspec/changes/add-vscode-lsp-output-channel/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+There is no obvious VSCode output channel for the Cosmos language server's stderr. That makes it hard to inspect server startup, probe failures, runtime stderr, and diagnostic-refresh behavior such as why pressing `Ctrl+S` changes the diagnostics state.
+
+## What Changes
+
+- Add a named VSCode output channel for the Cosmo language server.
+- Route language-server startup/probe failures and server stderr into that channel.
+- Add a command that reveals the output channel from VSCode.
+- Add tests or extension-level smoke coverage for output-channel creation and stderr capture.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cosmos-vscode-integration`: Adds observable language-server output and debugging support to the VSCode integration.
+
+## Impact
+
+- Future implementation will touch `editors/vscode/src/lsp.ts`, possibly `editors/vscode/src/cosmos-host.ts`, and `editors/vscode/package.json` command contributions.
+- The channel should help debug diagnostics refresh and host crashes without changing language semantics.
+- Care should be taken not to mix LSP stdout protocol traffic into the human-readable output channel.

--- a/openspec/changes/add-vscode-lsp-output-channel/specs/cosmos-vscode-integration/spec.md
+++ b/openspec/changes/add-vscode-lsp-output-channel/specs/cosmos-vscode-integration/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Language Server Output Channel
+
+The VSCode integration SHALL expose a human-readable output channel for Cosmos language-server diagnostics and stderr.
+
+#### Scenario: Activation creates the output channel
+
+- **WHEN** the Cosmo extension activates
+- **THEN** it creates or reuses a VSCode output channel named for the Cosmo language server
+- **AND** the language client is configured to use that channel for client/server diagnostic output
+
+#### Scenario: Server stderr is visible
+
+- **WHEN** the language-server process writes to stderr
+- **THEN** the stderr text is appended to the Cosmo language-server output channel
+- **AND** protocol stdout is not appended to the human-readable channel
+
+#### Scenario: User can reveal the channel
+
+- **WHEN** the user invokes the Cosmo command for language-server output
+- **THEN** VSCode reveals the Cosmo language-server output channel
+
+#### Scenario: Startup failure is recorded
+
+- **WHEN** probing or starting the Cosmos host fails
+- **THEN** the failure details are appended to the output channel
+- **AND** the activation error shown to the user points them to that channel

--- a/openspec/changes/add-vscode-lsp-output-channel/tasks.md
+++ b/openspec/changes/add-vscode-lsp-output-channel/tasks.md
@@ -1,0 +1,17 @@
+## 1. Output Channel
+
+- [ ] 1.1 Create or configure a named VSCode output channel for `Cosmo Language Server`.
+- [ ] 1.2 Append host probe failures, startup errors, and language-server stderr to the output channel.
+- [ ] 1.3 Ensure LSP stdout remains reserved for protocol messages and is not mirrored into the output channel.
+
+## 2. User Access
+
+- [ ] 2.1 Add a VSCode command such as `cosmo.showLanguageServerOutput` that reveals the channel.
+- [ ] 2.2 Contribute the command in `editors/vscode/package.json` with a clear title.
+- [ ] 2.3 Reveal or point to the channel when activation fails before the language client starts.
+
+## 3. Validation
+
+- [ ] 3.1 Add extension tests or focused unit coverage that verifies the output channel is created during activation.
+- [ ] 3.2 Add coverage for a probe/startup failure path that appends the failure text to the channel.
+- [ ] 3.3 Manually verify stderr from the VSCode-launched host is visible while reproducing diagnostics refresh issues.

--- a/openspec/changes/add-vscode-workspace-sample/.openspec.yaml
+++ b/openspec/changes/add-vscode-workspace-sample/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/add-vscode-workspace-sample/proposal.md
+++ b/openspec/changes/add-vscode-workspace-sample/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The repository has runnable Cosmo samples, but there is no ready-to-open VSCode workspace that lets a user choose a small editor experience and immediately exercise the extension. Opening individual sample files leaves too much implicit setup around package roots, language activation, and which file should be used for the first smoke check.
+
+## What Changes
+
+- Add a checked-in VSCode workspace sample focused on the existing sample package and `samples/HelloWorld/main.cos`.
+- Keep the sample workspace lightweight: it should reference existing sample files, avoid generated output directories, and activate the Cosmo extension through ordinary `.cos` documents.
+- Add validation that the workspace file is well-formed and only references paths that exist in the repository.
+- Document the workspace as the first manual editor smoke path for local extension testing.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cosmos-vscode-integration`: Adds a concrete sample workspace entry point for manual VSCode language-server evaluation.
+
+## Impact
+
+- Future implementation will add a `.code-workspace` asset under the sample/editor area and small validation coverage.
+- Makes manual VSCode testing repeatable without changing language-server semantics.
+- Provides a stable sample target for diagnostics, hover, and later navigation proposals.

--- a/openspec/changes/add-vscode-workspace-sample/specs/cosmos-vscode-integration/spec.md
+++ b/openspec/changes/add-vscode-workspace-sample/specs/cosmos-vscode-integration/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: VSCode Sample Workspace Is Available
+
+The repository SHALL provide a checked-in VSCode workspace sample that gives users a stable manual entry point for exercising the Cosmo extension against existing sample sources.
+
+#### Scenario: User opens the sample workspace
+
+- **WHEN** a user opens the sample workspace file in VSCode
+- **THEN** the workspace includes the existing sample package root
+- **AND** `samples/HelloWorld/main.cos` is available as the primary smoke document
+- **AND** opening the workspace is sufficient to activate the Cosmo extension for `.cos` files
+
+#### Scenario: Workspace references are stable
+
+- **WHEN** repository validation inspects the sample workspace file
+- **THEN** every referenced folder or file exists in the repository
+- **AND** generated output directories are not included as workspace folders

--- a/openspec/changes/add-vscode-workspace-sample/tasks.md
+++ b/openspec/changes/add-vscode-workspace-sample/tasks.md
@@ -1,0 +1,15 @@
+## 1. Workspace Asset
+
+- [ ] 1.1 Add a checked-in VSCode `.code-workspace` sample that opens the existing sample package root and highlights `samples/HelloWorld/main.cos` as the primary smoke file.
+- [ ] 1.2 Configure the workspace to avoid generated directories and repository build outputs.
+- [ ] 1.3 Keep language activation based on ordinary `.cos` files, without requiring custom commands before the workspace opens.
+
+## 2. Validation
+
+- [ ] 2.1 Add a repository check that parses the workspace JSON and verifies every referenced folder/file exists.
+- [ ] 2.2 Add a VSCode extension smoke note or test fixture that uses this workspace as the manual diagnostics/hover target.
+
+## 3. Documentation
+
+- [ ] 3.1 Update contributor or extension documentation with the exact workspace file to open from VSCode.
+- [ ] 3.2 Mention the expected first-screen experience: `HelloWorld/main.cos` is available as the starting file and the Cosmo extension activates for `.cos`.

--- a/openspec/changes/fix-diagnostics-active-document-switch/.openspec.yaml
+++ b/openspec/changes/fix-diagnostics-active-document-switch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/fix-diagnostics-active-document-switch/proposal.md
+++ b/openspec/changes/fix-diagnostics-active-document-switch/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Diagnostics currently appear stale when switching between open files: the visible diagnostics do not update to match the newly active document, and pressing `Ctrl+S` can make diagnostics disappear. Diagnostics should be tied to the active document URI and current in-memory text, not to save events or whichever file most recently triggered a publish.
+
+## What Changes
+
+- Add an active-editor diagnostics refresh path in the VSCode integration.
+- Keep Cosmos diagnostic state keyed by document URI so refreshing one file does not leak or clear diagnostics for another.
+- Ensure save-only events do not change diagnostics for unchanged text.
+- Add host/client smoke coverage with two open documents and an active-document switch.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cosmos-vscode-integration`: Adds active-document diagnostic refresh behavior in the editor integration.
+- `cosmos-diagnostics-pipeline`: Tightens per-URI diagnostic publication and refresh semantics.
+
+## Impact
+
+- Future implementation will touch `editors/vscode/src/lsp.ts`, host smoke tests, and possibly Cosmos diagnostics state helpers.
+- This proposal does not decide the HelloWorld false positives; it ensures the diagnostics shown belong to the active URI and update without saving.
+- The implementation should be compatible with both publish diagnostics and `textDocument/diagnostic` pull requests if both are kept.

--- a/openspec/changes/fix-diagnostics-active-document-switch/specs/cosmos-diagnostics-pipeline/spec.md
+++ b/openspec/changes/fix-diagnostics-active-document-switch/specs/cosmos-diagnostics-pipeline/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Diagnostic Publication Is URI-Scoped
+
+Cosmos diagnostics publication SHALL be scoped to the target document URI so refresh, publish, and clear operations for one document cannot mutate diagnostics for a different open document.
+
+#### Scenario: Refreshing one URI preserves another URI
+
+- **WHEN** Cosmos has published diagnostics for document A and document B
+- **AND** document A is refreshed
+- **THEN** the refresh publishes diagnostics for document A's URI only
+- **AND** document B's diagnostics are not cleared or replaced by document A's result
+
+#### Scenario: Repeated unchanged refresh is stable
+
+- **WHEN** Cosmos refreshes diagnostics for the same open document snapshot more than once
+- **THEN** each refresh produces the same diagnostics JSON
+- **AND** the result does not depend on whether the refresh was caused by open, change, active-editor switch, or save

--- a/openspec/changes/fix-diagnostics-active-document-switch/specs/cosmos-vscode-integration/spec.md
+++ b/openspec/changes/fix-diagnostics-active-document-switch/specs/cosmos-vscode-integration/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Active Document Diagnostics Refresh
+
+The VSCode integration SHALL refresh diagnostics for the active Cosmo document when the user switches between open Cosmo editors.
+
+#### Scenario: Switching files refreshes active diagnostics
+
+- **WHEN** two Cosmo documents are open in VSCode
+- **AND** the user switches the active editor from the first document to the second document
+- **THEN** the integration refreshes diagnostics for the second document URI
+- **AND** the diagnostics visible for the active editor correspond to the second document's current in-memory text
+- **AND** saving the document is not required to trigger the refresh
+
+#### Scenario: Save does not clear unchanged diagnostics
+
+- **WHEN** a Cosmo document has diagnostics for its current in-memory text
+- **AND** the user saves the document without changing that text
+- **THEN** the diagnostics for that document remain consistent with the pre-save diagnostics
+- **AND** the integration does not clear diagnostics solely because a save occurred

--- a/openspec/changes/fix-diagnostics-active-document-switch/tasks.md
+++ b/openspec/changes/fix-diagnostics-active-document-switch/tasks.md
@@ -1,0 +1,17 @@
+## 1. Client Refresh
+
+- [ ] 1.1 Add VSCode integration handling for active text editor changes when the active document is a Cosmo file.
+- [ ] 1.2 Request or republish diagnostics for the active document using its current in-memory text and URI.
+- [ ] 1.3 Ensure the refresh path does not require `Ctrl+S` and does not depend on the file's persisted on-disk contents.
+
+## 2. Per-URI Server Semantics
+
+- [ ] 2.1 Verify diagnostics are stored, published, and cleared by normalized document URI.
+- [ ] 2.2 Ensure refreshing document A never clears or overwrites diagnostics for document B.
+- [ ] 2.3 Ensure an unchanged save produces the same diagnostics as the pre-save snapshot.
+
+## 3. Validation
+
+- [ ] 3.1 Add a host/client smoke test that opens two Cosmo documents with different diagnostics states and switches the active editor.
+- [ ] 3.2 Verify diagnostics shown after the switch correspond to the active document URI.
+- [ ] 3.3 Verify pressing save without text changes does not make diagnostics disappear.

--- a/openspec/changes/fix-helloworld-diagnostics-false-positives/.openspec.yaml
+++ b/openspec/changes/fix-helloworld-diagnostics-false-positives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/fix-helloworld-diagnostics-false-positives/proposal.md
+++ b/openspec/changes/fix-helloworld-diagnostics-false-positives/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Opening `samples/HelloWorld/main.cos` currently produces many diagnostics in VSCode even though the sample is intended to be valid and is covered by the repository's compiler/sample paths. These diagnostics are false positives, so they make the language server look unreliable and obscure real errors.
+
+## What Changes
+
+- Add `samples/HelloWorld/main.cos` as an editor diagnostics regression fixture.
+- Align Cosmos document diagnostics with the parser/checker/package context that treats the sample as valid.
+- Ensure analyzer gaps for known-valid sample constructs do not surface as source diagnostics unless the compiler-facing pipeline also rejects the source.
+- Add host-level smoke coverage so the VSCode-launched server publishes an empty diagnostics array for `HelloWorld/main.cos`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cosmos-diagnostics-pipeline`: Adds known-valid sample regression behavior and tightens the boundary between real diagnostics and analyzer false positives.
+
+## Impact
+
+- Future implementation will touch `packages/cosmos/src/lsp/diagnostics.cos`, related tests, and possibly the VSCode host wrapper if it is constructing the wrong package/module snapshot for sample files.
+- The change should preserve real parser and checker diagnostics for invalid files.
+- This proposal is independent from active-editor diagnostic refresh; it fixes the content of diagnostics for the HelloWorld sample.

--- a/openspec/changes/fix-helloworld-diagnostics-false-positives/specs/cosmos-diagnostics-pipeline/spec.md
+++ b/openspec/changes/fix-helloworld-diagnostics-false-positives/specs/cosmos-diagnostics-pipeline/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Known-Valid Samples Do Not Produce Diagnostics
+
+Cosmos document diagnostics SHALL treat known-valid repository samples as diagnostics regression fixtures and SHALL NOT publish source diagnostics for those samples unless the compiler-facing pipeline also rejects them.
+
+#### Scenario: HelloWorld sample is clean
+
+- **WHEN** Cosmos analyzes `samples/HelloWorld/main.cos` using the sample package context
+- **THEN** it returns an empty diagnostics array
+- **AND** the VSCode-launched host publishes `textDocument/publishDiagnostics` for that URI with `diagnostics: []`
+
+#### Scenario: Invalid edit still reports diagnostics
+
+- **WHEN** the HelloWorld document text is changed to syntactically invalid Cosmo source
+- **THEN** Cosmos publishes parser diagnostics for that edited snapshot
+- **AND** the known-valid sample exemption does not suppress diagnostics for the edited invalid text
+
+### Requirement: Analyzer Gaps Do Not Become False Positives
+
+Cosmos diagnostics SHALL only publish checker diagnostics that are backed by the supported compiler-compatible analysis path for the current package and document snapshot.
+
+#### Scenario: Unsupported context is not reported as a source error
+
+- **WHEN** a document parses successfully but the current editor analyzer lacks package or standard-symbol context that the compiler-valid path provides
+- **THEN** Cosmos does not publish misleading source diagnostics for those missing analyzer internals
+- **AND** real parser diagnostics and supported checker diagnostics remain publishable

--- a/openspec/changes/fix-helloworld-diagnostics-false-positives/tasks.md
+++ b/openspec/changes/fix-helloworld-diagnostics-false-positives/tasks.md
@@ -1,0 +1,18 @@
+## 1. Reproduction
+
+- [ ] 1.1 Add a direct Cosmos diagnostics test for the exact text of `samples/HelloWorld/main.cos`.
+- [ ] 1.2 Add or update a VSCode host smoke test that opens the real HelloWorld sample URI and observes `textDocument/publishDiagnostics`.
+- [ ] 1.3 Capture the current false-positive diagnostic codes before changing behavior so the regression is explicit.
+
+## 2. Diagnostics Fix
+
+- [ ] 2.1 Fix package root, module path, standard symbol, or checker-context handling so HelloWorld analysis matches the compiler-valid path.
+- [ ] 2.2 Ensure unsupported analyzer limitations for known-valid constructs do not become editor source diagnostics.
+- [ ] 2.3 Keep parser diagnostics taking precedence for syntactically invalid documents.
+- [ ] 2.4 Keep checker diagnostics for documents that parse successfully and genuinely fail supported checking.
+
+## 3. Validation
+
+- [ ] 3.1 Verify `samples/HelloWorld/main.cos` publishes `[]` diagnostics through the host.
+- [ ] 3.2 Verify an intentionally invalid edit of the same document still publishes at least one diagnostic.
+- [ ] 3.3 Run the package and VSCode smoke tests that cover Cosmos diagnostics.


### PR DESCRIPTION
## Summary

- Add five independent OpenSpec proposals for the VSCode/Cosmos LSP follow-ups.
- Cover sample workspace, HelloWorld diagnostics false positives, active-document diagnostics refresh, language-server output channel, and definition/references.
- Keep this PR proposal-only so the specs can be driven independently later.

## Validation

- openspec validate add-vscode-workspace-sample
- openspec validate fix-helloworld-diagnostics-false-positives
- openspec validate fix-diagnostics-active-document-switch
- openspec validate add-vscode-lsp-output-channel
- openspec validate add-cosmos-definition-references