### PR TITLE
Install pnpm for GitHub Pages syntax build

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -55,6 +55,10 @@ jobs:
         with:
           node-version: 24
           cache: 'yarn'
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.16.1 --activate
       - name: Install deps
         run: yarn install
       - name: Compile Syntax


### PR DESCRIPTION
## Summary
- Add a pnpm setup step to the GitHub Pages workflow.
- This fixes `yarn run build:syntax`, which shells out to `pnpm --dir syntaxes/textmate ...`.

## Verification
- yarn run build:syntax