### PR TITLE
Fix GitHub Pages docs build

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -26,33 +26,50 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - run: git submodule update --init --recursive
+      - name: Make directories
+        run: |
+          if [ ! -d "${XDG_DATA_HOME:-$HOME/.local/share}" ]; then
+            echo "Creating data directory: ${XDG_DATA_HOME:-$HOME/.local/share}"
+            mkdir -p ${XDG_DATA_HOME:-$HOME/.local/share}
+          else
+            echo "Data directory already exists: ${XDG_DATA_HOME:-$HOME/.local/share}"
+          fi
+          if [ ! -d "${XDG_CACHE_HOME:-$HOME/.cache}" ]; then
+            echo "Creating cache directory: ${XDG_CACHE_HOME:-$HOME/.cache}"
+            mkdir -p ${XDG_CACHE_HOME:-$HOME/.cache}
+          else
+            echo "Cache directory already exists: ${XDG_CACHE_HOME:-$HOME/.cache}"
+          fi
       - name: Download font assets
         # use fonts in stable releases
         run: |
           mkdir -p assets/fonts/
           curl -L https://github.com/Myriad-Dreamin/shiroa/releases/download/v0.1.2/font-assets.tar.gz | tar -xvz -C assets/fonts
+          curl -L https://github.com/Myriad-Dreamin/shiroa/releases/download/v0.1.0/charter-font-assets.tar.gz | tar -xvz -C assets/fonts
+          curl -L https://github.com/Myriad-Dreamin/shiroa/releases/download/v0.1.5/source-han-serif-font-assets.tar.gz | tar -xvz -C assets/fonts
       - name: Download & install shiroa
         run: |
-          curl -L https://github.com/Myriad-Dreamin/shiroa/releases/download/v0.2.0-nightly4/shiroa-x86_64-unknown-linux-gnu.tar.gz | tar -xvz
-          chmod +x shiroa-x86_64-unknown-linux-gnu/bin/shiroa
-          sudo cp shiroa-x86_64-unknown-linux-gnu/bin/shiroa /usr/bin/shiroa
-      - name: Install packages
-        uses: borales/actions-yarn@v4
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Myriad-Dreamin/shiroa/releases/download/v0.3.1-rc4/shiroa-installer.sh | sh
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          cmd: install
+          node-version: 24
+          cache: 'yarn'
+      - name: Install deps
+        run: yarn install
       - name: Compile Syntax
         run: |
           yarn run build:syntax
       - name: Build Book
         run: |
-          shiroa build --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ --path-to-root /cosmo/ -w . docs/cosmo
+          shiroa build --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ --path-to-root /cosmo/ -w . docs/cosmo --mode=static-html
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload `/github-pages` sub directory
           path: './dist/docs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/docs/cosmo/book.typ
+++ b/docs/cosmo/book.typ
@@ -1,15 +1,19 @@
 
-#import "@preview/shiroa:0.1.2": *
+#import "@preview/shiroa:0.3.1": *
 
 #show: book
 
 #book-meta(
   title: "cosmo",
+  description: "The documentation for cosmo language design and implementation notes",
+  authors: ("Myriad-Dreamin",),
+  repository: "https://github.com/Myriad-Dreamin/cosmo",
+  repository-edit: "https://github.com/Myriad-Dreamin/cosmo/edit/main/{path}",
+  language: "en",
   summary: [
     #prefix-chapter("intro.typ")[Introduction]
     #prefix-chapter("syntax.typ")[Syntax]
     #prefix-chapter("syntax-bnf.typ")[BNF Specification]
-    #prefix-chapter("class.typ")[Class Design]
     #prefix-chapter("trait.typ")[Trait Design]
     #prefix-chapter("ufcs.typ")[Method Call Design]
   ],

--- a/docs/cosmo/ebook.typ
+++ b/docs/cosmo/ebook.typ
@@ -1,4 +1,4 @@
-#import "@preview/shiroa:0.1.2": *
+#import "@preview/shiroa:0.3.1": *
 
 #import "/typ/templates/ebook.typ"
 

--- a/docs/cosmo/intro.typ
+++ b/docs/cosmo/intro.typ
@@ -6,6 +6,5 @@ Cosmo is a language replacing awful C++'s compile-time magics. This is only some
 
 - #cross-link("/syntax.typ")[Syntax]
 - #cross-link("/syntax-bnf.typ")[BNF Specification]
-- #cross-link("/class.typ")[Class Design]
 - #cross-link("/trait.typ")[Trait Design]
 - #cross-link("/ufcs.typ")[Method Call Design]

--- a/docs/cosmo/mod.typ
+++ b/docs/cosmo/mod.typ
@@ -1,2 +1,2 @@
 #import "/docs/cosmo/book.typ": book-page
-#import "@preview/shiroa:0.1.2": *
+#import "@preview/shiroa:0.3.1": *

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cosmo": "node ./cmd/cosmo/main.js",
     "validate:cosmo0-docs": "node scripts/validateCosmo0Docs.js",
     "validate:sample-workspaces": "node scripts/validateSampleWorkspaces.mjs",
-    "docs": "shiroa serve --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ -w . docs/cosmo",
+    "docs": "shiroa serve --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ --path-to-root / -w . docs/cosmo --mode=static-html",
     "build:syntax": "node scripts/build.mjs build:syntax",
     "build:cosmos-host": "node scripts/build.mjs build:cosmos-host",
     "build:vscode": "node scripts/build.mjs build:vscode",

--- a/typ/templates/ebook.typ
+++ b/typ/templates/ebook.typ
@@ -1,4 +1,4 @@
-#import "@preview/shiroa:0.1.0": *
+#import "@preview/shiroa:0.3.1": *
 #import "/typ/templates/page.typ": project, part-style
 
 #let _page-project = project
@@ -7,7 +7,7 @@
 
 #let resolve-inclusion(inc) = _resolve-inclusion-state.update(it => inc)
 
-#let project(title: "", authors: (), spec: "", content) = {
+#let project(title: "", authors: (), spec: "", body) = {
   // Set document metadata early
   set document(
     author: authors,
@@ -21,17 +21,17 @@
     heading(title)
   }
 
-  locate(loc => {
-    let inc = _resolve-inclusion-state.final(loc)
+  context {
+    let inc = _resolve-inclusion-state.final()
     external-book(spec: inc(spec))
 
-    let mt = book-meta-state.final(loc)
+    let mt = book-meta-state.final()
     let styles = (inc: inc, part: part-style, chapter: it => it)
 
     if mt != none {
       mt.summary.map(it => visit-summary(it, styles)).sum()
     }
-  })
+  }
 
-  content
+  body
 }

--- a/typ/templates/page.typ
+++ b/typ/templates/page.typ
@@ -1,29 +1,29 @@
 // This is important for shiroa to produce a responsive layout
 // and multiple targets.
-#import "@preview/shiroa:0.1.2": get-page-width, target, is-web-target, is-pdf-target, plain-text, templates
+#import "@preview/shiroa:0.3.1": (
+  get-page-width, is-html-target, is-pdf-target, is-web-target, plain-text, shiroa-sys-target, templates, x-target,
+)
 #import templates: *
+#import "@preview/numbly:0.1.0": numbly
+#import "theme.typ": *
+
+#let web-theme = "starlight"
+#let is-starlight-theme = web-theme == "starlight"
 
 // Metadata
 #let page-width = get-page-width()
+#let is-html-target = is-html-target()
 #let is-pdf-target = is-pdf-target()
 #let is-web-target = is-web-target()
-
-// Theme (Colors)
-#let (
-  style: theme-style,
-  is-dark: is-dark-theme,
-  is-light: is-light-theme,
-  main-color: main-color,
-  dash-color: dash-color,
-  code-extra-colors: code-extra-colors,
-) = book-theme-from(toml("theme-style.toml"), xml: it => xml(it))
+#let is-md-target = x-target == "md"
+#let sys-is-html-target = ("target" in dictionary(std))
 
 // Fonts
 #let main-font = (
   "Charter",
-  // shiroa's embedded font
   "Libertinus Serif",
   "Source Han Serif SC",
+  // shiroa's embedded font
 )
 #let code-font = (
   "BlexMono Nerd Font Mono",
@@ -31,56 +31,84 @@
   "DejaVu Sans Mono",
 )
 
+#let part-counter = counter("shiroa-part-counter")
+
+#let md-equation-rules(body) = {
+  let gh-dark-fg = rgb("#f0f6fc")
+
+  show math.equation: it => theme-box(
+    tag: if it.block { "p" } else { "span" },
+    theme => {
+      set text(fill: if theme.is-dark { gh-dark-fg } else { theme.main-color })
+      html.frame(it)
+    },
+  )
+
+  body
+}
+
 // Sizes
 #let main-size = if is-web-target {
   16pt
 } else {
   10.5pt
 }
-#let heading-sizes = (26pt, 22pt, 14pt, 12pt, main-size)
+#let heading-sizes = if is-web-target {
+  (2, 1.5, 1.17, 1, 0.83).map(it => it * main-size)
+} else {
+  (26pt, 22pt, 14pt, 12pt, main-size)
+}
 #let list-indent = 0.5em
 
-/// The project function defines how your document looks.
-/// It takes your content and some metadata and formats it.
-/// Go ahead and customize it to your liking!
-#let project(title: "Typst Book", authors: (), kind: "page", body) = {
+#let markup-rules(
+  body,
+  dash-color: none,
+  web-theme: "starlight",
+  main-size: main-size,
+  heading-sizes: heading-sizes,
+  list-indent: list-indent,
+  starlight: "@preview/shiroa-starlight:0.3.1",
+) = {
+  assert(dash-color != none, message: "dash-color must be set")
 
-  // set basic document metadata
-  set document(
-    author: authors,
-    title: title,
-  ) if not is-pdf-target
+  let is-starlight-theme = web-theme == "starlight"
+  let in-heading = state("shiroa:in-heading", false)
 
-  // set web/pdf page properties
-  set page(
-    numbering: none,
-    number-align: center,
-    width: page-width,
-  )
+  let mdbook-heading-rule(it) = {
+    let it = {
+      set text(size: heading-sizes.at(it.level))
+      if is-web-target {
+        heading-hash(it, hash-color: dash-color)
+      }
 
-  // remove margins for web target
-  set page(
-    margin: (
-      // reserved beautiful top margin
-      top: 20pt,
-      // reserved for our heading style.
-      // If you apply a different heading style, you may remove it.
-      left: 20pt,
-      // Typst is setting the page's bottom to the baseline of the last line of text. So bad :(.
-      bottom: 0.5em,
-      // remove rest margins.
-      rest: 0pt,
-    ),
-    height: auto,
-  ) if is-web-target
+      in-heading.update(true)
+      it
+      in-heading.update(false)
+    }
 
-  // Set main text
-  set text(
-    font: main-font,
-    size: main-size,
-    fill: main-color,
-    lang: "en",
-  )
+    block(
+      spacing: 0.7em * 1.5 * 1.2,
+      below: 0.7em * 1.2,
+      it,
+    )
+  }
+
+  let starlight-heading-rule(it) = context if shiroa-sys-target() == "html" {
+    import starlight: builtin-icon
+
+    in-heading.update(true)
+    html.elem("div", attrs: (class: "sl-heading-wrapper level-h" + str(it.level + 1)))[
+      #it
+      #html.elem(
+        "h" + str(it.level + 1),
+        attrs: (class: "sl-heading-anchor not-content", role: "presentation"),
+        static-heading-link(it, body: builtin-icon("anchor"), canonical: true),
+      )
+    ]
+    in-heading.update(false)
+  } else {
+    mdbook-heading-rule(it)
+  }
 
   // Set main spacing
   set enum(
@@ -97,56 +125,344 @@
   // Set text, spacing for headings
   // Render a dash to hint headings instead of bolding it as well if it's for web.
   show heading: set text(weight: "regular") if is-web-target
-  show heading: it => {
-    let it = {
-      set text(size: heading-sizes.at(it.level))
-      if is-web-target {
-        heading-hash(it, hash-color: dash-color)
-      }
-      it
-    }
-
-    block(
-      spacing: 0.7em * 1.5 * 1.2,
-      below: 0.7em * 1.2,
-      it,
-    )
+  show heading: if is-starlight-theme {
+    starlight-heading-rule
+  } else {
+    mdbook-heading-rule
   }
 
-  // link setting
+  // Link setting
   show link: set text(fill: dash-color)
-
-  // math setting
-  show math.equation: set text(weight: 400)
-
-
-  // code block setting
-  set raw(syntaxes: "/assets/files/cosmo.sublime-syntax")
-  show raw.where(lang: "cos"): set raw(lang: "cosmo")
-  show raw: it => {
-    set text(font: code-font)
-    if "block" in it.fields() and it.block {
-      rect(
-        width: 100%,
-        inset: (x: 4pt, y: 5pt),
-        radius: 4pt,
-        fill: code-extra-colors.bg,
-        [
-          #set text(fill: code-extra-colors.fg) if code-extra-colors.fg != none
-          #set par(justify: false)
-          // #place(right, text(luma(110), it.lang))
-          #it
-        ],
-      )
-    } else {
-      it
-    }
-  }
-
-  // Main body.
-  set par(justify: true)
 
   body
 }
 
-#let part-style = heading
+#let equation-rules(
+  body,
+  web-theme: "starlight",
+  theme-box: none,
+) = {
+  let is-starlight-theme = web-theme == "starlight"
+  let in-heading = state("shiroa:in-heading", false)
+
+  let div-frame(content, attrs: (:), tag: "div") = html.elem(tag, html.frame(content), attrs: attrs)
+  let span-frame = div-frame.with(tag: "span")
+  let p-frame = div-frame.with(tag: "p")
+
+  let get-main-color(theme) = {
+    if is-starlight-theme and theme.is-dark and in-heading.get() {
+      white
+    } else {
+      theme.main-color
+    }
+  }
+
+  show math.equation: set text(weight: 400)
+  show math.equation.where(block: true): it => context if shiroa-sys-target() == "html" {
+    theme-box(tag: "div", theme => {
+      set text(fill: get-main-color(theme))
+      p-frame(attrs: ("class": "block-equation", "role": "math"), it)
+    })
+  } else {
+    it
+  }
+  show math.equation.where(block: false): it => context if shiroa-sys-target() == "html" {
+    theme-box(tag: "span", theme => {
+      set text(fill: get-main-color(theme))
+      span-frame(attrs: (class: "inline-equation", "role": "math"), it)
+    })
+  } else {
+    it
+  }
+
+  body
+}
+
+#let with-raw-theme = (theme, it) => {
+  if theme.len() > 0 {
+    raw(
+      align: it.align,
+      tab-size: 2,
+      block: it.block,
+      lang: it.lang,
+      syntaxes: it.syntaxes,
+      theme: theme,
+      it.text,
+    )
+  } else {
+    raw(
+      align: it.align,
+      tab-size: 2,
+      block: it.block,
+      lang: it.lang,
+      syntaxes: it.syntaxes,
+      theme: auto,
+      it.text,
+    )
+  }
+}
+
+#let code-block-rules(
+  body,
+  web-theme: "starlight",
+  code-font: none,
+  themes: none,
+  zebraw: "@preview/zebraw:0.6.1",
+) = {
+  import zebraw: zebraw, zebraw-init
+
+  let (
+    default-theme: (
+      style: theme-style,
+      is-dark: is-dark-theme,
+      is-light: is-light-theme,
+      main-color: main-color,
+      dash-color: dash-color,
+      code-extra-colors: code-extra-colors,
+    ),
+  ) = themes
+  let (
+    default-theme: default-theme,
+  ) = themes
+  let theme-box = theme-box.with(themes: themes)
+
+  let zebraw-commons = (
+    inset: (left: 1em, top: 0.375em),
+    lang: false,
+    numbering: false,
+  )
+
+  let init-with-theme((code-extra-colors, is-dark)) = if is-dark {
+    zebraw-init.with(
+      // should vary by theme
+      background-color: if code-extra-colors.bg != none {
+        (code-extra-colors.bg, code-extra-colors.bg)
+      },
+      highlight-color: rgb("#3d59a1"),
+      comment-color: rgb("#394b70"),
+      lang-color: rgb("#3d59a1"),
+      ..zebraw-commons,
+    )
+  } else {
+    zebraw-init.with(
+      // should vary by theme
+      background-color: if code-extra-colors.bg != none {
+        (code-extra-colors.bg, code-extra-colors.bg)
+      },
+      ..zebraw-commons,
+    )
+  }
+
+  context if shiroa-sys-target() != "html" {
+    counter("zebraw-html-styles").step()
+    counter("zebraw-html-clipboard").step()
+  }
+
+  /// HTML code block supported by zebraw.
+  show: init-with-theme(default-theme)
+  set raw(tab-size: 114)
+
+  let in-mk-raw = state("shiroa:in-mk-raw", false)
+  let mk-raw(
+    it,
+    tag: "div",
+    inline: false,
+  ) = {
+    theme-box(tag: tag, theme => {
+      show: init-with-theme(theme)
+      let code-extra-colors = theme.code-extra-colors
+      let use-fg = not inline and code-extra-colors.fg != none
+      set text(fill: code-extra-colors.fg) if use-fg
+      set text(fill: if theme.is-dark { rgb("dfdfd6") } else { black }) if not use-fg
+      set par(justify: false)
+      zebraw(
+        block-width: 100%,
+        wrap: false,
+        with-raw-theme(theme.style.code-theme, it),
+      )
+    })
+  }
+
+  show raw: set text(font: code-font) if code-font != none
+  show raw.where(block: false, tab-size: 114): it => context if shiroa-sys-target() == "paged" {
+    it
+  } else {
+    mk-raw(it, tag: "span", inline: true)
+  }
+  show raw.where(block: true, tab-size: 114): it => context if shiroa-sys-target() == "paged" {
+    rect(width: 100%, inset: (x: 4pt, y: 5pt), radius: 4pt, fill: code-extra-colors.bg, {
+      set text(fill: code-extra-colors.fg) if code-extra-colors.fg != none
+      set par(justify: false)
+      with-raw-theme(theme-style.code-theme, it)
+    })
+  } else {
+    mk-raw(it)
+  }
+
+  body
+}
+
+/// The project function defines how your document looks.
+/// It takes your content and some metadata and formats it.
+/// Go ahead and customize it to your liking!
+#let project(title: "", authors: (), kind: "page", description: none, body) = {
+  // Set basic document metadata
+  set document(
+    author: authors,
+    title: title,
+  ) if not is-pdf-target and not is-md-target
+
+  let is-main = title == "cosmo"
+
+  // Set web/pdf page properties
+  set page(
+    numbering: none,
+    number-align: center,
+    width: page-width,
+  ) if not (sys-is-html-target or is-html-target)
+  set page(numbering: "1") if (not sys-is-html-target and is-pdf-target) and not is-main and kind == "page"
+
+  // Remove margins for web target
+  set page(
+    margin: (
+      top: 20pt,
+      left: 20pt,
+      bottom: 0.5em,
+      rest: 0pt,
+    ),
+    height: auto,
+  ) if is-web-target and not is-html-target
+
+  show: if is-html-target {
+    import "@preview/shiroa-starlight:0.3.1": starlight
+
+    let description = if description != none { description } else {
+      let desc = plain-text(body, limit: 512).trim()
+      if desc.len() > 512 {
+        desc = desc.slice(0, 512) + "..."
+      }
+      desc
+    }
+
+    starlight.with(
+      include "/docs/cosmo/book.typ",
+      title: title,
+      description: description,
+    )
+  } else {
+    it => it
+  }
+
+  // Set main text
+  set text(
+    font: main-font,
+    size: main-size,
+    fill: main-color,
+    lang: "en",
+  )
+
+  show: if is-md-target {
+    it => it
+  } else {
+    markup-rules.with(web-theme: web-theme, dash-color: dash-color)
+  }
+  show: if is-md-target {
+    it => it
+  } else {
+    it => {
+      set heading(numbering: "1.") if is-pdf-target and not is-main
+      it
+    }
+  }
+
+  show: if is-md-target {
+    md-equation-rules
+  } else {
+    equation-rules.with(theme-box: theme-box)
+  }
+
+  show: if is-md-target {
+    it => it
+  } else {
+    code-block-rules.with(
+      zebraw: "@preview/zebraw:0.6.1",
+      themes: themes,
+      code-font: code-font,
+    )
+  }
+
+  if not is-md-target {
+    context if shiroa-sys-target() == "html" {
+      show raw: it => html.elem("style", it.text)
+      ```css
+      .pseudo-image svg {
+        width: 100%
+      }
+      ```
+    }
+  }
+
+  show <typst-raw-func>: it => {
+    it.lines.at(0).body.children.slice(0, -2).join()
+  }
+
+  if kind == "page" and is-pdf-target and not is-main {
+    text(size: 32pt, heading(level: 1, numbering: none, title))
+  }
+  if is-md-target {
+    html.elem("m1verbatim", attrs: (
+      src: "<!-- This file is generated by scripts/link-docs.mjs. Do not edit manually. -->\n",
+    ))
+    let title-text = plain-text(title)
+    if title-text.len() > 0 {
+      html.elem("m1verbatim", attrs: (src: "# " + title-text + "\n"))
+    }
+  }
+
+  set raw(syntaxes: "/assets/files/cosmo.sublime-syntax")
+  show raw.where(lang: "cos"): set raw(lang: "cosmo")
+
+  // Main body
+  set par(justify: true)
+
+  body
+
+  context if not is-md-target and shiroa-sys-target() == "html" {
+    html.elem(
+      "style",
+      ```css
+      .inline-equation {
+        display: inline-block;
+        width: fit-content;
+      }
+      .block-equation {
+        display: grid;
+        place-items: center;
+        overflow-x: auto;
+      }
+      .site-title {
+        font-size: 1.2rem;
+        font-weight: 600;
+        font-style: italic;
+      }
+      figcaption {
+        margin: 0.5rem 0;
+        text-align: center;
+      }
+      figure {
+        margin: 1.5rem 0 1rem 0;
+      }
+      ```.text,
+    )
+  }
+}
+
+#let part-style(it) = {
+  set text(size: heading-sizes.at(0))
+  set text(weight: "bold")
+  set text(fill: main-color)
+  part-counter.step()
+
+  context heading(numbering: none, [Part #part-counter.display(numbly("{1}. "))#it])
+  counter(heading).update(0)
+}

--- a/typ/templates/target.typ
+++ b/typ/templates/target.typ
@@ -1,0 +1,4 @@
+#import "@preview/shiroa:0.3.1": book-sys
+
+#let is-md-target = book-sys.target == "md"
+#let sys-is-html-target = book-sys.sys-is-html-target

--- a/typ/templates/theme.typ
+++ b/typ/templates/theme.typ
@@ -1,0 +1,155 @@
+#import "@preview/shiroa:0.3.1": templates, x-target
+#import templates: *
+#import "target.typ": is-md-target, sys-is-html-target
+
+/// Reads a theme from a preset dictionary and returns a structured theme object.
+///
+/// - preset (dictionary): A dictionary containing theme presets.
+/// - xml (function): Deprecated, pass `read` instead.
+/// - read (function): A function to read theme files.
+/// - x-target (string): The target platform or style, such as "web-light", "web-dark", or "pdf".
+/// -> dictionary
+#let book-theme-from(preset, xml: xml, read: none, x-target: x-target) = {
+  let theme-target = if x-target.contains("-") {
+    x-target.split("-").at(1)
+  } else {
+    "light"
+  }
+
+  let theme-style = preset.at(theme-target)
+  let is-dark-theme = theme-style.at("color-scheme") == "dark"
+  let is-light-theme = not is-dark-theme
+  let main-color = rgb(theme-style.at("main-color"))
+  let dash-color = rgb(theme-style.at("dash-color"))
+  let code-theme-file = theme-style.at("code-theme")
+
+  let code-extra-colors = if code-theme-file.len() > 0 {
+    if read != none {
+      theme-style.insert("code-theme", bytes(read(code-theme-file)))
+    }
+
+    let data = xml(theme-style.at("code-theme")).first()
+
+    let find-child(elem, tag) = {
+      elem.children.find(e => "tag" in e and e.tag == tag)
+    }
+
+    let find-kv(elem, key, tag) = {
+      let idx = elem.children.position(e => "tag" in e and e.tag == "key" and e.children.first() == key)
+      elem.children.slice(idx).find(e => "tag" in e and e.tag == tag)
+    }
+
+    let plist-dict = find-child(data, "dict")
+    let plist-array = find-child(plist-dict, "array")
+    let theme-setting = find-child(plist-array, "dict")
+    let theme-setting-items = find-kv(theme-setting, "settings", "dict")
+    let background-setting = find-kv(theme-setting-items, "background", "string")
+    let foreground-setting = find-kv(theme-setting-items, "foreground", "string")
+    (bg: rgb(background-setting.children.first()), fg: rgb(foreground-setting.children.first()))
+  } else {
+    (bg: rgb(239, 241, 243), fg: none)
+  }
+
+  (
+    style: theme-style,
+    is-dark: is-dark-theme,
+    is-light: is-light-theme,
+    main-color: main-color,
+    dash-color: dash-color,
+    code-extra-colors: code-extra-colors,
+  )
+}
+
+/// Reads themes from a preset dictionary and returns structured theme objects.
+///
+/// - preset (dictionary): A dictionary containing theme presets.
+/// - read (function): A function to read theme files.
+/// - x-target (string): The target platform or style, such as "web-light", "web-dark", or "pdf".
+/// -> dictionary
+#let theme-box-styles-from(
+  preset,
+  read: read,
+  x-target: x-target,
+  light-theme: none,
+  dark-theme: none,
+) = {
+  let sys-is-html-target = ("target" in dictionary(std))
+
+  if light-theme == none {
+    for (name, it) in preset.pairs() {
+      if it.at("color-scheme") == "light" {
+        light-theme = name
+      }
+    }
+  }
+
+  if dark-theme == none {
+    for (name, it) in preset.pairs() {
+      if it.at("color-scheme") == "dark" and dark-theme != "ayu" {
+        dark-theme = name
+      }
+    }
+  }
+
+  if light-theme == none {
+    light-theme = "light"
+  }
+  if dark-theme == none {
+    dark-theme = "dark"
+  }
+
+  let book-theme-from = book-theme-from.with(xml: xml, read: read)
+  let dark-theme = book-theme-from(preset, x-target: "web-" + dark-theme)
+  let light-theme = book-theme-from(preset, x-target: if sys-is-html-target { "web-" + light-theme } else { "pdf" })
+  let default-theme = book-theme-from(preset, x-target: x-target)
+
+  (
+    dark-theme: dark-theme,
+    light-theme: light-theme,
+    default-theme: default-theme,
+  )
+}
+
+#let theme-box(render, tag: "div", themes: none, class: none, theme-tag: none) = {
+  let (
+    dark-theme: dark-theme,
+    light-theme: light-theme,
+    default-theme: default-theme,
+  ) = themes
+
+  let is-md-target = x-target == "md"
+  let sys-is-html-target = ("target" in dictionary(std))
+
+  if is-md-target {
+    show: html.elem.with(tag)
+    show: html.elem.with("picture")
+    html.elem("m1source", attrs: (media: "(prefers-color-scheme: dark)"), render(dark-theme))
+    render(light-theme)
+  } else if sys-is-html-target {
+    if theme-tag == none {
+      theme-tag = tag
+    }
+    html.elem(tag, attrs: (class: "code-image themed" + if class != none { " " + class }), {
+      html.elem(theme-tag, render(dark-theme), attrs: (class: "dark"))
+      html.elem(theme-tag, render(light-theme), attrs: (class: "light"))
+    })
+  } else {
+    render(default-theme)
+  }
+}
+
+#let themes = theme-box-styles-from(toml("theme-style.toml"), read: it => read(it))
+#let (
+  default-theme: (
+    style: theme-style,
+    is-dark: is-dark-theme,
+    is-light: is-light-theme,
+    main-color: main-color,
+    dash-color: dash-color,
+    code-extra-colors: code-extra-colors,
+  ),
+) = themes;
+#let (
+  default-theme: default-theme,
+) = themes;
+#let theme-box = theme-box.with(themes: themes)


### PR DESCRIPTION
## Summary
- Reopens the GitHub Pages docs build fix against main after #87 was merged into name-resolution by mistake.
- Upgrade the cosmo docs imports/templates to Shiroa 0.3.1.
- Switch the docs serve/build commands to static HTML mode and refresh the Pages workflow actions/tooling.
- Add shared target/theme helpers for HTML, Markdown, and paged output rendering.

## Verification
- yarn run build:syntax
- shiroa build --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ --path-to-root /cosmo/ -w . docs/cosmo --mode=static-html

The docs build succeeds with warnings about Typst HTML export being experimental, missing local Charter/BlexMono fonts, and ignored HTML export constructs in existing docs.