### PR TITLE
feat: accept mutable refs for readonly parameters (#75)

### DIFF
--- a/packages/cosmo0/src/main/scala/cosmo0/LirLowerer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirLowerer.scala
@@ -414,9 +414,18 @@ final class LirLowerer(
     private def adaptArgument(value: LirValue, expected: SourceType, span: SourceSpan): Option[LirValue] =
       SourceType.dealias(expected) match
         case SourceType.Ref(target, mutable) =>
+          val expectedRef = SourceType.Ref(target, mutable)
           SourceType.dealias(value.valueType.source) match
-            case SourceType.Ref(actualTarget, _) if SourceType.same(actualTarget, target) =>
+            case actual @ SourceType.Ref(actualTarget, _)
+                if SourceType.same(actualTarget, target) && SourceType.assignable(actual, expectedRef) =>
               Some(value)
+            case actual @ SourceType.Ref(actualTarget, _) if SourceType.same(actualTarget, target) =>
+              report(
+                "cosmo0.lir.lower.argument-mismatch",
+                s"cannot pass ${actual.display} as ${expected.display}",
+                span,
+              )
+              None
             case actual if SourceType.same(actual, target) && isBorrowable(value) =>
               Some(LirBorrowValue(value, mutable))
             case actual if SourceType.same(actual, target) =>

--- a/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/LirTypeChecker.scala
@@ -218,7 +218,7 @@ final class LirTypeChecker(
     ): Unit =
       SourceType.dealias(param.valueType.source) match
         case SourceType.Ref(target, mutable) =>
-          if !sameSourceType(target, receiver.valueType) || (receiver.mutable && !mutable) then
+          if !sameSourceType(target, receiver.valueType) || mutable != receiver.mutable then
             error(
               "cosmo0.lir.invalid-signature",
               s"${function.id} receiver parameter has type ${param.valueType.display}, expected receiver ${receiver.valueType.display}",

--- a/packages/cosmo0/src/main/scala/cosmo0/SourceTypes.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/SourceTypes.scala
@@ -87,7 +87,13 @@ object SourceType:
       case _ => false
 
   def assignable(from: SourceType, to: SourceType): Boolean =
-    same(from, to)
+    same(from, to) ||
+      ((dealias(from), dealias(to)) match
+        case (Ref(fromTarget, true), Ref(toTarget, false)) =>
+          same(fromTarget, toTarget)
+        case _ =>
+          false
+      )
 
   def isInteger(value: SourceType): Boolean =
     dealias(value) match

--- a/packages/cosmo0/src/test/scala/cosmo0/CppBackendTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/CppBackendTests.scala
@@ -179,6 +179,38 @@ class CppBackendTests extends munit.FunSuite:
     assert(output.contains("push_label(&labels);"))
     assertCxxAccepts(output)
 
+  test("Cosmo0 compile passes mutable references to readonly parameters"):
+    val result = Cosmo0().compile(
+      SourceFile(
+        "mut_to_readonly_ref.cos",
+        """def read_len(labels: &Vec[String]): usize = {
+          |  labels.len()
+          |}
+          |
+          |def pass_len(labels: &mut Vec[String]): usize = {
+          |  read_len(labels)
+          |}
+          |
+          |def main(): Unit = {
+          |  val labels = Vec[String]();
+          |  val size: usize = pass_len(labels)
+          |}
+          |""".stripMargin,
+      ),
+    )
+
+    assertEquals(result.phase, Phase.Compile)
+    assert(
+      result.isSuccess,
+      s"compile failed with diagnostics: ${result.diagnostics.map(d => d.code -> d.message)}",
+    )
+    val output = result.value.get.output
+    assert(output.contains("read_len(const std::vector<std::string> * labels)"))
+    assert(output.contains("pass_len(std::vector<std::string> * labels)"))
+    assert(output.contains("read_len(labels);"))
+    assert(output.contains("pass_len(&labels);"))
+    assertCxxAccepts(output)
+
   test("backend emits extern-bound std calls and typed runtime requirements"):
     val lowered = Cosmo0().lower(
       SourceFile(

--- a/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/LirTests.scala
@@ -128,6 +128,20 @@ class LirTests extends munit.FunSuite:
     assertEquals(function.signature.sourceSignature, Some(sourceSignature))
     assertEquals(function.signature.params, List(Lir.t(SourceType.I32)))
 
+  test("reference assignability allows mutable refs as readonly values but not the reverse"):
+    val boxType = SourceType.User("Box")
+    val readonlyRef = SourceType.Ref(boxType, mutable = false)
+    val mutableRef = SourceType.Ref(boxType, mutable = true)
+
+    assert(SourceType.assignable(mutableRef, readonlyRef))
+    assert(!SourceType.assignable(readonlyRef, mutableRef))
+    assert(
+      !SourceType.assignable(
+        SourceType.Function(List(mutableRef), SourceType.Unit),
+        SourceType.Function(List(readonlyRef), SourceType.Unit),
+      ),
+    )
+
   test("LIR type checker accepts a valid hand-written module"):
     val result = LirTypeChecker().check(checkedLirModule())
 
@@ -135,6 +149,94 @@ class LirTests extends munit.FunSuite:
     assertEquals(result.status, PhaseStatus.Succeeded)
     assert(result.diagnostics.isEmpty)
     assertEquals(result.value, Some(checkedLirModule()))
+
+  test("LIR type checker permits mutable refs for readonly arguments and rejects readonly refs for mutable arguments"):
+    val boxType = SourceType.User("Box")
+    val readonlyRef = SourceType.Ref(boxType, mutable = false)
+    val mutableRef = SourceType.Ref(boxType, mutable = true)
+
+    val readBox = Lir.function(
+      "read_box",
+      List(Lir.param("box", readonlyRef)),
+      SourceType.Unit,
+      locals = Nil,
+      blocks = List(Lir.block("entry", terminator = LirReturn(None))),
+    )
+    val callRead = Lir.function(
+      "call_read",
+      List(Lir.param("box", mutableRef)),
+      SourceType.Unit,
+      locals = Nil,
+      blocks = List(
+        Lir.block(
+          "entry",
+          operations = List(
+            LirDirectCall(
+              None,
+              Lir.declId("read_box"),
+              List(Lir.ref("box", mutableRef)),
+              Lir.signature(List(readonlyRef), SourceType.Unit),
+            ),
+          ),
+          terminator = LirReturn(None),
+        ),
+      ),
+    )
+    val accepted = LirTypeChecker().check(LirModule("refs", List(readBox, callRead)))
+    assertEquals(accepted.status, PhaseStatus.Succeeded)
+
+    val mutateBox = Lir.function(
+      "mutate_box",
+      List(Lir.param("box", mutableRef)),
+      SourceType.Unit,
+      locals = Nil,
+      blocks = List(Lir.block("entry", terminator = LirReturn(None))),
+    )
+    val callMutate = Lir.function(
+      "call_mutate",
+      List(Lir.param("box", readonlyRef)),
+      SourceType.Unit,
+      locals = Nil,
+      blocks = List(
+        Lir.block(
+          "entry",
+          operations = List(
+            LirDirectCall(
+              None,
+              Lir.declId("mutate_box"),
+              List(Lir.ref("box", readonlyRef)),
+              Lir.signature(List(mutableRef), SourceType.Unit),
+            ),
+          ),
+          terminator = LirReturn(None),
+        ),
+      ),
+    )
+    val rejected = LirTypeChecker().check(LirModule("refs", List(mutateBox, callMutate)))
+    assertEquals(rejected.status, PhaseStatus.Failed)
+    assert(rejected.diagnostics.exists(_.code == "cosmo0.lir.assignment-mismatch"))
+
+  test("LIR source signatures reject mutable receiver params for readonly receivers"):
+    val boxType = SourceType.User("Box")
+    val readonlySource = CallableSignature(
+      "inspect",
+      Nil,
+      SourceType.Unit,
+      Some(CallableReceiver(boxType, mutable = false)),
+    )
+    val function = Lir.function(
+      "inspect",
+      List(Lir.param("self", SourceType.Ref(boxType, mutable = true))),
+      SourceType.Unit,
+      locals = Nil,
+      blocks = List(Lir.block("entry", terminator = LirReturn(None))),
+      sourceSignature = Some(readonlySource),
+    )
+
+    val result = LirTypeChecker().check(LirModule("readonly", List(function)))
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assert(result.diagnostics.exists(_.code == "cosmo0.lir.invalid-signature"))
 
   test("LIR type checker rejects structural, type, call, variant, and mutability errors"):
     val cases = List(

--- a/packages/cosmoc/src/ir/lowering.cos
+++ b/packages/cosmoc/src/ir/lowering.cos
@@ -9,10 +9,10 @@ import types.declaration_resolution
 import types.model
 
 class IrDeclarationLowerer {
-  val arenas: SyntaxArenas
-  val names: NameResolution
-  val resolved: DeclarationResolution
-  val checked: ExpressionCheckResult
+  val arenas: &SyntaxArenas
+  val names: &NameResolution
+  val resolved: &DeclarationResolution
+  val checked: &ExpressionCheckResult
 
   def lower_module(&self, module_id: ModuleId): IrModule = {
     val module_value = self.arenas.module_value(module_id);
@@ -23,7 +23,7 @@ class IrDeclarationLowerer {
     IrModule("cosmo1", declarations)
   }
 
-  def lower_decl(&self, module_id: ModuleId, id: DeclId, declarations: Vec[IrDeclaration]): Unit = {
+  def lower_decl(&self, module_id: ModuleId, id: DeclId, declarations: &mut Vec[IrDeclaration]): Unit = {
     val decl = self.arenas.decl_value(id);
     decl match {
       case SyntaxDecl.Class(name, members, span) => {
@@ -50,16 +50,19 @@ class IrDeclarationLowerer {
     module_id: ModuleId,
     id: DeclId,
     name: String,
-    members: Vec[MemberId],
-    declarations: Vec[IrDeclaration]
+    members: &Vec[MemberId],
+    declarations: &mut Vec[IrDeclaration]
   ): Unit = {
     val class_signature = self.resolved.class_signatures.get(id);
     class_signature match {
       case Option[ClassSignature]::Some(signature) => {
         val fields = Vec[IrField]();
         val methods = Vec[IrDeclaration]();
-        for (member_id in members) {
+        var index: usize = 0;
+        while (index < members.len()) {
+          val member_id = members.get(index);
           self.lower_class_member(module_id, member_id, signature.definition, methods, fields)
+          index = index + 1
         }
         declarations.push(IrDeclaration.Type(IrTypeDecl(self.ir_id_for_def(signature.definition), name, fields)));
         for (method in methods) {
@@ -76,8 +79,8 @@ class IrDeclarationLowerer {
     module_id: ModuleId,
     id: MemberId,
     owner: DefId,
-    declarations: Vec[IrDeclaration],
-    fields: Vec[IrField]
+    declarations: &mut Vec[IrDeclaration],
+    fields: &mut Vec[IrField]
   ): Unit = {
     val member = self.arenas.member_value(id);
     member match {
@@ -98,7 +101,7 @@ class IrDeclarationLowerer {
     }
   }
 
-  def lower_field(&self, id: MemberId, name: String, fields: Vec[IrField]): Unit = {
+  def lower_field(&self, id: MemberId, name: String, fields: &mut Vec[IrField]): Unit = {
     val signature = self.resolved.field_signatures.get(id);
     signature match {
       case Option[FieldSignature]::Some(field) => {
@@ -116,7 +119,7 @@ class IrDeclarationLowerer {
     name: String,
     body: ExprId,
     owner: DefId,
-    declarations: Vec[IrDeclaration]
+    declarations: &mut Vec[IrDeclaration]
   ): Unit = {
     val signature = self.resolved.method_signatures.get(id);
     signature match {
@@ -128,7 +131,7 @@ class IrDeclarationLowerer {
     }
   }
 
-  def lower_function_decl(&self, module_id: ModuleId, id: DeclId, name: String, body: ExprId, declarations: Vec[IrDeclaration]): Unit = {
+  def lower_function_decl(&self, module_id: ModuleId, id: DeclId, name: String, body: ExprId, declarations: &mut Vec[IrDeclaration]): Unit = {
     val signature = self.resolved.function_signatures.get(id);
     signature match {
       case Option[CallableSignature]::Some(callable) => {
@@ -143,7 +146,7 @@ class IrDeclarationLowerer {
     &self,
     module_id: ModuleId,
     name: String,
-    signature: CallableSignature,
+    signature: &CallableSignature,
     body: ExprId,
     owner: Option[DefId]
   ): IrFunction = {
@@ -182,7 +185,7 @@ class IrDeclarationLowerer {
     )
   }
 
-  def lower_param(&self, id: ParamId, params: Vec[IrParam]): Unit = {
+  def lower_param(&self, id: ParamId, params: &mut Vec[IrParam]): Unit = {
     val signature = self.resolved.param_signatures.get(id);
     signature match {
       case Option[ParameterSignature]::Some(param) => {
@@ -261,12 +264,12 @@ class IrLoweredFunctionBody {
 }
 
 class IrFunctionBodyBuilder {
-  val arenas: SyntaxArenas
-  val names: NameResolution
-  val resolved: DeclarationResolution
-  val checked: ExpressionCheckResult
+  val arenas: &SyntaxArenas
+  val names: &NameResolution
+  val resolved: &DeclarationResolution
+  val checked: &ExpressionCheckResult
   val module_id: ModuleId
-  val signature: CallableSignature
+  val signature: &CallableSignature
   val params: Vec[IrParam]
   var locals: Vec[IrLocal]
   var operations: Vec[IrOperation]
@@ -285,7 +288,7 @@ class IrFunctionBodyBuilder {
     } else {
       val maybe_value = self.lower_expr(body);
       if (!self.terminated) {
-        self.terminate_return(maybe_value)
+        self.terminate_body_result(maybe_value)
       }
 
       self.finish_current_block();
@@ -388,12 +391,15 @@ class IrFunctionBodyBuilder {
     }
   }
 
-  def lower_block(&mut self, items: Vec[ExprId]): Option[IrValue] = {
+  def lower_block(&mut self, items: &Vec[ExprId]): Option[IrValue] = {
     var result = Option[IrValue]::Some(IrValue.Unit(self.signature.return_type));
-    for (item in items) {
+    var index: usize = 0;
+    while (index < items.len()) {
+      val item = items.get(index);
       if (!self.terminated) {
         result = self.lower_expr(item)
       }
+      index = index + 1
     }
     result
   }
@@ -532,7 +538,7 @@ class IrFunctionBodyBuilder {
     }
   }
 
-  def lower_call(&mut self, id: ExprId, typ: TypeId, callee: ExprId, args: Vec[ExprId]): Option[IrValue] = {
+  def lower_call(&mut self, id: ExprId, typ: TypeId, callee: ExprId, args: &Vec[ExprId]): Option[IrValue] = {
     val callee_expr = self.arenas.expr_value(callee);
     callee_expr match {
       case SyntaxExpr.Select(receiver, field, span) => {
@@ -593,7 +599,7 @@ class IrFunctionBodyBuilder {
     }
   }
 
-  def lower_construct_type(&mut self, name: String, typ: TypeId, args: Vec[ExprId]): Option[IrValue] = {
+  def lower_construct_type(&mut self, name: String, typ: TypeId, args: &Vec[ExprId]): Option[IrValue] = {
     val lowered_args = self.lower_args(args);
     if (lowered_args.len() != args.len()) {
       return Option[IrValue]::None
@@ -615,7 +621,7 @@ class IrFunctionBodyBuilder {
     Option[IrValue]::Some(IrValue.Local(output.id, typ))
   }
 
-  def construct_field_inits(&self, name: String, values: Vec[IrValue]): Vec[IrFieldInit] = {
+  def construct_field_inits(&self, name: String, values: &Vec[IrValue]): Vec[IrFieldInit] = {
     val result = Vec[IrFieldInit]();
     val members = self.constructor_members(name);
     var index: usize = 0;
@@ -669,8 +675,10 @@ class IrFunctionBodyBuilder {
     result
   }
 
-  def append_constructor_fields(&self, members: Vec[MemberId], result: Vec[MemberId]): Unit = {
-    for (member_id in members) {
+  def append_constructor_fields(&self, members: &Vec[MemberId], result: &mut Vec[MemberId]): Unit = {
+    var index: usize = 0;
+    while (index < members.len()) {
+      val member_id = members.get(index);
       val member = self.arenas.member_value(member_id);
       member match {
         case SyntaxMember.Field(field_name, mutable, typ, span) => {
@@ -687,6 +695,7 @@ class IrFunctionBodyBuilder {
         case SyntaxMember.Variant(member_name, fields, span) => {
         }
       }
+      index = index + 1
     }
   }
 
@@ -713,7 +722,7 @@ class IrFunctionBodyBuilder {
     callee: ExprId,
     receiver: ExprId,
     field: String,
-    args: Vec[ExprId]
+    args: &Vec[ExprId]
   ): Option[IrValue] = {
     val maybe_receiver = self.lower_expr(receiver);
     val lowered_args = self.lower_args(args);
@@ -996,16 +1005,19 @@ class IrFunctionBodyBuilder {
     true
   }
 
-  def prepend_arg(&self, first: IrValue, rest: Vec[IrValue]): Vec[IrValue] = {
+  def prepend_arg(&self, first: IrValue, rest: &Vec[IrValue]): Vec[IrValue] = {
     val result = Vec[IrValue]();
     result.push(first);
-    for (arg in rest) {
+    var index: usize = 0;
+    while (index < rest.len()) {
+      val arg = rest.get(index);
       result.push(arg)
+      index = index + 1
     }
     result
   }
 
-  def signature_with_receiver(&self, receiver: IrValue, signature: IrFunctionSignature): IrFunctionSignature = {
+  def signature_with_receiver(&self, receiver: IrValue, signature: &IrFunctionSignature): IrFunctionSignature = {
     val params = Vec[TypeId]();
     params.push(ir_value_type(receiver));
     for (param in signature.params) {
@@ -1060,9 +1072,11 @@ class IrFunctionBodyBuilder {
     ""
   }
 
-  def lower_args(&mut self, args: Vec[ExprId]): Vec[IrValue] = {
+  def lower_args(&mut self, args: &Vec[ExprId]): Vec[IrValue] = {
     val lowered = Vec[IrValue]();
-    for (arg in args) {
+    var index: usize = 0;
+    while (index < args.len()) {
+      val arg = args.get(index);
       val maybe_value = self.lower_expr(arg);
       maybe_value match {
         case Option[IrValue]::Some(value) => {
@@ -1071,6 +1085,7 @@ class IrFunctionBodyBuilder {
         case Option[IrValue]::None => {
         }
       }
+      index = index + 1
     }
     lowered
   }
@@ -1182,6 +1197,17 @@ class IrFunctionBodyBuilder {
     self.terminator = Option[IrTerminator]::Some(IrTerminator.Return(value))
   }
 
+  def terminate_body_result(&mut self, value: Option[IrValue]): Unit = {
+    value match {
+      case Option[IrValue]::Some(actual) => {
+        self.terminate_return(Option[IrValue]::Some(actual))
+      }
+      case Option[IrValue]::None => {
+        self.terminate_unreachable("body lowering pending")
+      }
+    }
+  }
+
   def terminate_branch(&mut self, target: IrBlockId): Unit = {
     self.terminated = true;
     self.terminator = Option[IrTerminator]::Some(IrTerminator.Branch(target))
@@ -1232,13 +1258,16 @@ class IrFunctionBodyBuilder {
     val expr = self.arenas.expr_value(id);
     expr match {
       case SyntaxExpr.Local(name, mutable, typ, init, span) => {
+        if (self.local_type_expr_is_missing(typ)) {
+          return self.local_init_type(init)
+        }
         val maybe_type = self.resolved.type_expr_types.get(typ);
         maybe_type match {
           case Option[TypeId]::Some(local_type) => {
             local_type
           }
           case Option[TypeId]::None => {
-            self.signature.return_type
+            self.local_init_type(init)
           }
         }
       }
@@ -1292,6 +1321,39 @@ class IrFunctionBodyBuilder {
       }
       case SyntaxExpr.Return(value, span) => {
         self.signature.return_type
+      }
+    }
+  }
+
+  def local_init_type(&self, init: ExprId): TypeId = {
+    val maybe_typed = self.checked.typed_exprs.get(init);
+    maybe_typed match {
+      case Option[TypedExpr]::Some(typed) => {
+        typed.typ
+      }
+      case Option[TypedExpr]::None => {
+        self.signature.return_type
+      }
+    }
+  }
+
+  def local_type_expr_is_missing(&self, id: TypeExprId): Bool = {
+    val typ = self.arenas.type_value(id);
+    typ match {
+      case SyntaxType.Missing(span) => {
+        true
+      }
+      case SyntaxType.AEmpty => {
+        true
+      }
+      case SyntaxType.Name(name, span) => {
+        false
+      }
+      case SyntaxType.Generic(base, args, span) => {
+        false
+      }
+      case SyntaxType.Ref(mutable, inner, span) => {
+        false
       }
     }
   }
@@ -1364,15 +1426,21 @@ class IrFunctionBodyBuilder {
   }
 
   def has_local_id(&self, name: String): Bool = {
-    for (param in self.params) {
+    var param_index: usize = 0;
+    while (param_index < self.params.len()) {
+      val param = self.params.get(param_index);
       if (param.id.value == name) {
         return true
       }
+      param_index = param_index + 1
     }
-    for (local in self.locals) {
+    var local_index: usize = 0;
+    while (local_index < self.locals.len()) {
+      val local = self.locals.get(local_index);
       if (local.id.value == name) {
         return true
       }
+      local_index = local_index + 1
     }
     false
   }
@@ -1399,12 +1467,7 @@ def ir_ordinal_text(value: usize): String = {
   if (value < 10) {
     return ir_digit_text(value)
   }
-  if (value < 100) {
-    val tens = value / 10;
-    val ones = value % 10;
-    return ir_digit_text(tens).concat(ir_digit_text(ones))
-  }
-  "many".concat(ir_digit_text(value % 10))
+  ir_ordinal_text(value / 10).concat(ir_digit_text(value % 10))
 }
 
 def ir_digit_text(value: usize): String = {
@@ -1450,10 +1513,10 @@ def ir_constructor_name_is_variant(name: String): Bool = {
 }
 
 def lower_module_declarations(
-  arenas: SyntaxArenas,
+  arenas: &SyntaxArenas,
   module_id: ModuleId,
-  names: NameResolution,
-  resolved: DeclarationResolution
+  names: &NameResolution,
+  resolved: &DeclarationResolution
 ): IrModule = {
   val checked = check_module_basic_expressions_with_resolution(arenas, module_id, names, resolved);
   IrDeclarationLowerer(arenas, names, resolved, checked).lower_module(module_id)

--- a/packages/cosmoc/src/ir/model.cos
+++ b/packages/cosmoc/src/ir/model.cos
@@ -125,6 +125,11 @@ class IrFunctionEnv {
   val defined: Vec[IrLocalId]
 }
 
+class IrVerifierEnv {
+  val function_param_counts: Map[String, usize]
+  val fields: Map[String, IrField]
+}
+
 def ir_decl_id(value: String): IrDeclId = {
   IrDeclId(value)
 }
@@ -166,31 +171,70 @@ def ir_value_type(value: IrValue): TypeId = {
 
 def verify_ir_module(types: &TypeStore, ir_module: &IrModule): IrVerifyResult = {
   val diagnostics = Vec[IrDiagnostic]();
+  val env = build_ir_verifier_env(ir_module);
   verify_duplicate_declarations(ir_module, diagnostics);
-  for (declaration in ir_module.declarations) {
+  val declarations: &Vec[IrDeclaration] = &ir_module.declarations;
+  var index: usize = 0;
+  while (index < declarations.len()) {
+    val declaration = declarations.get(index);
     declaration match {
       case IrDeclaration.Type(type_decl) => {
         verify_ir_type(type_decl, diagnostics)
       }
       case IrDeclaration.Function(fn_value) => {
-        verify_ir_function(types, ir_module, fn_value, diagnostics)
+        verify_ir_function(types, env, ir_module, fn_value, diagnostics)
       }
     }
+    index = index + 1
   }
   IrVerifyResult(diagnostics)
 }
 
-def verify_duplicate_declarations(ir_module: &IrModule, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
+def build_ir_verifier_env(ir_module: &IrModule): IrVerifierEnv = {
+  var function_param_counts = Map[String, usize]();
+  var fields = Map[String, IrField]();
+  val declarations: &Vec[IrDeclaration] = &ir_module.declarations;
   var index: usize = 0;
-  while (index < ir_module.declarations.len()) {
-    val current = declaration_id(ir_module.declarations.get(index));
-    var next = index + 1;
-    while (next < ir_module.declarations.len()) {
-      val other = declaration_id(ir_module.declarations.get(next));
-      if (current.value == other.value) {
-        ir_error(diagnostics, "cosmo1.ir.duplicate-declaration", "duplicate declaration ".concat(current.value))
+  while (index < declarations.len()) {
+    val declaration = declarations.get(index);
+    declaration match {
+      case IrDeclaration.Type(type_decl) => {
+        val type_fields: &Vec[IrField] = &type_decl.fields;
+        var field_index: usize = 0;
+        while (field_index < type_fields.len()) {
+          val field = type_fields.get(field_index);
+          val key = ir_field_key(type_decl.name, field.name);
+          if (!fields.contains_key(key)) {
+            fields.insert(key, field);
+          }
+          field_index = field_index + 1
+        }
       }
-      next = next + 1
+      case IrDeclaration.Function(fn_value) => {
+        if (!function_param_counts.contains_key(fn_value.id.value)) {
+          function_param_counts.insert(fn_value.id.value, fn_value.params.len());
+        }
+      }
+    }
+    index = index + 1
+  }
+  IrVerifierEnv(function_param_counts, fields)
+}
+
+def ir_field_key(type_name: String, field_name: String): String = {
+  type_name.concat(".").concat(field_name)
+}
+
+def verify_duplicate_declarations(ir_module: &IrModule, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
+  var seen = Set[String]();
+  val declarations: &Vec[IrDeclaration] = &ir_module.declarations;
+  var index: usize = 0;
+  while (index < declarations.len()) {
+    val current = declaration_id(declarations.get(index));
+    if (seen.contains(current.value)) {
+      ir_error(diagnostics, "cosmo1.ir.duplicate-declaration", "duplicate declaration ".concat(current.value))
+    } else {
+      seen.insert(current.value)
     }
     index = index + 1
   }
@@ -208,12 +252,13 @@ def declaration_id(declaration: IrDeclaration): IrDeclId = {
 }
 
 def verify_ir_type(type_decl: &IrTypeDecl, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
+  val fields: &Vec[IrField] = &type_decl.fields;
   var index: usize = 0;
-  while (index < type_decl.fields.len()) {
-    val current = type_decl.fields.get(index).name;
+  while (index < fields.len()) {
+    val current = fields.get(index).name;
     var next = index + 1;
-    while (next < type_decl.fields.len()) {
-      val other = type_decl.fields.get(next).name;
+    while (next < fields.len()) {
+      val other = fields.get(next).name;
       if (current == other) {
         ir_error(diagnostics, "cosmo1.ir.duplicate-field", "duplicate field ".concat(current))
       }
@@ -225,11 +270,13 @@ def verify_ir_type(type_decl: &IrTypeDecl, diagnostics: &mut Vec[IrDiagnostic]):
 
 def verify_ir_function(
   types: &TypeStore,
+  env: &IrVerifierEnv,
   ir_module: &IrModule,
   fn_value: &IrFunction,
   diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
-  if (fn_value.blocks.is_empty()) {
+  val blocks: &Vec[IrBlock] = &fn_value.blocks;
+  if (blocks.is_empty()) {
     ir_error(diagnostics, "cosmo1.ir.missing-block", "fn_value ".concat(fn_value.id.value).concat(" has no blocks"));
   } else {
     verify_duplicate_params(fn_value, diagnostics);
@@ -237,19 +284,25 @@ def verify_ir_function(
     verify_duplicate_blocks(fn_value, diagnostics);
     verify_branch_targets(fn_value, diagnostics);
 
-    for (block in fn_value.blocks) {
-      verify_ir_block(types, ir_module, fn_value, block, diagnostics)
+    val function_env = initial_function_env(fn_value);
+    define_function_operation_outputs(fn_value, function_env);
+    var index: usize = 0;
+    while (index < blocks.len()) {
+      val block = blocks.get(index);
+      verify_ir_block(types, env, ir_module, fn_value, block, function_env, diagnostics);
+      index = index + 1
     }
   }
 }
 
 def verify_duplicate_params(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
+  val params: &Vec[IrParam] = &fn_value.params;
   var index: usize = 0;
-  while (index < fn_value.params.len()) {
-    val current = fn_value.params.get(index).id;
+  while (index < params.len()) {
+    val current = params.get(index).id;
     var next = index + 1;
-    while (next < fn_value.params.len()) {
-      val other = fn_value.params.get(next).id;
+    while (next < params.len()) {
+      val other = params.get(next).id;
       if (current.value == other.value) {
         ir_error(diagnostics, "cosmo1.ir.duplicate-local", "duplicate parameter ".concat(current.value))
       }
@@ -260,15 +313,16 @@ def verify_duplicate_params(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagn
 }
 
 def verify_duplicate_locals(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
+  val locals: &Vec[IrLocal] = &fn_value.locals;
   var index: usize = 0;
-  while (index < fn_value.locals.len()) {
-    val current = fn_value.locals.get(index).id;
+  while (index < locals.len()) {
+    val current = locals.get(index).id;
     if (function_has_param(fn_value, current)) {
       ir_error(diagnostics, "cosmo1.ir.duplicate-local", "local duplicates parameter ".concat(current.value))
     }
     var next = index + 1;
-    while (next < fn_value.locals.len()) {
-      val other = fn_value.locals.get(next).id;
+    while (next < locals.len()) {
+      val other = locals.get(next).id;
       if (current.value == other.value) {
         ir_error(diagnostics, "cosmo1.ir.duplicate-local", "duplicate local ".concat(current.value))
       }
@@ -279,12 +333,13 @@ def verify_duplicate_locals(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagn
 }
 
 def verify_duplicate_blocks(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
+  val blocks: &Vec[IrBlock] = &fn_value.blocks;
   var index: usize = 0;
-  while (index < fn_value.blocks.len()) {
-    val current = fn_value.blocks.get(index).id;
+  while (index < blocks.len()) {
+    val current = blocks.get(index).id;
     var next = index + 1;
-    while (next < fn_value.blocks.len()) {
-      val other = fn_value.blocks.get(next).id;
+    while (next < blocks.len()) {
+      val other = blocks.get(next).id;
       if (current.value == other.value) {
         ir_error(diagnostics, "cosmo1.ir.duplicate-block", "duplicate block ".concat(current.value))
       }
@@ -295,7 +350,10 @@ def verify_duplicate_blocks(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagn
 }
 
 def verify_branch_targets(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
-  for (block in fn_value.blocks) {
+  val blocks: &Vec[IrBlock] = &fn_value.blocks;
+  var index: usize = 0;
+  while (index < blocks.len()) {
+    val block = blocks.get(index);
     block.terminator match {
       case IrTerminator.Return(value) => {
       }
@@ -309,6 +367,7 @@ def verify_branch_targets(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnos
       case IrTerminator.Unreachable(reason) => {
       }
     }
+    index = index + 1
   }
 }
 
@@ -320,32 +379,47 @@ def verify_block_target(fn_value: &IrFunction, target: IrBlockId, diagnostics: &
 
 def verify_ir_block(
   types: &TypeStore,
+  env: &IrVerifierEnv,
   ir_module: &IrModule,
   fn_value: &IrFunction,
   block: &IrBlock,
+  function_env: &mut IrFunctionEnv,
   diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
-  val env = initial_function_env(fn_value);
-  define_function_operation_outputs(fn_value, env);
-  for (operation in block.operations) {
-    verify_ir_operation(types, ir_module, fn_value, env, operation, diagnostics)
+  val operations: &Vec[IrOperation] = &block.operations;
+  var index: usize = 0;
+  while (index < operations.len()) {
+    val operation = operations.get(index);
+    verify_ir_operation(types, env, ir_module, fn_value, function_env, operation, diagnostics);
+    index = index + 1
   }
-  verify_ir_terminator(types, fn_value, env, block.terminator, diagnostics)
+  verify_ir_terminator(types, fn_value, function_env, block.terminator, diagnostics)
 }
 
 def initial_function_env(fn_value: &IrFunction): IrFunctionEnv = {
   val defined = Vec[IrLocalId]();
-  for (param in fn_value.params) {
+  val params: &Vec[IrParam] = &fn_value.params;
+  var index: usize = 0;
+  while (index < params.len()) {
+    val param = params.get(index);
     defined.push(param.id)
+    index = index + 1
   }
   IrFunctionEnv(defined)
 }
 
 def define_function_operation_outputs(fn_value: &IrFunction, env: &mut IrFunctionEnv): Unit = {
-  for (block in fn_value.blocks) {
-    for (operation in block.operations) {
-      define_operation_output(operation, env)
+  val blocks: &Vec[IrBlock] = &fn_value.blocks;
+  var block_index: usize = 0;
+  while (block_index < blocks.len()) {
+    val block = blocks.get(block_index);
+    val operations: &Vec[IrOperation] = &block.operations;
+    var operation_index: usize = 0;
+    while (operation_index < operations.len()) {
+      define_operation_output(operations.get(operation_index), env);
+      operation_index = operation_index + 1
     }
+    block_index = block_index + 1
   }
 }
 
@@ -389,6 +463,7 @@ def define_optional_local(env: &mut IrFunctionEnv, output: Option[IrLocalId]): U
 
 def verify_ir_operation(
   types: &TypeStore,
+  verifier_env: &IrVerifierEnv,
   ir_module: &IrModule,
   fn_value: &IrFunction,
   env: &mut IrFunctionEnv,
@@ -407,19 +482,19 @@ def verify_ir_operation(
       define_local(env, target)
     }
     case IrOperation.ConstructType(output, owner, fields) => {
-      verify_construct_type(types, ir_module, fn_value, env, output, owner, fields, diagnostics)
+      verify_construct_type(types, verifier_env, fn_value, env, output, owner, fields, diagnostics)
     }
     case IrOperation.DirectCall(output, callee, args, signature) => {
-      verify_call(types, ir_module, fn_value, env, output, callee, args, signature, diagnostics)
+      verify_call(types, verifier_env, ir_module, fn_value, env, output, callee, args, signature, diagnostics)
     }
     case IrOperation.IntrinsicCall(output, name, args, signature) => {
       verify_intrinsic_call(types, fn_value, env, output, name, args, signature, diagnostics)
     }
     case IrOperation.FieldGet(output, receiver, field, result_type) => {
-      verify_field_get(types, ir_module, fn_value, env, output, receiver, field, result_type, diagnostics)
+      verify_field_get(types, verifier_env, fn_value, env, output, receiver, field, result_type, diagnostics)
     }
     case IrOperation.FieldSet(receiver, field, value) => {
-      verify_field_set(types, ir_module, fn_value, env, receiver, field, value, diagnostics)
+      verify_field_set(types, verifier_env, fn_value, env, receiver, field, value, diagnostics)
     }
     case IrOperation.Binary(output, op, left, right, result_type) => {
       verify_binary(types, fn_value, env, output, op, left, right, result_type, diagnostics)
@@ -429,7 +504,7 @@ def verify_ir_operation(
 
 def verify_construct_type(
   types: &TypeStore,
-  ir_module: &IrModule,
+  verifier_env: &IrVerifierEnv,
   fn_value: &IrFunction,
   env: &mut IrFunctionEnv,
   output: IrLocalId,
@@ -441,7 +516,7 @@ def verify_construct_type(
   while (index < fields.len()) {
     val init = fields.get(index);
     verify_value(types, fn_value, env, init.value, diagnostics);
-    val maybe_field = find_ir_field(types, ir_module, owner, init.name);
+    val maybe_field = find_ir_field(types, verifier_env, owner, init.name);
     maybe_field match {
       case Option[IrField]::Some(field_value) => {
         if (!ir_type_equals(types, field_value.typ, ir_value_type(init.value))) {
@@ -460,7 +535,7 @@ def verify_construct_type(
 
 def verify_field_get(
   types: &TypeStore,
-  ir_module: &IrModule,
+  verifier_env: &IrVerifierEnv,
   fn_value: &IrFunction,
   env: &mut IrFunctionEnv,
   output: IrLocalId,
@@ -470,7 +545,7 @@ def verify_field_get(
   diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   verify_value(types, fn_value, env, receiver, diagnostics);
-  val maybe_field = find_ir_field(types, ir_module, ir_value_type(receiver), field);
+  val maybe_field = find_ir_field(types, verifier_env, ir_value_type(receiver), field);
   maybe_field match {
     case Option[IrField]::Some(field_value) => {
       if (!ir_type_equals(types, field_value.typ, result_type)) {
@@ -487,7 +562,7 @@ def verify_field_get(
 
 def verify_field_set(
   types: &TypeStore,
-  ir_module: &IrModule,
+  verifier_env: &IrVerifierEnv,
   fn_value: &IrFunction,
   env: &mut IrFunctionEnv,
   receiver: IrValue,
@@ -497,7 +572,7 @@ def verify_field_set(
 ): Unit = {
   verify_value(types, fn_value, env, receiver, diagnostics);
   verify_value(types, fn_value, env, value, diagnostics);
-  val maybe_field = find_ir_field(types, ir_module, ir_value_type(receiver), field);
+  val maybe_field = find_ir_field(types, verifier_env, ir_value_type(receiver), field);
   maybe_field match {
     case Option[IrField]::Some(field_value) => {
       if (!field_value.mutable) {
@@ -538,6 +613,7 @@ def verify_binary(
 
 def verify_call(
   types: &TypeStore,
+  verifier_env: &IrVerifierEnv,
   ir_module: &IrModule,
   fn_value: &IrFunction,
   env: &mut IrFunctionEnv,
@@ -547,16 +623,17 @@ def verify_call(
   signature: IrFunctionSignature,
   diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
-  verify_function_callee(ir_module, callee, signature, diagnostics);
-  if (args.len() != signature.params.len()) {
+  val params: &Vec[TypeId] = &signature.params;
+  verify_function_callee(verifier_env, callee, signature, diagnostics);
+  if (args.len() != params.len()) {
     ir_error(diagnostics, "cosmo1.ir.invalid-call", "call arity mismatch for ".concat(callee.value))
   }
 
   var index: usize = 0;
-  while (index < args.len() and index < signature.params.len()) {
+  while (index < args.len() and index < params.len()) {
     val arg = args.get(index);
     verify_value(types, fn_value, env, arg, diagnostics);
-    if (!ir_type_equals(types, ir_value_type(arg), signature.params.get(index))) {
+    if (!ir_type_equals(types, ir_value_type(arg), params.get(index))) {
       ir_error(diagnostics, "cosmo1.ir.invalid-call", "call argument type mismatch for ".concat(callee.value))
     }
     index = index + 1
@@ -585,18 +662,19 @@ def verify_intrinsic_call(
   signature: IrFunctionSignature,
   diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
+  val params: &Vec[TypeId] = &signature.params;
   if (!ir_intrinsic_is_known(name)) {
     ir_error(diagnostics, "cosmo1.ir.invalid-intrinsic", "unknown intrinsic ".concat(name))
   }
-  if (args.len() != signature.params.len()) {
+  if (args.len() != params.len()) {
     ir_error(diagnostics, "cosmo1.ir.invalid-intrinsic", "intrinsic arity mismatch for ".concat(name))
   }
 
   var index: usize = 0;
-  while (index < args.len() and index < signature.params.len()) {
+  while (index < args.len() and index < params.len()) {
     val arg = args.get(index);
     verify_value(types, fn_value, env, arg, diagnostics);
-    if (!ir_type_equals(types, ir_value_type(arg), signature.params.get(index))) {
+    if (!ir_type_equals(types, ir_value_type(arg), params.get(index))) {
       ir_error(diagnostics, "cosmo1.ir.invalid-intrinsic", "intrinsic argument type mismatch for ".concat(name))
     }
     index = index + 1
@@ -625,19 +703,19 @@ def ir_intrinsic_is_known(name: String): Bool = {
 }
 
 def verify_function_callee(
-  ir_module: &IrModule,
+  env: &IrVerifierEnv,
   callee: IrDeclId,
   signature: IrFunctionSignature,
   diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
-  val maybe_function = find_function(ir_module, callee);
-  maybe_function match {
-    case Option[IrFunction]::Some(fn_value) => {
-      if (fn_value.params.len() != signature.params.len()) {
+  val maybe_param_count = env.function_param_counts.get(callee.value);
+  maybe_param_count match {
+    case Option[usize]::Some(param_count) => {
+      if (param_count != signature.params.len()) {
         ir_error(diagnostics, "cosmo1.ir.invalid-call", "callee signature arity mismatch for ".concat(callee.value))
       }
     }
-    case Option[IrFunction]::None => {
+    case Option[usize]::None => {
       ir_error(diagnostics, "cosmo1.ir.invalid-call", "unknown callee ".concat(callee.value))
     }
   }
@@ -740,9 +818,10 @@ def verify_defined_local_type(
 }
 
 def find_function(ir_module: &IrModule, id: IrDeclId): Option[IrFunction] = {
+  val declarations: &Vec[IrDeclaration] = &ir_module.declarations;
   var index: usize = 0;
-  while (index < ir_module.declarations.len()) {
-    val declaration = ir_module.declarations.get(index);
+  while (index < declarations.len()) {
+    val declaration = declarations.get(index);
     declaration match {
       case IrDeclaration.Function(fn_value) => {
         if (fn_value.id.value == id.value) {
@@ -757,29 +836,16 @@ def find_function(ir_module: &IrModule, id: IrDeclId): Option[IrFunction] = {
   Option[IrFunction]::None
 }
 
-def find_ir_field(types: &TypeStore, ir_module: &IrModule, receiver_type: TypeId, name: String): Option[IrField] = {
+def find_ir_field(types: &TypeStore, env: &IrVerifierEnv, receiver_type: TypeId, name: String): Option[IrField] = {
   val receiver_name = ir_receiver_type_name(types, receiver_type);
-  var index: usize = 0;
-  while (index < ir_module.declarations.len()) {
-    val declaration = ir_module.declarations.get(index);
-    declaration match {
-      case IrDeclaration.Type(type_decl) => {
-        if (type_decl.name == receiver_name) {
-          return find_type_field(type_decl, name)
-        }
-      }
-      case IrDeclaration.Function(fn_value) => {
-      }
-    }
-    index = index + 1
-  }
-  Option[IrField]::None
+  env.fields.get(ir_field_key(receiver_name, name))
 }
 
 def find_type_field(type_decl: &IrTypeDecl, name: String): Option[IrField] = {
+  val fields: &Vec[IrField] = &type_decl.fields;
   var index: usize = 0;
-  while (index < type_decl.fields.len()) {
-    val field = type_decl.fields.get(index);
+  while (index < fields.len()) {
+    val field = fields.get(index);
     if (field.name == name) {
       return Option[IrField]::Some(field)
     }
@@ -813,17 +879,19 @@ def ir_receiver_type_name(types: &TypeStore, id: TypeId): String = {
 }
 
 def find_local_type(fn_value: &IrFunction, id: IrLocalId): Option[TypeId] = {
+  val params: &Vec[IrParam] = &fn_value.params;
   var param_index: usize = 0;
-  while (param_index < fn_value.params.len()) {
-    val param = fn_value.params.get(param_index);
+  while (param_index < params.len()) {
+    val param = params.get(param_index);
     if (param.id.value == id.value) {
       return Option[TypeId]::Some(param.typ)
     }
     param_index = param_index + 1
   }
+  val locals: &Vec[IrLocal] = &fn_value.locals;
   var local_index: usize = 0;
-  while (local_index < fn_value.locals.len()) {
-    val local = fn_value.locals.get(local_index);
+  while (local_index < locals.len()) {
+    val local = locals.get(local_index);
     if (local.id.value == id.value) {
       return Option[TypeId]::Some(local.typ)
     }
@@ -833,9 +901,10 @@ def find_local_type(fn_value: &IrFunction, id: IrLocalId): Option[TypeId] = {
 }
 
 def function_has_param(fn_value: &IrFunction, id: IrLocalId): Bool = {
+  val params: &Vec[IrParam] = &fn_value.params;
   var index: usize = 0;
-  while (index < fn_value.params.len()) {
-    val param = fn_value.params.get(index);
+  while (index < params.len()) {
+    val param = params.get(index);
     if (param.id.value == id.value) {
       return true
     }
@@ -857,9 +926,10 @@ def function_has_local_or_param(fn_value: &IrFunction, id: IrLocalId): Bool = {
 }
 
 def function_has_block(fn_value: &IrFunction, id: IrBlockId): Bool = {
+  val blocks: &Vec[IrBlock] = &fn_value.blocks;
   var index: usize = 0;
-  while (index < fn_value.blocks.len()) {
-    val block = fn_value.blocks.get(index);
+  while (index < blocks.len()) {
+    val block = blocks.get(index);
     if (block.id.value == id.value) {
       return true
     }
@@ -869,9 +939,10 @@ def function_has_block(fn_value: &IrFunction, id: IrBlockId): Bool = {
 }
 
 def local_is_defined(env: &mut IrFunctionEnv, id: IrLocalId): Bool = {
+  val defined: &Vec[IrLocalId] = &env.defined;
   var index: usize = 0;
-  while (index < env.defined.len()) {
-    val defined_id = env.defined.get(index);
+  while (index < defined.len()) {
+    val defined_id = defined.get(index);
     if (defined_id.value == id.value) {
       return true
     }

--- a/packages/cosmoc/src/ir/model.cos
+++ b/packages/cosmoc/src/ir/model.cos
@@ -164,7 +164,7 @@ def ir_value_type(value: IrValue): TypeId = {
   }
 }
 
-def verify_ir_module(types: TypeStore, ir_module: IrModule): IrVerifyResult = {
+def verify_ir_module(types: &TypeStore, ir_module: &IrModule): IrVerifyResult = {
   val diagnostics = Vec[IrDiagnostic]();
   verify_duplicate_declarations(ir_module, diagnostics);
   for (declaration in ir_module.declarations) {
@@ -180,7 +180,7 @@ def verify_ir_module(types: TypeStore, ir_module: IrModule): IrVerifyResult = {
   IrVerifyResult(diagnostics)
 }
 
-def verify_duplicate_declarations(ir_module: IrModule, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_duplicate_declarations(ir_module: &IrModule, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   var index: usize = 0;
   while (index < ir_module.declarations.len()) {
     val current = declaration_id(ir_module.declarations.get(index));
@@ -207,7 +207,7 @@ def declaration_id(declaration: IrDeclaration): IrDeclId = {
   }
 }
 
-def verify_ir_type(type_decl: IrTypeDecl, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_ir_type(type_decl: &IrTypeDecl, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   var index: usize = 0;
   while (index < type_decl.fields.len()) {
     val current = type_decl.fields.get(index).name;
@@ -224,10 +224,10 @@ def verify_ir_type(type_decl: IrTypeDecl, diagnostics: Vec[IrDiagnostic]): Unit 
 }
 
 def verify_ir_function(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  diagnostics: Vec[IrDiagnostic]
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   if (fn_value.blocks.is_empty()) {
     ir_error(diagnostics, "cosmo1.ir.missing-block", "fn_value ".concat(fn_value.id.value).concat(" has no blocks"));
@@ -243,7 +243,7 @@ def verify_ir_function(
   }
 }
 
-def verify_duplicate_params(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_duplicate_params(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   var index: usize = 0;
   while (index < fn_value.params.len()) {
     val current = fn_value.params.get(index).id;
@@ -259,7 +259,7 @@ def verify_duplicate_params(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]
   }
 }
 
-def verify_duplicate_locals(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_duplicate_locals(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   var index: usize = 0;
   while (index < fn_value.locals.len()) {
     val current = fn_value.locals.get(index).id;
@@ -278,7 +278,7 @@ def verify_duplicate_locals(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]
   }
 }
 
-def verify_duplicate_blocks(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_duplicate_blocks(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   var index: usize = 0;
   while (index < fn_value.blocks.len()) {
     val current = fn_value.blocks.get(index).id;
@@ -294,7 +294,7 @@ def verify_duplicate_blocks(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]
   }
 }
 
-def verify_branch_targets(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_branch_targets(fn_value: &IrFunction, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   for (block in fn_value.blocks) {
     block.terminator match {
       case IrTerminator.Return(value) => {
@@ -312,18 +312,18 @@ def verify_branch_targets(fn_value: IrFunction, diagnostics: Vec[IrDiagnostic]):
   }
 }
 
-def verify_block_target(fn_value: IrFunction, target: IrBlockId, diagnostics: Vec[IrDiagnostic]): Unit = {
+def verify_block_target(fn_value: &IrFunction, target: IrBlockId, diagnostics: &mut Vec[IrDiagnostic]): Unit = {
   if (!function_has_block(fn_value, target)) {
     ir_error(diagnostics, "cosmo1.ir.invalid-branch", "missing block ".concat(target.value))
   }
 }
 
 def verify_ir_block(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  block: IrBlock,
-  diagnostics: Vec[IrDiagnostic]
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  block: &IrBlock,
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   val env = initial_function_env(fn_value);
   define_function_operation_outputs(fn_value, env);
@@ -333,7 +333,7 @@ def verify_ir_block(
   verify_ir_terminator(types, fn_value, env, block.terminator, diagnostics)
 }
 
-def initial_function_env(fn_value: IrFunction): IrFunctionEnv = {
+def initial_function_env(fn_value: &IrFunction): IrFunctionEnv = {
   val defined = Vec[IrLocalId]();
   for (param in fn_value.params) {
     defined.push(param.id)
@@ -341,7 +341,7 @@ def initial_function_env(fn_value: IrFunction): IrFunctionEnv = {
   IrFunctionEnv(defined)
 }
 
-def define_function_operation_outputs(fn_value: IrFunction, env: IrFunctionEnv): Unit = {
+def define_function_operation_outputs(fn_value: &IrFunction, env: &mut IrFunctionEnv): Unit = {
   for (block in fn_value.blocks) {
     for (operation in block.operations) {
       define_operation_output(operation, env)
@@ -349,7 +349,7 @@ def define_function_operation_outputs(fn_value: IrFunction, env: IrFunctionEnv):
   }
 }
 
-def define_operation_output(operation: IrOperation, env: IrFunctionEnv): Unit = {
+def define_operation_output(operation: IrOperation, env: &mut IrFunctionEnv): Unit = {
   operation match {
     case IrOperation.InitLocal(target, value) => {
       define_local(env, target)
@@ -377,7 +377,7 @@ def define_operation_output(operation: IrOperation, env: IrFunctionEnv): Unit = 
   }
 }
 
-def define_optional_local(env: IrFunctionEnv, output: Option[IrLocalId]): Unit = {
+def define_optional_local(env: &mut IrFunctionEnv, output: Option[IrLocalId]): Unit = {
   output match {
     case Option[IrLocalId]::Some(target) => {
       define_local(env, target)
@@ -388,12 +388,12 @@ def define_optional_local(env: IrFunctionEnv, output: Option[IrLocalId]): Unit =
 }
 
 def verify_ir_operation(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   operation: IrOperation,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   operation match {
     case IrOperation.InitLocal(target, value) => {
@@ -428,14 +428,14 @@ def verify_ir_operation(
 }
 
 def verify_construct_type(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   output: IrLocalId,
   owner: TypeId,
-  fields: Vec[IrFieldInit],
-  diagnostics: Vec[IrDiagnostic]
+  fields: &Vec[IrFieldInit],
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   var index: usize = 0;
   while (index < fields.len()) {
@@ -459,15 +459,15 @@ def verify_construct_type(
 }
 
 def verify_field_get(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   output: IrLocalId,
   receiver: IrValue,
   field: String,
   result_type: TypeId,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   verify_value(types, fn_value, env, receiver, diagnostics);
   val maybe_field = find_ir_field(types, ir_module, ir_value_type(receiver), field);
@@ -486,14 +486,14 @@ def verify_field_get(
 }
 
 def verify_field_set(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   receiver: IrValue,
   field: String,
   value: IrValue,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   verify_value(types, fn_value, env, receiver, diagnostics);
   verify_value(types, fn_value, env, value, diagnostics);
@@ -514,15 +514,15 @@ def verify_field_set(
 }
 
 def verify_binary(
-  types: TypeStore,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   output: IrLocalId,
   op: String,
   left: IrValue,
   right: IrValue,
   result_type: TypeId,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   verify_value(types, fn_value, env, left, diagnostics);
   verify_value(types, fn_value, env, right, diagnostics);
@@ -537,15 +537,15 @@ def verify_binary(
 }
 
 def verify_call(
-  types: TypeStore,
-  ir_module: IrModule,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  ir_module: &IrModule,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   output: Option[IrLocalId],
   callee: IrDeclId,
-  args: Vec[IrValue],
+  args: &Vec[IrValue],
   signature: IrFunctionSignature,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   verify_function_callee(ir_module, callee, signature, diagnostics);
   if (args.len() != signature.params.len()) {
@@ -576,14 +576,14 @@ def verify_call(
 }
 
 def verify_intrinsic_call(
-  types: TypeStore,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   output: Option[IrLocalId],
   name: String,
-  args: Vec[IrValue],
+  args: &Vec[IrValue],
   signature: IrFunctionSignature,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   if (!ir_intrinsic_is_known(name)) {
     ir_error(diagnostics, "cosmo1.ir.invalid-intrinsic", "unknown intrinsic ".concat(name))
@@ -625,10 +625,10 @@ def ir_intrinsic_is_known(name: String): Bool = {
 }
 
 def verify_function_callee(
-  ir_module: IrModule,
+  ir_module: &IrModule,
   callee: IrDeclId,
   signature: IrFunctionSignature,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   val maybe_function = find_function(ir_module, callee);
   maybe_function match {
@@ -644,11 +644,11 @@ def verify_function_callee(
 }
 
 def verify_ir_terminator(
-  types: TypeStore,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   terminator: IrTerminator,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   terminator match {
     case IrTerminator.Return(value) => {
@@ -668,11 +668,11 @@ def verify_ir_terminator(
 }
 
 def verify_return(
-  types: TypeStore,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   value: Option[IrValue],
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   value match {
     case Option[IrValue]::Some(actual) => {
@@ -690,11 +690,11 @@ def verify_return(
 }
 
 def verify_value(
-  types: TypeStore,
-  fn_value: IrFunction,
-  env: IrFunctionEnv,
+  types: &TypeStore,
+  fn_value: &IrFunction,
+  env: &mut IrFunctionEnv,
   value: IrValue,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   value match {
     case IrValue.Unit(typ) => {
@@ -720,11 +720,11 @@ def verify_value(
 }
 
 def verify_defined_local_type(
-  types: TypeStore,
-  fn_value: IrFunction,
+  types: &TypeStore,
+  fn_value: &IrFunction,
   id: IrLocalId,
   actual: TypeId,
-  diagnostics: Vec[IrDiagnostic]
+  diagnostics: &mut Vec[IrDiagnostic]
 ): Unit = {
   val maybe_expected = find_local_type(fn_value, id);
   maybe_expected match {
@@ -739,8 +739,10 @@ def verify_defined_local_type(
   }
 }
 
-def find_function(ir_module: IrModule, id: IrDeclId): Option[IrFunction] = {
-  for (declaration in ir_module.declarations) {
+def find_function(ir_module: &IrModule, id: IrDeclId): Option[IrFunction] = {
+  var index: usize = 0;
+  while (index < ir_module.declarations.len()) {
+    val declaration = ir_module.declarations.get(index);
     declaration match {
       case IrDeclaration.Function(fn_value) => {
         if (fn_value.id.value == id.value) {
@@ -750,13 +752,16 @@ def find_function(ir_module: IrModule, id: IrDeclId): Option[IrFunction] = {
       case IrDeclaration.Type(type_decl) => {
       }
     }
+    index = index + 1
   }
   Option[IrFunction]::None
 }
 
-def find_ir_field(types: TypeStore, ir_module: IrModule, receiver_type: TypeId, name: String): Option[IrField] = {
+def find_ir_field(types: &TypeStore, ir_module: &IrModule, receiver_type: TypeId, name: String): Option[IrField] = {
   val receiver_name = ir_receiver_type_name(types, receiver_type);
-  for (declaration in ir_module.declarations) {
+  var index: usize = 0;
+  while (index < ir_module.declarations.len()) {
+    val declaration = ir_module.declarations.get(index);
     declaration match {
       case IrDeclaration.Type(type_decl) => {
         if (type_decl.name == receiver_name) {
@@ -766,20 +771,24 @@ def find_ir_field(types: TypeStore, ir_module: IrModule, receiver_type: TypeId, 
       case IrDeclaration.Function(fn_value) => {
       }
     }
+    index = index + 1
   }
   Option[IrField]::None
 }
 
-def find_type_field(type_decl: IrTypeDecl, name: String): Option[IrField] = {
-  for (field in type_decl.fields) {
+def find_type_field(type_decl: &IrTypeDecl, name: String): Option[IrField] = {
+  var index: usize = 0;
+  while (index < type_decl.fields.len()) {
+    val field = type_decl.fields.get(index);
     if (field.name == name) {
       return Option[IrField]::Some(field)
     }
+    index = index + 1
   }
   Option[IrField]::None
 }
 
-def ir_receiver_type_name(types: TypeStore, id: TypeId): String = {
+def ir_receiver_type_name(types: &TypeStore, id: TypeId): String = {
   val value = types.type_value(id);
   value match {
     case CosmoType.User(name) => {
@@ -803,30 +812,39 @@ def ir_receiver_type_name(types: TypeStore, id: TypeId): String = {
   }
 }
 
-def find_local_type(fn_value: IrFunction, id: IrLocalId): Option[TypeId] = {
-  for (param in fn_value.params) {
+def find_local_type(fn_value: &IrFunction, id: IrLocalId): Option[TypeId] = {
+  var param_index: usize = 0;
+  while (param_index < fn_value.params.len()) {
+    val param = fn_value.params.get(param_index);
     if (param.id.value == id.value) {
       return Option[TypeId]::Some(param.typ)
     }
+    param_index = param_index + 1
   }
-  for (local in fn_value.locals) {
+  var local_index: usize = 0;
+  while (local_index < fn_value.locals.len()) {
+    val local = fn_value.locals.get(local_index);
     if (local.id.value == id.value) {
       return Option[TypeId]::Some(local.typ)
     }
+    local_index = local_index + 1
   }
   Option[TypeId]::None
 }
 
-def function_has_param(fn_value: IrFunction, id: IrLocalId): Bool = {
-  for (param in fn_value.params) {
+def function_has_param(fn_value: &IrFunction, id: IrLocalId): Bool = {
+  var index: usize = 0;
+  while (index < fn_value.params.len()) {
+    val param = fn_value.params.get(index);
     if (param.id.value == id.value) {
       return true
     }
+    index = index + 1
   }
   false
 }
 
-def function_has_local_or_param(fn_value: IrFunction, id: IrLocalId): Bool = {
+def function_has_local_or_param(fn_value: &IrFunction, id: IrLocalId): Bool = {
   val local_type = find_local_type(fn_value, id);
   local_type match {
     case Option[TypeId]::Some(value) => {
@@ -838,35 +856,41 @@ def function_has_local_or_param(fn_value: IrFunction, id: IrLocalId): Bool = {
   }
 }
 
-def function_has_block(fn_value: IrFunction, id: IrBlockId): Bool = {
-  for (block in fn_value.blocks) {
+def function_has_block(fn_value: &IrFunction, id: IrBlockId): Bool = {
+  var index: usize = 0;
+  while (index < fn_value.blocks.len()) {
+    val block = fn_value.blocks.get(index);
     if (block.id.value == id.value) {
       return true
     }
+    index = index + 1
   }
   false
 }
 
-def local_is_defined(env: IrFunctionEnv, id: IrLocalId): Bool = {
-  for (defined_id in env.defined) {
+def local_is_defined(env: &mut IrFunctionEnv, id: IrLocalId): Bool = {
+  var index: usize = 0;
+  while (index < env.defined.len()) {
+    val defined_id = env.defined.get(index);
     if (defined_id.value == id.value) {
       return true
     }
+    index = index + 1
   }
   false
 }
 
-def define_local(env: IrFunctionEnv, id: IrLocalId): Unit = {
+def define_local(env: &mut IrFunctionEnv, id: IrLocalId): Unit = {
   if (!local_is_defined(env, id)) {
     env.defined.push(id)
   }
 }
 
-def is_unit_type(types: TypeStore, id: TypeId): Bool = {
+def is_unit_type(types: &TypeStore, id: TypeId): Bool = {
   ir_type_display(types, id) == "Unit"
 }
 
-def ir_binary_result_matches(types: TypeStore, op: String, operand_type: TypeId, result_type: TypeId): Bool = {
+def ir_binary_result_matches(types: &TypeStore, op: String, operand_type: TypeId, result_type: TypeId): Bool = {
   if (ir_binary_is_arithmetic(op)) {
     return ir_type_equals(types, operand_type, result_type)
   }
@@ -895,19 +919,19 @@ def ir_binary_is_bool(op: String): Bool = {
   op == "and" or op == "or"
 }
 
-def ir_error(diagnostics: Vec[IrDiagnostic], code: String, message: String): Unit = {
+def ir_error(diagnostics: &mut Vec[IrDiagnostic], code: String, message: String): Unit = {
   diagnostics.push(IrDiagnostic(code, message))
 }
 
-def ir_type_equals(types: TypeStore, left: TypeId, right: TypeId): Bool = {
-  ir_type_display(types, left) == ir_type_display(types, right)
+def ir_type_equals(types: &TypeStore, left: TypeId, right: TypeId): Bool = {
+  type_equals(types, left, right)
 }
 
-def ir_type_display(types: TypeStore, id: TypeId): String = {
+def ir_type_display(types: &TypeStore, id: TypeId): String = {
   ir_type_node_display(types, types.type_value(id))
 }
 
-def ir_type_node_display(types: TypeStore, value: CosmoType): String = {
+def ir_type_node_display(types: &TypeStore, value: CosmoType): String = {
   value match {
     case CosmoType.Primitive(name) => {
       name
@@ -934,7 +958,7 @@ def ir_type_node_display(types: TypeStore, value: CosmoType): String = {
   }
 }
 
-def ir_type_display_list(types: TypeStore, items: Vec[TypeId]): String = {
+def ir_type_display_list(types: &TypeStore, items: &Vec[TypeId]): String = {
   var text = "";
   var index: usize = 0;
   while (index < items.len()) {
@@ -947,7 +971,7 @@ def ir_type_display_list(types: TypeStore, items: Vec[TypeId]): String = {
   text
 }
 
-def render_ir_module(types: TypeStore, ir_module: IrModule): String = {
+def render_ir_module(types: &TypeStore, ir_module: &IrModule): String = {
   var text = "module ".concat(ir_module.name).concat(" {\n");
   for (declaration in ir_module.declarations) {
     text = text.concat(render_ir_declaration(types, declaration)).concat("\n")
@@ -955,7 +979,7 @@ def render_ir_module(types: TypeStore, ir_module: IrModule): String = {
   text.concat("}")
 }
 
-def render_ir_declaration(types: TypeStore, declaration: IrDeclaration): String = {
+def render_ir_declaration(types: &TypeStore, declaration: IrDeclaration): String = {
   declaration match {
     case IrDeclaration.Type(type_decl) => {
       render_ir_type(types, type_decl)
@@ -966,7 +990,7 @@ def render_ir_declaration(types: TypeStore, declaration: IrDeclaration): String 
   }
 }
 
-def render_ir_type(types: TypeStore, type_decl: IrTypeDecl): String = {
+def render_ir_type(types: &TypeStore, type_decl: &IrTypeDecl): String = {
   var text = "  type @".concat(type_decl.id.value).concat(" ").concat(type_decl.name).concat(" {\n");
   for (field in type_decl.fields) {
     text = text.concat("    field ");
@@ -978,7 +1002,7 @@ def render_ir_type(types: TypeStore, type_decl: IrTypeDecl): String = {
   text.concat("  }")
 }
 
-def render_ir_function(types: TypeStore, fn_value: IrFunction): String = {
+def render_ir_function(types: &TypeStore, fn_value: &IrFunction): String = {
   var text = "  fn @".concat(fn_value.id.value).concat(" ").concat(fn_value.name).concat("(");
   text = text.concat(render_ir_params(types, fn_value.params));
   text = text.concat(") -> ").concat(ir_type_display(types, fn_value.return_type));
@@ -1011,7 +1035,7 @@ def render_ir_function(types: TypeStore, fn_value: IrFunction): String = {
   text.concat("  }")
 }
 
-def render_ir_params(types: TypeStore, params: Vec[IrParam]): String = {
+def render_ir_params(types: &TypeStore, params: &Vec[IrParam]): String = {
   var text = "";
   var index: usize = 0;
   while (index < params.len()) {
@@ -1026,7 +1050,7 @@ def render_ir_params(types: TypeStore, params: Vec[IrParam]): String = {
   text
 }
 
-def render_ir_block(types: TypeStore, block: IrBlock): String = {
+def render_ir_block(types: &TypeStore, block: &IrBlock): String = {
   var text = "    ^".concat(block.id.value).concat(":\n");
   for (operation in block.operations) {
     text = text.concat("      ").concat(render_ir_operation(types, operation)).concat("\n")
@@ -1034,7 +1058,7 @@ def render_ir_block(types: TypeStore, block: IrBlock): String = {
   text.concat("      ").concat(render_ir_terminator(types, block.terminator)).concat("\n")
 }
 
-def render_ir_operation(types: TypeStore, operation: IrOperation): String = {
+def render_ir_operation(types: &TypeStore, operation: IrOperation): String = {
   operation match {
     case IrOperation.InitLocal(target, value) => {
       "%".concat(target.value).concat(" = init ").concat(render_ir_value(types, value))
@@ -1082,7 +1106,7 @@ def render_ir_operation(types: TypeStore, operation: IrOperation): String = {
   }
 }
 
-def render_ir_construct_type(types: TypeStore, output: IrLocalId, owner: TypeId, fields: Vec[IrFieldInit]): String = {
+def render_ir_construct_type(types: &TypeStore, output: IrLocalId, owner: TypeId, fields: &Vec[IrFieldInit]): String = {
   var text = "%".concat(output.value).concat(" = construct ").concat(ir_type_display(types, owner)).concat("(");
   var index: usize = 0;
   while (index < fields.len()) {
@@ -1097,10 +1121,10 @@ def render_ir_construct_type(types: TypeStore, output: IrLocalId, owner: TypeId,
 }
 
 def render_ir_intrinsic_call(
-  types: TypeStore,
+  types: &TypeStore,
   output: Option[IrLocalId],
   name: String,
-  args: Vec[IrValue],
+  args: &Vec[IrValue],
   signature: IrFunctionSignature
 ): String = {
   var text = "";
@@ -1117,10 +1141,10 @@ def render_ir_intrinsic_call(
 }
 
 def render_ir_call(
-  types: TypeStore,
+  types: &TypeStore,
   output: Option[IrLocalId],
   callee: IrDeclId,
-  args: Vec[IrValue],
+  args: &Vec[IrValue],
   signature: IrFunctionSignature
 ): String = {
   var text = "";
@@ -1136,7 +1160,7 @@ def render_ir_call(
   text.concat(ir_type_display(types, signature.return_type))
 }
 
-def render_ir_terminator(types: TypeStore, terminator: IrTerminator): String = {
+def render_ir_terminator(types: &TypeStore, terminator: IrTerminator): String = {
   terminator match {
     case IrTerminator.Return(value) => {
       value match {
@@ -1160,7 +1184,7 @@ def render_ir_terminator(types: TypeStore, terminator: IrTerminator): String = {
   }
 }
 
-def render_ir_args(types: TypeStore, args: Vec[IrValue]): String = {
+def render_ir_args(types: &TypeStore, args: &Vec[IrValue]): String = {
   var text = "";
   var index: usize = 0;
   while (index < args.len()) {
@@ -1173,7 +1197,7 @@ def render_ir_args(types: TypeStore, args: Vec[IrValue]): String = {
   text
 }
 
-def render_ir_value(types: TypeStore, value: IrValue): String = {
+def render_ir_value(types: &TypeStore, value: IrValue): String = {
   value match {
     case IrValue.Unit(typ) => {
       "()"

--- a/packages/cosmoc/src/names/resolution.cos
+++ b/packages/cosmoc/src/names/resolution.cos
@@ -58,7 +58,7 @@ class NameResolution {
 }
 
 class NameResolver {
-  val arenas: SyntaxArenas
+  val arenas: &SyntaxArenas
   var symbols: SymbolInterner
   var env: NameEnvironment
   val module_scope: ScopeId
@@ -177,7 +177,7 @@ class NameResolver {
     result.id
   }
 
-  def collect_class_decl(&mut self, id: DeclId, name: String, members: Vec[MemberId], span: Span): Unit = {
+  def collect_class_decl(&mut self, id: DeclId, name: String, members: &Vec[MemberId], span: Span): Unit = {
     val result = self.define(self.module_scope, name, DefinitionKind.Class, span, Option[DefId]::None);
     self.decl_definitions.insert(id, result.id);
 
@@ -189,12 +189,15 @@ class NameResolver {
     self.decl_scopes.insert(id, class_scope);
     self.class_scopes.insert(result.id, class_scope);
 
-    for (member_id in members) {
+    var index: usize = 0;
+    while (index < members.len()) {
+      val member_id = members.get(index);
       self.collect_member(member_id, class_scope, result.id)
+      index = index + 1
     }
   }
 
-  def collect_function_decl(&mut self, id: DeclId, name: String, params: Vec[ParamId], span: Span): Unit = {
+  def collect_function_decl(&mut self, id: DeclId, name: String, params: &Vec[ParamId], span: Span): Unit = {
     val result = self.define(self.module_scope, name, DefinitionKind.Function, span, Option[DefId]::None);
     self.decl_definitions.insert(id, result.id);
 
@@ -249,7 +252,7 @@ class NameResolver {
     class_scope: ScopeId,
     class_def: DefId,
     name: String,
-    params: Vec[ParamId],
+    params: &Vec[ParamId],
     span: Span
   ): Unit = {
     val result = self.define(class_scope, name, DefinitionKind.Method, span, Option[DefId]::Some(class_def));
@@ -264,8 +267,10 @@ class NameResolver {
     self.collect_params(params, method_scope, result.id)
   }
 
-  def collect_params(&mut self, params: Vec[ParamId], scope_id: ScopeId, owner: DefId): Unit = {
-    for (param_id in params) {
+  def collect_params(&mut self, params: &Vec[ParamId], scope_id: ScopeId, owner: DefId): Unit = {
+    var index: usize = 0;
+    while (index < params.len()) {
+      val param_id = params.get(index);
       val param = self.arenas.param_value(param_id);
       param match {
         case SyntaxParam.AEmpty => {
@@ -279,6 +284,7 @@ class NameResolver {
           self.param_definitions.insert(param_id, result.id);
         }
       }
+      index = index + 1
     }
   }
 
@@ -314,15 +320,18 @@ class NameResolver {
     }
   }
 
-  def resolve_class_decl(&mut self, id: DeclId, members: Vec[MemberId]): Unit = {
+  def resolve_class_decl(&mut self, id: DeclId, members: &Vec[MemberId]): Unit = {
     val class_scope = self.decl_scopes.get(id);
     class_scope match {
       case Option[ScopeId]::Some(scope_id) => {
         val class_def = self.decl_definitions.get(id);
         class_def match {
           case Option[DefId]::Some(owner) => {
-            for (member_id in members) {
+            var index: usize = 0;
+            while (index < members.len()) {
+              val member_id = members.get(index);
               self.resolve_member(member_id, scope_id, owner)
+              index = index + 1
             }
           }
           case Option[DefId]::None => {
@@ -334,7 +343,7 @@ class NameResolver {
     }
   }
 
-  def resolve_function_decl(&mut self, id: DeclId, params: Vec[ParamId], return_type: TypeExprId, body: ExprId): Unit = {
+  def resolve_function_decl(&mut self, id: DeclId, params: &Vec[ParamId], return_type: TypeExprId, body: ExprId): Unit = {
     val function_scope = self.decl_scopes.get(id);
     function_scope match {
       case Option[ScopeId]::Some(scope_id) => {
@@ -374,7 +383,7 @@ class NameResolver {
   def resolve_method_member(
     &mut self,
     id: MemberId,
-    params: Vec[ParamId],
+    params: &Vec[ParamId],
     return_type: TypeExprId,
     body: ExprId,
     class_def: DefId
@@ -391,8 +400,10 @@ class NameResolver {
     }
   }
 
-  def resolve_params(&mut self, params: Vec[ParamId], scope_id: ScopeId, current_class: Option[DefId]): Unit = {
-    for (param_id in params) {
+  def resolve_params(&mut self, params: &Vec[ParamId], scope_id: ScopeId, current_class: Option[DefId]): Unit = {
+    var index: usize = 0;
+    while (index < params.len()) {
+      val param_id = params.get(index);
       val param = self.arenas.param_value(param_id);
       param match {
         case SyntaxParam.AEmpty => {
@@ -404,6 +415,7 @@ class NameResolver {
           self.resolve_expr(default_value, scope_id, current_class)
         }
       }
+      index = index + 1
     }
   }
 
@@ -498,10 +510,13 @@ class NameResolver {
     }
   }
 
-  def resolve_block_expr(&mut self, items: Vec[ExprId], parent_scope: ScopeId, current_class: Option[DefId]): Unit = {
+  def resolve_block_expr(&mut self, items: &Vec[ExprId], parent_scope: ScopeId, current_class: Option[DefId]): Unit = {
     val block_scope = self.env.add_scope(ScopeKind.Block, Option[ScopeId]::Some(parent_scope), Option[DefId]::None);
-    for (item in items) {
+    var index: usize = 0;
+    while (index < items.len()) {
+      val item = items.get(index);
       self.resolve_expr(item, block_scope, current_class)
+      index = index + 1
     }
   }
 
@@ -746,7 +761,7 @@ class NameResolver {
   }
 }
 
-def resolve_module_names(arenas: SyntaxArenas, module_id: ModuleId): NameResolution = {
+def resolve_module_names(arenas: &SyntaxArenas, module_id: ModuleId): NameResolution = {
   var env = name_environment();
   val prelude_scope = env.add_scope(ScopeKind.Prelude, Option[ScopeId]::None, Option[DefId]::None);
   val module_scope = env.add_scope(ScopeKind.Module, Option[ScopeId]::Some(prelude_scope), Option[DefId]::None);

--- a/packages/cosmoc/src/package/module_graph.cos
+++ b/packages/cosmoc/src/package/module_graph.cos
@@ -381,7 +381,7 @@ def module_key_from_import_path(path: String): Symbol = {
   symbol_from_string(output)
 }
 
-def import_edges_from_syntax_module(arenas: SyntaxArenas, id: ModuleId): Vec[Symbol] = {
+def import_edges_from_syntax_module(arenas: &SyntaxArenas, id: ModuleId): Vec[Symbol] = {
   val syntax_module = arenas.module_value(id);
   val imports = Vec[Symbol]();
   for (decl_id in syntax_module.declarations) {
@@ -420,13 +420,16 @@ def import_path_or_empty(decl: SyntaxDecl): String = {
   }
 }
 
-def plan_package_modules(arenas: SyntaxArenas, modules: Vec[PackageSyntaxModule]): ModuleGraphPlan = {
+def plan_package_modules(arenas: &SyntaxArenas, modules: &Vec[PackageSyntaxModule]): ModuleGraphPlan = {
   var package_modules = Arena[PackageModule]();
   var graph = empty_module_graph();
-  for (source_module in modules) {
+  var index: usize = 0;
+  while (index < modules.len()) {
+    val source_module = modules.get(index);
     val id = package_modules.alloc(PackageModule(source_module.name));
     graph.add_root(source_module.name, id);
     graph.add_edges(source_module.name, import_edges_from_syntax_module(arenas, source_module.syntax_id));
+    index = index + 1
   }
   module_graph_order(graph)
 }
@@ -469,7 +472,7 @@ def module_graph_order(graph: ModuleGraph): ModuleGraphPlan = {
   }
 }
 
-def collect_missing_imports(graph: ModuleGraph): Vec[ModuleGraphDiagnostic] = {
+def collect_missing_imports(graph: &ModuleGraph): Vec[ModuleGraphDiagnostic] = {
   val diagnostics = Vec[ModuleGraphDiagnostic]();
   for (name in graph.modules) {
     val imports = graph.imports_for(name);
@@ -489,7 +492,7 @@ def collect_missing_imports(graph: ModuleGraph): Vec[ModuleGraphDiagnostic] = {
   diagnostics
 }
 
-def imports_are_emitted(graph: ModuleGraph, name: Symbol, emitted: Set[Symbol]): Bool = {
+def imports_are_emitted(graph: &ModuleGraph, name: Symbol, emitted: &Set[Symbol]): Bool = {
   val imports = graph.imports_for(name);
   for (imported in imports) {
     if (!emitted.contains(imported)) {

--- a/packages/cosmoc/src/types/check.cos
+++ b/packages/cosmoc/src/types/check.cos
@@ -97,10 +97,10 @@ class ExpressionCheckResult {
 }
 
 class ExpressionChecker {
-  val arenas: SyntaxArenas
+  val arenas: &SyntaxArenas
   val module_id: ModuleId
-  val names: NameResolution
-  val declarations: DeclarationResolution
+  val names: &NameResolution
+  val declarations: &DeclarationResolution
   var types: TypeStore
   var diagnostics: Vec[ExpressionResolutionDiagnostic]
   var typed_exprs: Map[ExprId, TypedExpr]
@@ -177,9 +177,11 @@ class ExpressionChecker {
     }
   }
 
-  def callable_type(&mut self, params: Vec[ParamId], return_type: TypeId): TypeId = {
+  def callable_type(&mut self, params: &Vec[ParamId], return_type: TypeId): TypeId = {
     val param_types = Vec[TypeId]();
-    for (param_id in params) {
+    var index: usize = 0;
+    while (index < params.len()) {
+      val param_id = params.get(index);
       val maybe_signature = self.declarations.param_signatures.get(param_id);
       maybe_signature match {
         case Option[ParameterSignature]::Some(signature) => {
@@ -188,6 +190,7 @@ class ExpressionChecker {
         case Option[ParameterSignature]::None => {
         }
       }
+      index = index + 1
     }
     var types = self.types;
     val callable_type = types.alloc_function(param_types, return_type);
@@ -195,7 +198,7 @@ class ExpressionChecker {
     callable_type
   }
 
-  def check_decl(&mut self, id: DeclId, module_bindings: Vec[LocalBinding]): Unit = {
+  def check_decl(&mut self, id: DeclId, module_bindings: &Vec[LocalBinding]): Unit = {
     val decl = self.arenas.decl_value(id);
     decl match {
       case SyntaxDecl.Function(name, params, return_type, body, span) => {
@@ -218,13 +221,16 @@ class ExpressionChecker {
     }
   }
 
-  def check_class_decl(&mut self, members: Vec[MemberId], module_bindings: Vec[LocalBinding]): Unit = {
-    for (member_id in members) {
+  def check_class_decl(&mut self, members: &Vec[MemberId], module_bindings: &Vec[LocalBinding]): Unit = {
+    var index: usize = 0;
+    while (index < members.len()) {
+      val member_id = members.get(index);
       self.check_member(member_id, module_bindings)
+      index = index + 1
     }
   }
 
-  def check_member(&mut self, id: MemberId, module_bindings: Vec[LocalBinding]): Unit = {
+  def check_member(&mut self, id: MemberId, module_bindings: &Vec[LocalBinding]): Unit = {
     val member = self.arenas.member_value(id);
     member match {
       case SyntaxMember.Method(name, params, return_type, body, span) => {
@@ -243,7 +249,7 @@ class ExpressionChecker {
     }
   }
 
-  def check_function_decl(&mut self, id: DeclId, params: Vec[ParamId], body: ExprId, module_bindings: Vec[LocalBinding]): Unit = {
+  def check_function_decl(&mut self, id: DeclId, params: &Vec[ParamId], body: ExprId, module_bindings: &Vec[LocalBinding]): Unit = {
     val maybe_signature = self.declarations.function_signatures.get(id);
     maybe_signature match {
       case Option[CallableSignature]::Some(signature) => {
@@ -254,7 +260,7 @@ class ExpressionChecker {
     }
   }
 
-  def check_method_member(&mut self, id: MemberId, params: Vec[ParamId], body: ExprId, module_bindings: Vec[LocalBinding]): Unit = {
+  def check_method_member(&mut self, id: MemberId, params: &Vec[ParamId], body: ExprId, module_bindings: &Vec[LocalBinding]): Unit = {
     val maybe_signature = self.declarations.method_signatures.get(id);
     maybe_signature match {
       case Option[CallableSignature]::Some(signature) => {
@@ -265,7 +271,7 @@ class ExpressionChecker {
     }
   }
 
-  def check_value_decl(&mut self, id: DeclId, init: ExprId, module_bindings: Vec[LocalBinding]): Unit = {
+  def check_value_decl(&mut self, id: DeclId, init: ExprId, module_bindings: &Vec[LocalBinding]): Unit = {
     val maybe_signature = self.declarations.value_signatures.get(id);
     maybe_signature match {
       case Option[ValueSignature]::Some(signature) => {
@@ -285,14 +291,17 @@ class ExpressionChecker {
 
   def check_callable_body(
     &mut self,
-    params: Vec[ParamId],
+    params: &Vec[ParamId],
     body: ExprId,
     return_type: TypeId,
-    parent_bindings: Vec[LocalBinding]
+    parent_bindings: &Vec[LocalBinding]
   ): Unit = {
     var bindings = copy_local_bindings(parent_bindings);
-    for (param_id in params) {
+    var index: usize = 0;
+    while (index < params.len()) {
+      val param_id = params.get(index);
       bindings = self.append_param_binding(bindings, param_id)
+      index = index + 1
     }
     self.check_param_defaults(params, bindings);
     val body_type = self.check_expr(
@@ -309,7 +318,7 @@ class ExpressionChecker {
     }
   }
 
-  def append_param_binding(&mut self, bindings: Vec[LocalBinding], param_id: ParamId): Vec[LocalBinding] = {
+  def append_param_binding(&mut self, bindings: &Vec[LocalBinding], param_id: ParamId): Vec[LocalBinding] = {
     val next = copy_local_bindings(bindings);
     val maybe_signature = self.declarations.param_signatures.get(param_id);
     maybe_signature match {
@@ -322,8 +331,10 @@ class ExpressionChecker {
     next
   }
 
-  def check_param_defaults(&mut self, params: Vec[ParamId], bindings: Vec[LocalBinding]): Unit = {
-    for (param_id in params) {
+  def check_param_defaults(&mut self, params: &Vec[ParamId], bindings: &Vec[LocalBinding]): Unit = {
+    var index: usize = 0;
+    while (index < params.len()) {
+      val param_id = params.get(index);
       val param = self.arenas.param_value(param_id);
       param match {
         case SyntaxParam.Named(name, typ, default_value, span) => {
@@ -353,13 +364,14 @@ class ExpressionChecker {
         case SyntaxParam.Self(mutable, span) => {
         }
       }
+      index = index + 1
     }
   }
 
   def check_expr(
     &mut self,
     id: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     expected: Option[TypeId],
     return_type: Option[TypeId]
   ): TypeId = {
@@ -422,7 +434,7 @@ class ExpressionChecker {
     }
   }
 
-  def check_name_expr(&mut self, id: ExprId, bindings: Vec[LocalBinding], span: Span): TypeId = {
+  def check_name_expr(&mut self, id: ExprId, bindings: &Vec[LocalBinding], span: Span): TypeId = {
     val maybe_definition = self.names.expr_definitions.get(id);
     maybe_definition match {
       case Option[DefId]::Some(definition) => {
@@ -593,7 +605,7 @@ class ExpressionChecker {
     &mut self,
     id: ExprId,
     items: Vec[ExprId],
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     expected: Option[TypeId],
     return_type: Option[TypeId]
   ): TypeId = {
@@ -669,7 +681,7 @@ class ExpressionChecker {
 
   def append_local_binding(
     &mut self,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     id: ExprId,
     mutable: Bool,
     typ: TypeExprId,
@@ -731,7 +743,7 @@ class ExpressionChecker {
     mutable: Bool,
     typ: TypeExprId,
     init: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId]
   ): TypeId = {
     if (self.type_expr_is_missing(typ)) {
@@ -782,7 +794,7 @@ class ExpressionChecker {
     id: ExprId,
     target: ExprId,
     value: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId]
   ): TypeId = {
     val target_type = self.check_expr(target, bindings, Option[TypeId]::None, return_type);
@@ -814,7 +826,7 @@ class ExpressionChecker {
     self.record_typed_expr(id, TypedExprKind.Assign(target, value), self.unit_type())
   }
 
-  def assignment_binding(&mut self, target: ExprId, bindings: Vec[LocalBinding]): Option[LocalBinding] = {
+  def assignment_binding(&mut self, target: ExprId, bindings: &Vec[LocalBinding]): Option[LocalBinding] = {
     val target_expr = self.arenas.expr_value(target);
     target_expr match {
       case SyntaxExpr.Name(name, span) => {
@@ -887,7 +899,7 @@ class ExpressionChecker {
     id: ExprId,
     receiver: ExprId,
     field: String,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     span: Span
   ): Option[LocalBinding] = {
     val receiver_type = self.check_expr(receiver, bindings, Option[TypeId]::None, Option[TypeId]::None);
@@ -908,7 +920,7 @@ class ExpressionChecker {
     id: ExprId,
     receiver: ExprId,
     field: String,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): TypeId = {
@@ -965,7 +977,7 @@ class ExpressionChecker {
     id: ExprId,
     callee: ExprId,
     args: Vec[ExprId],
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): TypeId = {
@@ -1056,7 +1068,7 @@ class ExpressionChecker {
     id: ExprId,
     op: String,
     value: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     expected: Option[TypeId],
     return_type: Option[TypeId],
     span: Span
@@ -1136,16 +1148,19 @@ class ExpressionChecker {
 
   def check_prelude_print_args(
     &mut self,
-    args: Vec[ExprId],
-    bindings: Vec[LocalBinding],
+    args: &Vec[ExprId],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): Unit = {
     if (args.len() != 1) {
       self.diagnostic("cosmo1.type.call-arity", "call argument count does not match callable signature", span)
     }
-    for (arg in args) {
+    var index: usize = 0;
+    while (index < args.len()) {
+      val arg = args.get(index);
       val ignored = self.check_expr(arg, bindings, Option[TypeId]::None, return_type);
+      index = index + 1
     }
   }
 
@@ -1156,7 +1171,7 @@ class ExpressionChecker {
     receiver: ExprId,
     field: String,
     args: Vec[ExprId],
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span,
     select_span: Span
@@ -1207,9 +1222,9 @@ class ExpressionChecker {
 
   def check_call_args(
     &mut self,
-    args: Vec[ExprId],
-    params: Vec[TypeId],
-    bindings: Vec[LocalBinding],
+    args: &Vec[ExprId],
+    params: &Vec[TypeId],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): Unit = {
@@ -1303,9 +1318,9 @@ class ExpressionChecker {
 
   def check_constructor_args(
     &mut self,
-    args: Vec[ExprId],
+    args: &Vec[ExprId],
     result_type: TypeId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): Unit = {
@@ -1526,9 +1541,11 @@ class ExpressionChecker {
     Option[IntrinsicSignature]::None
   }
 
-  def variant_intrinsic_signature(&mut self, receiver_type: TypeId, fields: Vec[TypeExprId]): Option[IntrinsicSignature] = {
+  def variant_intrinsic_signature(&mut self, receiver_type: TypeId, fields: &Vec[TypeExprId]): Option[IntrinsicSignature] = {
     val params = Vec[TypeId]();
-    for (field_type in fields) {
+    var index: usize = 0;
+    while (index < fields.len()) {
+      val field_type = fields.get(index);
       val maybe_type = self.type_for_member_type_expr(field_type);
       maybe_type match {
         case Option[TypeId]::Some(typ) => {
@@ -1538,6 +1555,7 @@ class ExpressionChecker {
           return Option[IntrinsicSignature]::None
         }
       }
+      index = index + 1
     }
     Option[IntrinsicSignature]::Some(IntrinsicSignature(params, receiver_type))
   }
@@ -1745,7 +1763,7 @@ class ExpressionChecker {
     self.types.alloc_user(text)
   }
 
-  def callable_type_without_receiver(&mut self, signature: CallableSignature): TypeId = {
+  def callable_type_without_receiver(&mut self, signature: &CallableSignature): TypeId = {
     val params = self.callable_params_without_receiver(signature);
     self.callable_type_from_types(params, signature.return_type)
   }
@@ -1757,7 +1775,7 @@ class ExpressionChecker {
     callable_type
   }
 
-  def callable_params_without_receiver(&self, signature: CallableSignature): Vec[TypeId] = {
+  def callable_params_without_receiver(&self, signature: &CallableSignature): Vec[TypeId] = {
     val result = Vec[TypeId]();
     for (param_id in signature.params) {
       if (!self.param_is_receiver(signature, param_id)) {
@@ -1774,7 +1792,7 @@ class ExpressionChecker {
     result
   }
 
-  def param_is_receiver(&self, signature: CallableSignature, param_id: ParamId): Bool = {
+  def param_is_receiver(&self, signature: &CallableSignature, param_id: ParamId): Bool = {
     signature.receiver match {
       case Option[ParamId]::Some(receiver) => {
         self.param_key(receiver) == self.param_key(param_id)
@@ -1792,9 +1810,9 @@ class ExpressionChecker {
   def check_receiver_mutability(
     &mut self,
     receiver: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     receiver_type: TypeId,
-    signature: CallableSignature,
+    signature: &CallableSignature,
     method_name: String,
     span: Span
   ): Unit = {
@@ -1820,7 +1838,7 @@ class ExpressionChecker {
     }
   }
 
-  def receiver_allows_mutation(&mut self, receiver: ExprId, bindings: Vec[LocalBinding], receiver_type: TypeId): Bool = {
+  def receiver_allows_mutation(&mut self, receiver: ExprId, bindings: &Vec[LocalBinding], receiver_type: TypeId): Bool = {
     val binding = self.assignment_binding(receiver, bindings);
     binding match {
       case Option[LocalBinding]::Some(local) => {
@@ -1838,7 +1856,7 @@ class ExpressionChecker {
     op: String,
     left: ExprId,
     right: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     expected: Option[TypeId],
     return_type: Option[TypeId]
   ): TypeId = {
@@ -1871,7 +1889,7 @@ class ExpressionChecker {
     op: String,
     left: ExprId,
     right: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     expected: Option[TypeId],
     return_type: Option[TypeId]
   ): TypeId = {
@@ -1892,7 +1910,7 @@ class ExpressionChecker {
     op: String,
     left: ExprId,
     right: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     right_expected: Option[TypeId],
     return_type: Option[TypeId]
   ): TypeId = {
@@ -1930,8 +1948,7 @@ class ExpressionChecker {
     if (!self.type_is_integer(left_type) or !self.type_is_integer(right_type)) {
       return self.invalid_binary_expr(id, op, left, right, self.arenas.expr_span(id))
     }
-    var types = self.types;
-    if (!expression_type_equals(types, left_type, right_type)) {
+    if (!expression_type_equals(self.types, left_type, right_type)) {
       val ignored = self.expect_assignable(
         self.arenas.expr_span(right),
         left_type,
@@ -1957,8 +1974,7 @@ class ExpressionChecker {
     if (!self.type_is_integer(left_type) or !self.type_is_integer(right_type)) {
       return self.invalid_binary_expr(id, op, left, right, self.arenas.expr_span(id))
     }
-    var types = self.types;
-    if (!expression_type_equals(types, left_type, right_type)) {
+    if (!expression_type_equals(self.types, left_type, right_type)) {
       val ignored = self.expect_assignable(
         self.arenas.expr_span(right),
         left_type,
@@ -1984,8 +2000,7 @@ class ExpressionChecker {
     if (!self.type_is_primitive(left_type) or !self.type_is_primitive(right_type)) {
       return self.invalid_binary_expr(id, op, left, right, self.arenas.expr_span(id))
     }
-    var types = self.types;
-    if (!expression_type_equals(types, left_type, right_type)) {
+    if (!expression_type_equals(self.types, left_type, right_type)) {
       val ignored = self.expect_assignable(
         self.arenas.expr_span(right),
         left_type,
@@ -2016,7 +2031,7 @@ class ExpressionChecker {
     &mut self,
     id: ExprId,
     value: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): TypeId = {
@@ -2043,7 +2058,7 @@ class ExpressionChecker {
     condition: ExprId,
     then_body: ExprId,
     else_body: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     expected: Option[TypeId],
     return_type: Option[TypeId],
     span: Span
@@ -2066,7 +2081,7 @@ class ExpressionChecker {
     id: ExprId,
     condition: ExprId,
     body: ExprId,
-    bindings: Vec[LocalBinding],
+    bindings: &Vec[LocalBinding],
     return_type: Option[TypeId],
     span: Span
   ): TypeId = {
@@ -2085,15 +2100,14 @@ class ExpressionChecker {
     if (self.type_id_is_never(else_type)) {
       return then_type
     }
-    var types = self.types;
-    if (expression_type_equals(types, then_type, else_type)) {
+    if (expression_type_equals(self.types, then_type, else_type)) {
       return then_type
     }
     self.mismatch(span, then_type, else_type);
     self.error_type()
   }
 
-  def binding_for_definition(&self, bindings: Vec[LocalBinding], definition: DefId): Option[LocalBinding] = {
+  def binding_for_definition(&self, bindings: &Vec[LocalBinding], definition: DefId): Option[LocalBinding] = {
     if (bindings.is_empty()) {
       return Option[LocalBinding]::None
     }
@@ -2120,8 +2134,7 @@ class ExpressionChecker {
     if (self.type_id_is_never(actual)) {
       return true
     }
-    var types = self.types;
-    if (expression_type_equals(types, expected, actual)) {
+    if (expression_type_equals(self.types, expected, actual)) {
       return true
     }
     self.mismatch(span, expected, actual);
@@ -2212,11 +2225,14 @@ class ExpressionChecker {
     }
   }
 
-  def block_definitely_returns(&self, items: Vec[ExprId]): Bool = {
-    for (item in items) {
+  def block_definitely_returns(&self, items: &Vec[ExprId]): Bool = {
+    var index: usize = 0;
+    while (index < items.len()) {
+      val item = items.get(index);
       if (self.expr_definitely_returns(item)) {
         return true
       }
+      index = index + 1
     }
     false
   }
@@ -2552,10 +2568,13 @@ class ExpressionChecker {
   }
 }
 
-def copy_local_bindings(bindings: Vec[LocalBinding]): Vec[LocalBinding] = {
+def copy_local_bindings(bindings: &Vec[LocalBinding]): Vec[LocalBinding] = {
   val next = Vec[LocalBinding]();
-  for (binding in bindings) {
+  var index: usize = 0;
+  while (index < bindings.len()) {
+    val binding = bindings.get(index);
     next.push(binding)
+    index = index + 1
   }
   next
 }
@@ -2629,7 +2648,7 @@ def arithmetic_result_expected(op: String, expected: Option[TypeId]): Option[Typ
   expected
 }
 
-def expression_diagnostic_expected_text(types: TypeStore, diagnostic: ExpressionResolutionDiagnostic): String = {
+def expression_diagnostic_expected_text(types: &TypeStore, diagnostic: &ExpressionResolutionDiagnostic): String = {
   diagnostic.mismatch match {
     case Option[TypeMismatch]::Some(mismatch) => {
       expression_type_display(types, mismatch.expected)
@@ -2640,7 +2659,7 @@ def expression_diagnostic_expected_text(types: TypeStore, diagnostic: Expression
   }
 }
 
-def expression_diagnostic_actual_text(types: TypeStore, diagnostic: ExpressionResolutionDiagnostic): String = {
+def expression_diagnostic_actual_text(types: &TypeStore, diagnostic: &ExpressionResolutionDiagnostic): String = {
   diagnostic.mismatch match {
     case Option[TypeMismatch]::Some(mismatch) => {
       expression_type_display(types, mismatch.actual)
@@ -2651,17 +2670,17 @@ def expression_diagnostic_actual_text(types: TypeStore, diagnostic: ExpressionRe
   }
 }
 
-def check_module_basic_expressions(arenas: SyntaxArenas, module_id: ModuleId): ExpressionCheckResult = {
+def check_module_basic_expressions(arenas: &SyntaxArenas, module_id: ModuleId): ExpressionCheckResult = {
   val names = resolve_module_names(arenas, module_id);
   val declarations = resolve_module_declarations_with_names(arenas, module_id, names);
   check_module_basic_expressions_with_resolution(arenas, module_id, names, declarations)
 }
 
 def check_module_basic_expressions_with_resolution(
-  arenas: SyntaxArenas,
+  arenas: &SyntaxArenas,
   module_id: ModuleId,
-  names: NameResolution,
-  declarations: DeclarationResolution
+  names: &NameResolution,
+  declarations: &DeclarationResolution
 ): ExpressionCheckResult = {
   var checker = ExpressionChecker(
     arenas,
@@ -2676,11 +2695,11 @@ def check_module_basic_expressions_with_resolution(
   checker.finish()
 }
 
-def expression_type_equals(types: TypeStore, left: TypeId, right: TypeId): Bool = {
+def expression_type_equals(types: &TypeStore, left: TypeId, right: TypeId): Bool = {
   expression_type_nodes_equal(types, types.type_value(left), types.type_value(right))
 }
 
-def expression_type_nodes_equal(types: TypeStore, left: CosmoType, right: CosmoType): Bool = {
+def expression_type_nodes_equal(types: &TypeStore, left: CosmoType, right: CosmoType): Bool = {
   left match {
     case CosmoType.Primitive(left_name) => {
       expression_type_equals_primitive(left_name, right)
@@ -2750,8 +2769,8 @@ def expression_type_equals_user(left_name: String, right: CosmoType): Bool = {
 }
 
 def expression_type_equals_function(
-  types: TypeStore,
-  left_params: Vec[TypeId],
+  types: &TypeStore,
+  left_params: &Vec[TypeId],
   left_return: TypeId,
   right: CosmoType
 ): Bool = {
@@ -2779,7 +2798,7 @@ def expression_type_equals_function(
 }
 
 def expression_type_equals_reference(
-  types: TypeStore,
+  types: &TypeStore,
   left_mutable: Bool,
   left_inner: TypeId,
   right: CosmoType
@@ -2806,7 +2825,7 @@ def expression_type_equals_reference(
   }
 }
 
-def expression_type_id_lists_equal(types: TypeStore, left: Vec[TypeId], right: Vec[TypeId]): Bool = {
+def expression_type_id_lists_equal(types: &TypeStore, left: &Vec[TypeId], right: &Vec[TypeId]): Bool = {
   if (left.len() != right.len()) {
     return false
   }
@@ -2821,11 +2840,11 @@ def expression_type_id_lists_equal(types: TypeStore, left: Vec[TypeId], right: V
   true
 }
 
-def expression_type_display(types: TypeStore, id: TypeId): String = {
+def expression_type_display(types: &TypeStore, id: TypeId): String = {
   expression_type_node_display(types, types.type_value(id))
 }
 
-def expression_type_node_display(types: TypeStore, value: CosmoType): String = {
+def expression_type_node_display(types: &TypeStore, value: CosmoType): String = {
   value match {
     case CosmoType.Primitive(name) => {
       name
@@ -2848,11 +2867,11 @@ def expression_type_node_display(types: TypeStore, value: CosmoType): String = {
   }
 }
 
-def expression_type_display_function(types: TypeStore, params: Vec[TypeId], return_type: TypeId): String = {
+def expression_type_display_function(types: &TypeStore, params: &Vec[TypeId], return_type: TypeId): String = {
   "fn(".concat(expression_type_display_list(types, params)).concat(") -> ").concat(expression_type_display(types, return_type))
 }
 
-def expression_type_display_reference(types: TypeStore, mutable: Bool, inner: TypeId): String = {
+def expression_type_display_reference(types: &TypeStore, mutable: Bool, inner: TypeId): String = {
   if (mutable) {
     "&mut ".concat(expression_type_display(types, inner))
   } else {
@@ -2860,7 +2879,7 @@ def expression_type_display_reference(types: TypeStore, mutable: Bool, inner: Ty
   }
 }
 
-def expression_type_display_list(types: TypeStore, items: Vec[TypeId]): String = {
+def expression_type_display_list(types: &TypeStore, items: &Vec[TypeId]): String = {
   var text = "";
   var index: usize = 0;
   while (index < items.len()) {

--- a/packages/cosmoc/src/types/declaration_resolution.cos
+++ b/packages/cosmoc/src/types/declaration_resolution.cos
@@ -72,8 +72,8 @@ class DeclarationResolution {
 }
 
 class DeclarationResolver {
-  val arenas: SyntaxArenas
-  val names: NameResolution
+  val arenas: &SyntaxArenas
+  val names: &NameResolution
   var types: TypeStore
   var diagnostics: Vec[DeclarationResolutionDiagnostic]
   var type_expr_types: Map[TypeExprId, TypeId]
@@ -306,10 +306,11 @@ class DeclarationResolver {
     }
   }
 
-  def resolve_params(&mut self, params: Vec[ParamId], current_class: Option[DefId]): Option[ParamId] = {
+  def resolve_params(&mut self, params: &Vec[ParamId], current_class: Option[DefId]): Option[ParamId] = {
     var receiver = Option[ParamId]::None;
     var index: usize = 0;
-    for (param_id in params) {
+    while (index < params.len()) {
+      val param_id = params.get(index);
       val param = self.arenas.param_value(param_id);
       param match {
         case SyntaxParam.Self(mutable, span) => {
@@ -430,8 +431,7 @@ class DeclarationResolver {
       return self.types.alloc_error()
     }
 
-    var arenas = self.arenas;
-    self.types.alloc_user(type_expr_text(arenas, id))
+    self.types.alloc_user(type_expr_text(self.arenas, id))
   }
 
   def resolve_definition_type(&mut self, definition: DefId, name: String, span: Span, alias_stack: Vec[usize]): TypeId = {
@@ -579,15 +579,15 @@ class DeclarationResolver {
   }
 }
 
-def resolve_module_declarations(arenas: SyntaxArenas, module_id: ModuleId): DeclarationResolution = {
+def resolve_module_declarations(arenas: &SyntaxArenas, module_id: ModuleId): DeclarationResolution = {
   val names = resolve_module_names(arenas, module_id);
   resolve_module_declarations_with_names(arenas, module_id, names)
 }
 
 def resolve_module_declarations_with_names(
-  arenas: SyntaxArenas,
+  arenas: &SyntaxArenas,
   module_id: ModuleId,
-  names: NameResolution
+  names: &NameResolution
 ): DeclarationResolution = {
   var resolver = DeclarationResolver(
     arenas,
@@ -629,29 +629,35 @@ def prelude_is_named_type(name: String): Bool = {
     name == "Id"
 }
 
-def alias_stack_contains(stack: Vec[usize], target: usize): Bool = {
-  for (definition in stack) {
+def alias_stack_contains(stack: &Vec[usize], target: usize): Bool = {
+  var index: usize = 0;
+  while (index < stack.len()) {
+    val definition = stack.get(index);
     if (definition == target) {
       return true
     }
+    index = index + 1
   }
   false
 }
 
-def alias_stack_push(stack: Vec[usize], target: usize): Vec[usize] = {
+def alias_stack_push(stack: &Vec[usize], target: usize): Vec[usize] = {
   val next = Vec[usize]();
-  for (definition in stack) {
+  var index: usize = 0;
+  while (index < stack.len()) {
+    val definition = stack.get(index);
     next.push(definition)
+    index = index + 1
   }
   next.push(target);
   next
 }
 
-def type_expr_text(arenas: SyntaxArenas, id: TypeExprId): String = {
+def type_expr_text(arenas: &SyntaxArenas, id: TypeExprId): String = {
   type_expr_node_text(arenas, arenas.type_value(id))
 }
 
-def type_expr_node_text(arenas: SyntaxArenas, typ: SyntaxType): String = {
+def type_expr_node_text(arenas: &SyntaxArenas, typ: SyntaxType): String = {
   typ match {
     case SyntaxType.Name(name, span) => {
       name

--- a/packages/cosmoc/src/types/model.cos
+++ b/packages/cosmoc/src/types/model.cos
@@ -126,7 +126,7 @@ def type_equals_user(left_name: String, right: CosmoType): Bool = {
       false
     }
     case CosmoType.User(right_name) => {
-      left_name == right_name
+      type_alias_canonical_name(left_name) == type_alias_canonical_name(right_name)
     }
     case CosmoType.Function(right_params, right_return) => {
       false
@@ -143,7 +143,41 @@ def type_equals_user(left_name: String, right: CosmoType): Bool = {
   }
 }
 
-def type_equals_function(types: &TypeStore, left_params: Vec[TypeId], left_return: TypeId, right: CosmoType): Bool = {
+def type_alias_canonical_name(name: String): String = {
+  if (name == "ModuleId") {
+    return "Id[SyntaxModule]"
+  }
+  if (name == "DeclId") {
+    return "Id[SyntaxDecl]"
+  }
+  if (name == "MemberId") {
+    return "Id[SyntaxMember]"
+  }
+  if (name == "ParamId") {
+    return "Id[SyntaxParam]"
+  }
+  if (name == "ExprId") {
+    return "Id[SyntaxExpr]"
+  }
+  if (name == "TypeExprId") {
+    return "Id[SyntaxType]"
+  }
+  if (name == "TypeId") {
+    return "Id[CosmoType]"
+  }
+  if (name == "DefId") {
+    return "Id[Definition]"
+  }
+  if (name == "ScopeId") {
+    return "Id[Scope]"
+  }
+  if (name == "PackageModuleId") {
+    return "Id[PackageModule]"
+  }
+  name
+}
+
+def type_equals_function(types: &TypeStore, left_params: &Vec[TypeId], left_return: TypeId, right: CosmoType): Bool = {
   right match {
     case CosmoType.Primitive(right_name) => {
       false
@@ -189,7 +223,7 @@ def type_equals_reference(types: &TypeStore, left_mutable: Bool, left_inner: Typ
   }
 }
 
-def type_id_lists_equal(types: &TypeStore, left: Vec[TypeId], right: Vec[TypeId]): Bool = {
+def type_id_lists_equal(types: &TypeStore, left: &Vec[TypeId], right: &Vec[TypeId]): Bool = {
   if (left.len() != right.len()) {
     return false
   }
@@ -278,7 +312,7 @@ def type_node_display(types: &TypeStore, value: CosmoType): String = {
   }
 }
 
-def type_display_function(types: &TypeStore, params: Vec[TypeId], return_type: TypeId): String = {
+def type_display_function(types: &TypeStore, params: &Vec[TypeId], return_type: TypeId): String = {
   "fn(".concat(type_display_list(types, params)).concat(") -> ").concat(type_display(types, return_type))
 }
 
@@ -290,7 +324,7 @@ def type_display_reference(types: &TypeStore, mutable: Bool, inner: TypeId): Str
   }
 }
 
-def type_display_list(types: &TypeStore, items: Vec[TypeId]): String = {
+def type_display_list(types: &TypeStore, items: &Vec[TypeId]): String = {
   var text = "";
   var index: usize = 0;
   while (index < items.len()) {
@@ -316,7 +350,7 @@ def type_mismatch_diagnostic(span: Span, expected: TypeId, actual: TypeId): Type
   )
 }
 
-def type_diagnostic_expected_text(types: &TypeStore, diagnostic: TypeDiagnostic): String = {
+def type_diagnostic_expected_text(types: &TypeStore, diagnostic: &TypeDiagnostic): String = {
   diagnostic.mismatch match {
     case Option[TypeMismatch]::Some(mismatch) => {
       type_display(types, mismatch.expected)
@@ -327,7 +361,7 @@ def type_diagnostic_expected_text(types: &TypeStore, diagnostic: TypeDiagnostic)
   }
 }
 
-def type_diagnostic_actual_text(types: &TypeStore, diagnostic: TypeDiagnostic): String = {
+def type_diagnostic_actual_text(types: &TypeStore, diagnostic: &TypeDiagnostic): String = {
   diagnostic.mismatch match {
     case Option[TypeMismatch]::Some(mismatch) => {
       type_display(types, mismatch.actual)
@@ -338,7 +372,7 @@ def type_diagnostic_actual_text(types: &TypeStore, diagnostic: TypeDiagnostic): 
   }
 }
 
-def render_type_diagnostic(types: &TypeStore, diagnostic: TypeDiagnostic): String = {
+def render_type_diagnostic(types: &TypeStore, diagnostic: &TypeDiagnostic): String = {
   diagnostic.mismatch match {
     case Option[TypeMismatch]::Some(mismatch) => {
       diagnostic.message


### PR DESCRIPTION
## Summary
- allow mutable references to flow into readonly reference parameters while keeping the reverse direction rejected
- tighten receiver signature checks so mutability must match the declared receiver kind
- propagate shared references through Cosmo1 lowering, name resolution, declaration resolution, and IR verification
- add coverage for mutable-to-readonly reference calls and the corresponding backend output

## Tests
- added LIR assignability and type-checker tests for reference mutability
- added backend compilation coverage for passing `&mut` values to readonly parameters
- added Cosmo1 lowering and IR model updates to keep reference handling consistent