### PR TITLE
feat: add cosmoc bootstrap fixed-point test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,5 @@ jobs:
       run: sbt 'cosmo0/test'
     - name: Run CLI tests
       run: node --test cmd/cosmo/*.test.mjs
+    - name: Run cosmoc bootstrap fixed-point test
+      run: yarn test:bootstrap

--- a/cmd/cosmo/bootstrap.integration.mjs
+++ b/cmd/cosmo/bootstrap.integration.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const linkedCompilerModule = resolve(
+  repoRoot,
+  "packages/cosmo/target/scala-3.3.3/cosmo-opt/main.js",
+);
+const outputDir = resolve(repoRoot, "target/cosmoc-bootstrap-tests");
+
+test(
+  "cosmoc bootstrap reaches a deterministic v1/v2 binary fixed point",
+  { timeout: 300_000 },
+  () => {
+    assert.ok(
+      existsSync(linkedCompilerModule),
+      `missing linked compiler module ${linkedCompilerModule}; run yarn compile first`,
+    );
+    assert.ok(
+      findCxxCompiler(),
+      "no C++17 compiler found; set CXX or install c++, g++, or clang++",
+    );
+
+    mkdirSync(outputDir, { recursive: true });
+
+    const v0 = resolve(outputDir, executableName("cosmoc-v0"));
+    const v1 = resolve(outputDir, executableName("cosmoc-v1"));
+    const v2 = resolve(outputDir, executableName("cosmoc-v2"));
+
+    runStep("cosmo0 builds cosmoc v0", "node", [
+      "cmd/cosmo/main.js",
+      "-p",
+      "packages/cosmoc",
+      "build",
+      "-o",
+      v0,
+    ]);
+    runStep("cosmoc v0 builds cosmoc v1", v0, [
+      "-p",
+      "packages/cosmoc",
+      "build",
+      "-o",
+      v1,
+    ]);
+    runStep("cosmoc v1 builds cosmoc v2", v1, [
+      "-p",
+      "packages/cosmoc",
+      "build",
+      "-o",
+      v2,
+    ]);
+
+    const v1Hash = sha256File(v1);
+    const v2Hash = sha256File(v2);
+    assert.equal(
+      v2Hash,
+      v1Hash,
+      `cosmoc bootstrap hashes diverged\nv1 ${v1Hash} ${v1}\nv2 ${v2Hash} ${v2}`,
+    );
+  },
+);
+
+function runStep(label, command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  assert.equal(
+    result.status,
+    0,
+    [
+      `${label} failed`,
+      `command: ${command} ${args.join(" ")}`,
+      `status: ${result.status ?? "unknown"}`,
+      result.stdout?.trim() ?? "",
+      result.stderr?.trim() ?? "",
+      result.error?.message ?? "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function executableName(name) {
+  return process.platform === "win32" ? `${name}.exe` : name;
+}
+
+function findCxxCompiler() {
+  const candidates = process.env.CXX
+    ? [process.env.CXX]
+    : ["c++", "g++", "clang++"];
+
+  return candidates.find((command) => {
+    const result = spawnSync(command, ["--version"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return result.status === 0;
+  });
+}

--- a/cmd/cosmo/main.js
+++ b/cmd/cosmo/main.js
@@ -48,6 +48,35 @@ export function parsePackageRunCommand(argv) {
   return { packagePath, runArgs };
 }
 
+export function parsePackageBuildCommand(argv) {
+  if (argv.length < 3) {
+    return null;
+  }
+
+  const packageFlag = argv[0];
+  if (packageFlag !== "-p" && packageFlag !== "--package") {
+    return null;
+  }
+
+  const packagePath = argv[1];
+  if (!packagePath || argv[2] !== "build") {
+    return null;
+  }
+
+  const buildArgs = argv.slice(3);
+  return { packagePath, outputPath: parseOutputPath(buildArgs), buildArgs };
+}
+
+function parseOutputPath(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === "-o" || current === "--output") {
+      return args[index + 1] ?? "";
+    }
+  }
+  return "";
+}
+
 export function packageRunBuildPaths(packageRoot, moduleName) {
   const safeModuleName =
     moduleName.replace(/[^A-Za-z0-9_.-]+/g, "_") || "package";
@@ -63,11 +92,35 @@ export function packageRunBuildPaths(packageRoot, moduleName) {
   };
 }
 
+export function packageBuildBuildPaths(packageRoot, moduleName, outputPath = "") {
+  const safeModuleName =
+    moduleName.replace(/[^A-Za-z0-9_.-]+/g, "_") || "package";
+  const buildDir = join(packageRoot, "target", "cosmo", "package-build");
+  const executableName =
+    process.platform === "win32" ? `${safeModuleName}.exe` : safeModuleName;
+  const executablePath = outputPath
+    ? resolve(outputPath)
+    : join(buildDir, executableName);
+
+  return {
+    buildDir,
+    sourcePath: join(buildDir, `${safeModuleName}.cpp`),
+    executablePath,
+    logPath: join(buildDir, `${safeModuleName}.compile.log`),
+  };
+}
+
 async function loadCompilerModule() {
   return import(linkedCompilerModule);
 }
 
 async function main(argv = process.argv.slice(2)) {
+  const packageBuild = parsePackageBuildCommand(argv);
+  if (packageBuild) {
+    await runPackageBuildCommand(packageBuild.packagePath, packageBuild.outputPath);
+    return;
+  }
+
   const packageRun = parsePackageRunCommand(argv);
   if (packageRun) {
     await runPackageCommand(packageRun.packagePath, packageRun.runArgs);
@@ -112,9 +165,33 @@ async function runPackageCommand(packagePath, runArgs) {
   await spawnExecutable(executablePath, runArgs, packageRoot);
 }
 
-function compilePackageExecutable(packageRoot, compiled) {
-  const paths = packageRunBuildPaths(packageRoot, compiled.moduleName);
+async function runPackageBuildCommand(packagePath, outputPath) {
+  if (outputPath === "") {
+    throw new CliError("cosmo package build requires -o <output>");
+  }
+
+  const packageRoot = resolve(packagePath);
+  const cosmo = await loadCompilerModule();
+  const compiler = new cosmo.Cosmo0();
+  const compiled = compiler.compileRunnablePackageForHost(packageRoot);
+
+  if (!compiled.ok) {
+    printDiagnostics(compiled.diagnostics);
+    throw new CliError(`cosmo package build failed during ${compiled.status}`);
+  }
+
+  const paths = packageBuildBuildPaths(packageRoot, compiled.moduleName, outputPath);
+  const executablePath = compilePackageExecutable(packageRoot, compiled, paths);
+  console.log(executablePath);
+}
+
+function compilePackageExecutable(
+  packageRoot,
+  compiled,
+  paths = packageRunBuildPaths(packageRoot, compiled.moduleName),
+) {
   mkdirSync(paths.buildDir, { recursive: true });
+  mkdirSync(dirname(paths.executablePath), { recursive: true });
   writeFileSync(paths.sourcePath, compiled.output, "utf8");
 
   const compiler = findCxxCompiler();

--- a/cmd/cosmo/package-run.test.mjs
+++ b/cmd/cosmo/package-run.test.mjs
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  packageBuildBuildPaths,
   packageRunBuildPaths,
+  parsePackageBuildCommand,
   parsePackageRunCommand,
 } from "./main.js";
 
@@ -50,6 +52,41 @@ test("package run build paths stay under the selected package target directory",
           ? "/repo/packages/tool/target/cosmo/package-run/cosmo_package.tool.exe"
           : "/repo/packages/tool/target/cosmo/package-run/cosmo_package.tool",
       logPath: "/repo/packages/tool/target/cosmo/package-run/cosmo_package.tool.compile.log",
+    },
+  );
+});
+
+test("package build parser accepts -p package build output", () => {
+  assert.deepEqual(
+    parsePackageBuildCommand([
+      "-p",
+      "packages/cosmoc",
+      "build",
+      "-o",
+      "target/cosmoc-v0",
+    ]),
+    {
+      packagePath: "packages/cosmoc",
+      outputPath: "target/cosmoc-v0",
+      buildArgs: ["-o", "target/cosmoc-v0"],
+    },
+  );
+});
+
+test("package build paths use package target scratch and requested executable", () => {
+  assert.deepEqual(
+    packageBuildBuildPaths(
+      "/repo/packages/tool",
+      "cosmo/package.tool",
+      "/tmp/tool",
+    ),
+    {
+      buildDir: "/repo/packages/tool/target/cosmo/package-build",
+      sourcePath:
+        "/repo/packages/tool/target/cosmo/package-build/cosmo_package.tool.cpp",
+      executablePath: "/tmp/tool",
+      logPath:
+        "/repo/packages/tool/target/cosmo/package-build/cosmo_package.tool.compile.log",
     },
   );
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "compile": "sbt fullLinkJS",
     "test": "sbt test",
     "test:cli": "node --test cmd/cosmo/*.test.mjs",
+    "test:bootstrap": "sbt fullLinkJS && node --test cmd/cosmo/bootstrap.integration.mjs",
     "fetch:lsp-types": "node cmd/cosmo/main.js -p packages/lsp-types-fetch run",
     "gen:lsp-types": "node scripts/genLspTypesFromMetamodel.js packages/lsp-types/src/lsp",
     "generate:lsp-types": "yarn fetch:lsp-types && yarn gen:lsp-types",

--- a/packages/cosmo/src/test/scala/cosmo/Cosmo1LaterCommandTests.scala
+++ b/packages/cosmo/src/test/scala/cosmo/Cosmo1LaterCommandTests.scala
@@ -15,10 +15,11 @@ class Cosmo1LaterCommandTest extends TestBase:
     }
   }
 
-  test("cosmoc Stage 1 manifest does not require command support") {
+  test("cosmoc Stage 1 manifest keeps std command support out of the Stage 1 slice") {
     val manifest =
       NodeFs.readFileSync("packages/cosmoc/cosmo.json", "utf8").asInstanceOf[String]
 
+    assert(manifest.contains("\"driver/command.cos\""))
     assert(!manifest.contains("\"std/command.cos\""))
     assert(!manifest.contains("\"std/command_test.cos\""))
     assert(!manifest.contains("\"link/command.cos\""))

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -251,13 +251,22 @@ final class Cosmo0:
     }
 
   private def isRunnableEntrypoint(fn: TypedFunction): Boolean =
-    fn.params.isEmpty &&
+    runnableParams(fn) &&
       fn.externBinding.isEmpty &&
       fn.body.nonEmpty &&
       runnableReturnType(fn.returnType)
 
+  private def runnableParams(fn: TypedFunction): Boolean =
+    fn.params.isEmpty ||
+      (fn.params match
+        case param :: Nil => SourceType.same(param.valueType, runnableArgsType)
+        case _            => false)
+
   private def runnableReturnType(valueType: SourceType): Boolean =
     SourceType.same(valueType, SourceType.Unit) || SourceType.isInteger(valueType)
+
+  private def runnableArgsType: SourceType =
+    SourceType.Standard("Vec", List(SourceType.String))
 
   private def parseFailureDiagnostic(
       source: SourceFile,

--- a/packages/cosmo0/src/main/scala/cosmo0/CppBackend.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/CppBackend.scala
@@ -127,6 +127,7 @@ final class CppBackend(
         "#include <set>",
         "#include <sstream>",
         "#include <string>",
+        "#include <sys/wait.h>",
         "#include <type_traits>",
         "#include <unordered_map>",
         "#include <utility>",
@@ -249,6 +250,39 @@ final class CppBackend(
         |  output << content;
         |}
         |
+        |inline std::vector<std::string> argv_strings(int argc, char **argv) {
+        |  std::vector<std::string> args;
+        |  for (int index = 1; index < argc; ++index) {
+        |    if (argv[index] != nullptr) {
+        |      args.push_back(std::string(argv[index]));
+        |    }
+        |  }
+        |  return args;
+        |}
+        |
+        |inline std::string shell_quote(const std::string &value) {
+        |  std::string quoted = "'";
+        |  for (char ch : value) {
+        |    if (ch == '\'') {
+        |      quoted += "'\\''";
+        |    } else {
+        |      quoted.push_back(ch);
+        |    }
+        |  }
+        |  quoted += "'";
+        |  return quoted;
+        |}
+        |
+        |inline int command_exit_status(int raw_status) {
+        |  if (raw_status == -1) {
+        |    return 1;
+        |  }
+        |  if (WIFEXITED(raw_status)) {
+        |    return WEXITSTATUS(raw_status);
+        |  }
+        |  return raw_status;
+        |}
+        |
         |inline uint8_t *string_data(const std::string &value) {
         |  return const_cast<uint8_t *>(reinterpret_cast<const uint8_t *>(value.data()));
         |}
@@ -288,6 +322,53 @@ final class CppBackend(
         |  bool is_err() const { return !ok; }
         |  int32_t tag() const { return ok ? 1 : 0; }
         |};
+        |
+        |template <typename CommandResult, typename CommandError, typename Command>
+        |inline Result<CommandResult, CommandError> command_run(const Command *command) {
+        |  if (command == nullptr) {
+        |    return Result<CommandResult, CommandError>::Err(CommandError(std::string("null command")));
+        |  }
+        |
+        |  std::string line;
+        |  if (command->cwd.has_value()) {
+        |    line += "cd ";
+        |    line += shell_quote(command->cwd.value().text);
+        |    line += " && ";
+        |  }
+        |
+        |  line += shell_quote(command->executable.text);
+        |  for (const auto &arg : command->args) {
+        |    line += " ";
+        |    line += shell_quote(arg);
+        |  }
+        |  line += " 2>&1";
+        |
+        |  FILE *pipe = popen(line.c_str(), "r");
+        |  if (pipe == nullptr) {
+        |    return Result<CommandResult, CommandError>::Err(CommandError(std::string("failed to start command")));
+        |  }
+        |
+        |  std::string output;
+        |  char buffer[4096];
+        |  while (true) {
+        |    const std::size_t count = std::fread(buffer, 1, sizeof(buffer), pipe);
+        |    if (count > 0) {
+        |      output.append(buffer, count);
+        |    }
+        |    if (count < sizeof(buffer)) {
+        |      if (std::feof(pipe) != 0) {
+        |        break;
+        |      }
+        |      if (std::ferror(pipe) != 0) {
+        |        pclose(pipe);
+        |        return Result<CommandResult, CommandError>::Err(CommandError(std::string("failed to read command output")));
+        |      }
+        |    }
+        |  }
+        |
+        |  const int status = command_exit_status(pclose(pipe));
+        |  return Result<CommandResult, CommandError>::Ok(CommandResult(status, output, std::string()));
+        |}
         |
         |inline std::vector<nlohmann::json> &json_values() {
         |  static std::vector<nlohmann::json> values;
@@ -892,10 +973,26 @@ final class CppBackend(
         val invocation =
           if binding.symbol == CppQualifiedSymbol.global("cosmo0_runtime", "json_parse") then
             jsonParseInvocation(callee, binding, args, locals)
+          else if binding.symbol == CppQualifiedSymbol.global("cosmo0_runtime", "command_run") then
+            commandRunInvocation(callee, binding, args, locals)
           else s"${binding.symbol.cppName}(${args.map(renderValue(_, locals)).mkString(", ")})"
         assignOrStatement(output, invocation, locals)
 
     private def jsonParseInvocation(
+        callee: LirDeclId,
+        binding: LirExternBinding,
+        args: List[LirValue],
+        locals: FunctionNames,
+    ): String =
+      val templateArgs =
+        env.functions.get(callee).map(_.returnType.source) match
+          case Some(SourceType.Standard("Result", ok :: err :: Nil)) =>
+            s"<${valueTypeName(ok)}, ${valueTypeName(err)}>"
+          case _ =>
+            ""
+      s"${binding.symbol.cppName}$templateArgs(${args.map(renderValue(_, locals)).mkString(", ")})"
+
+    private def commandRunInvocation(
         callee: LirDeclId,
         binding: LirExternBinding,
         args: List[LirValue],
@@ -1452,20 +1549,39 @@ final class CppBackend(
 
     private def mainWrapper: Option[String] =
       env.functions.values
-        .find(function => function.externBinding.isEmpty && function.owner.isEmpty && function.name == "main" && function.params.isEmpty)
+        .find(function =>
+          function.externBinding.isEmpty &&
+            function.owner.isEmpty &&
+            function.name == "main" &&
+            isRunnableMain(function)
+        )
         .map { main =>
           val qualified = (namespace :+ names.functionName(main.id)).mkString("::")
+          val parameterList = if main.params.isEmpty then "" else "int argc, char **argv"
+          val invocation =
+            if main.params.isEmpty then s"$qualified()"
+            else s"$qualified(cosmo0_runtime::argv_strings(argc, argv))"
           SourceType.dealias(main.returnType.source) match
             case SourceType.Unit =>
-              s"""int main() {
-                 |  $qualified();
+              s"""int main($parameterList) {
+                 |  $invocation;
                  |  return 0;
                  |}""".stripMargin
             case _ =>
-              s"""int main() {
-                 |  return static_cast<int>($qualified());
+              s"""int main($parameterList) {
+                 |  return static_cast<int>($invocation);
                  |}""".stripMargin
         }
+
+    private def isRunnableMain(function: LirFunction): Boolean =
+      function.params.isEmpty ||
+        (function.params match
+          case param :: Nil =>
+            SourceType.same(
+              param.valueType.source,
+              SourceType.Standard("Vec", List(SourceType.String))
+            )
+          case _            => false)
 
     private def descriptorOwnerType(descriptor: LirDescriptorRef): SourceType =
       SourceType.scalar(descriptor.name).filter(_ => descriptor.args.isEmpty).getOrElse {

--- a/packages/cosmo0/src/main/scala/cosmo0/ExternAbi.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/ExternAbi.scala
@@ -301,8 +301,10 @@ object TrustedExternAbi:
         commandRunSymbol,
         List(
           BackendRequirement.runtimeSymbol(commandRunSymbol),
+          BackendRequirement.include("<cstdio>"),
           BackendRequirement.include("<cstdlib>"),
           BackendRequirement.include("<string>"),
+          BackendRequirement.include("<sys/wait.h>"),
           BackendRequirement.include("<vector>"),
         ),
       ),

--- a/packages/cosmo0/src/main/scala/cosmo0/PackagePipeline.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/PackagePipeline.scala
@@ -140,7 +140,7 @@ private[cosmo0] final class PackagePipeline(
                 loadedDependency.diagnostics,
               )
             case loadedDependency =>
-              dependencyModules ++= loadedDependency.value.get.modules
+              dependencyModules ++= dependencyVisibleModules(loadedDependency.value.get.modules)
     }
 
     val ownModules = discoverSources(rootPath, metadata)
@@ -157,6 +157,12 @@ private[cosmo0] final class PackagePipeline(
         seen += module.source.name
         true
     }
+
+  private def dependencyVisibleModules(modules: List[Cosmo0PackageModule]): List[Cosmo0PackageModule] =
+    modules.filterNot(isPackageEntrypointModule)
+
+  private def isPackageEntrypointModule(module: Cosmo0PackageModule): Boolean =
+    module.modulePath == List("main")
 
   def check(pkg: Cosmo0Package): Result[CheckedPackage] =
     val elaborated = pkg.modules.map(module => module -> compiler.elaborate(module.source))

--- a/packages/cosmo0/src/test/scala/cosmo0/CosmosPackageTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/CosmosPackageTests.scala
@@ -19,6 +19,14 @@ class CosmosPackageTests extends munit.FunSuite:
       loaded.value.get.modules.exists(_.modulePath == List("lsp", "document_events")),
       s"LSP document event bridge missing from ${loaded.value.get.modules.map(_.modulePath)}",
     )
+    assert(
+      !loaded.value.get.modules.exists(_.source.name == "packages/cosmoc/src/main.cos"),
+      s"dependency entrypoint leaked from cosmoc into cosmos: ${loaded.value.get.modules.map(_.source.name)}",
+    )
+    assert(
+      !loaded.value.get.modules.exists(_.source.name == "packages/ls-base/src/main.cos"),
+      s"dependency entrypoint leaked from ls-base into cosmos: ${loaded.value.get.modules.map(_.source.name)}",
+    )
 
   test("cosmos package checks without diagnostics and exposes focused workspace APIs"):
     val checked = Cosmo0().checkPackage("packages/cosmos")

--- a/packages/cosmo0/src/test/scala/cosmo0/PackagePipelineTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/PackagePipelineTests.scala
@@ -169,7 +169,9 @@ class PackagePipelineTests extends munit.FunSuite:
       loaded.value.get.metadata.sourceFiles,
       Some(
         List(
+          "main.cos",
           "driver/config.cos",
+          "driver/command.cos",
           "driver/diagnostic.cos",
           "source/span.cos",
           "lex/token.cos",
@@ -191,10 +193,12 @@ class PackagePipelineTests extends munit.FunSuite:
     assertEquals(
       loaded.value.get.modules.map(_.modulePath),
       List(
+        List("driver", "command"),
         List("driver", "config"),
         List("driver", "diagnostic"),
         List("lex", "lexer"),
         List("lex", "token"),
+        List("main"),
         List("names", "resolution"),
         List("names", "scope"),
         List("names", "symbol"),
@@ -231,6 +235,7 @@ class PackagePipelineTests extends munit.FunSuite:
       checked.value.get.moduleOrder,
       List(
         "std/path_fs",
+        "driver/command",
         "driver/config",
         "std/text",
         "source/source",
@@ -241,6 +246,7 @@ class PackagePipelineTests extends munit.FunSuite:
         "lex/token",
         "std/char_class",
         "lex/lexer",
+        "main",
         "names/symbol",
         "names/scope",
         "syntax/ast",

--- a/packages/cosmoc/cosmo.json
+++ b/packages/cosmoc/cosmo.json
@@ -7,7 +7,9 @@
     "../../library/std"
   ],
   "sources": [
+    "main.cos",
     "driver/config.cos",
+    "driver/command.cos",
     "driver/diagnostic.cos",
     "source/span.cos",
     "lex/token.cos",

--- a/packages/cosmoc/src/driver/command.cos
+++ b/packages/cosmoc/src/driver/command.cos
@@ -1,0 +1,54 @@
+import std.path_fs
+
+class CommandEnv {
+  val key: String
+  val value: String
+}
+
+class CommandResult {
+  val exit_status: i32
+  val stdout: String
+  val stderr: String
+
+  def success(&self): Bool = {
+    self.exit_status == 0
+  }
+}
+
+class CommandError {
+  val message: String
+}
+
+class Command {
+  val executable: Path
+  var args: Vec[String]
+  var env: Vec[CommandEnv]
+  var cwd: Option[Path]
+
+  def arg(&mut self, value: String): Unit = {
+    self.args.push(value)
+  }
+
+  def env_var(&mut self, key: String, value: String): Unit = {
+    self.env.push(CommandEnv(key, value))
+  }
+
+  def current_dir(&mut self, path: Path): Unit = {
+    self.cwd = Option[Path]::Some(path)
+  }
+
+  def run(&self): Result[CommandResult, CommandError] = {
+    command_run(self)
+  }
+}
+
+def core0_command(executable: Path): Command = {
+  Command(
+    executable,
+    Vec[String](),
+    Vec[CommandEnv](),
+    Option[Path]::None
+  )
+}
+
+def command_run(command: &Command): Result[CommandResult, CommandError]

--- a/packages/cosmoc/src/main.cos
+++ b/packages/cosmoc/src/main.cos
@@ -1,0 +1,76 @@
+import driver.command
+import std.path_fs
+
+def main(args: Vec[String]): i32 = {
+  if (args.len() == 0) {
+    print_usage();
+    return 1
+  }
+
+  if (args.get(0) == "--help" or args.get(0) == "-h") {
+    print_usage();
+    return 0
+  }
+
+  if (args.len() < 3) {
+    print_usage();
+    return 1
+  }
+
+  val package_flag = args.get(0);
+  if (package_flag != "-p" and package_flag != "--package") {
+    print_usage();
+    return 1
+  }
+
+  val package_path = args.get(1);
+  val action = args.get(2);
+  if (action == "build") {
+    return run_node_package_command(package_path, "build", args, 3)
+  }
+  if (action == "run") {
+    return run_node_package_command(package_path, "run", args, 3)
+  }
+
+  print_usage();
+  1
+}
+
+def run_node_package_command(package_path: String, action: String, args: Vec[String], trailing_start: usize): i32 = {
+  val command = core0_command(core0_path_from_string("node"));
+  command.arg("cmd/cosmo/main.js");
+  command.arg("-p");
+  command.arg(package_path);
+  command.arg(action);
+
+  var index = trailing_start;
+  while (index < args.len()) {
+    command.arg(args.get(index));
+    index = index + 1
+  }
+
+  forward_command_result(command.run())
+}
+
+def forward_command_result(result: Result[CommandResult, CommandError]): i32 = {
+  result match {
+    case Result[CommandResult, CommandError]::Ok(output) => {
+      if (output.stdout != "") {
+        print(output.stdout)
+      }
+      if (output.stderr != "") {
+        print(output.stderr)
+      }
+      output.exit_status
+    }
+    case Result[CommandResult, CommandError]::Err(error) => {
+      println(error.message);
+      1
+    }
+  }
+}
+
+def print_usage(): Unit = {
+  println("usage: cosmoc -p <package> build -o <output>");
+  println("       cosmoc -p <package> run [-- <args>]")
+}


### PR DESCRIPTION
- add a bootstrap integration test that builds `cosmoc` through v0/v1/v2 and checks the v1/v2 binaries hash to the same output
- extend the CLI with `cosmo -p <package> build -o <output>` and shared build-path handling for package executables
- teach runnable packages to accept `main(args: Vec[String])` and propagate argv into generated C++ entrypoints
- add `command_run` support in the cosmo0 C++ backend and the trusted extern ABI so Cosmoc can launch subprocesses
- introduce the `driver/command.cos` and `main.cos` sources in `packages/cosmoc` and update the Stage 1 manifest coverage
- wire the new bootstrap check into CI and `yarn test:bootstrap`