### PR TITLE
fix: resolve TextMate tsc

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
 
   syntaxes/textmate:
     devDependencies:
+      '@types/node':
+        specifier: ^20.8.10
+        version: 20.19.41
+      typescript:
+        specifier: ^5.2.2
+        version: 5.9.3
       vscode-tmgrammar-test:
         specifier: ^0.1.3
         version: 0.1.3

--- a/syntaxes/textmate/package.json
+++ b/syntaxes/textmate/package.json
@@ -3,11 +3,13 @@
   "version": "0.1.0-rc1",
   "private": true,
   "scripts": {
-    "compile": "npx tsc && node ./dist/main.mjs && python ./scripts/convert_syntax.py ./cosmo.tmLanguage.json",
+    "compile": "pnpm exec tsc && node ./dist/main.mjs && python ./scripts/convert_syntax.py ./cosmo.tmLanguage.json",
     "bundle": "node scripts/install.cjs",
     "test": "pnpm run compile && pnpm exec vscode-tmgrammar-snap --updateSnapshot tests/unit/**/*.typ"
   },
   "devDependencies": {
+    "@types/node": "^20.8.10",
+    "typescript": "^5.2.2",
     "vscode-tmgrammar-test": "^0.1.3"
   },
   "contributes": {


### PR DESCRIPTION
## Summary
- replace the TextMate syntax build's npx tsc call with pnpm exec tsc
- declare TypeScript and Node types in the TextMate package so CI installs the compiler deterministically
- update the lockfile importer for the new dev dependencies

## Verification
- pnpm --dir syntaxes/textmate run compile
- pnpm run build:syntax
- git diff --check