### PR TITLE
docs: split effects and plan type checker experiments

### DIFF
--- a/docs/async.typ
+++ b/docs/async.typ
@@ -1,0 +1,288 @@
+= Async Design Notes
+
+== Status
+
+This file records design notes for Cosmo async computations. It is not yet a
+normative specification. It is self-contained, but it uses the effect vocabulary
+from `effect.typ` and the concrete yield protocol from `generator.typ`.
+
+The central rule is:
+
+```text
+`async` is an abstract suspension effect.
+```
+
+It describes that a computation may suspend, but it does not commit the function
+to a generator return type, a stackless state machine, a boxed future, or a
+fiber-backed runtime handle.
+
+== Async Function Types
+
+Functions and lambdas keep the unified shape:
+
+```cos
+A => R with E
+```
+
+An async-capable function is an ordinary function whose effect row contains
+`async`:
+
+```cos
+def fetch(path: Path): String with async = {
+  reschedule()
+  Fs.read_to_string(path)
+}
+```
+
+Its function type is:
+
+```cos
+Path => String with async
+```
+
+This means that the computation eventually produces a `String`, but it may
+suspend before doing so.
+
+== Async Is Not Generator
+
+`R with async` is not the same type as:
+
+```cos
+R with yield[Pending]
+```
+
+The async effect is abstract. A backend or runtime may implement it with:
+
+- a stackless state machine;
+- a fiber stack;
+- a boxed runtime continuation;
+- a VM frame;
+- a platform async primitive;
+- another representation that preserves the async semantics.
+
+The source type should remain stable when the runtime representation changes.
+
+== Pending and Ready Model
+
+It is useful to understand one possible async protocol as:
+
+```cos
+class Poll[R] {
+  case Pending
+  case Ready(R)
+}
+```
+
+In that model an async activation may produce `Pending` zero or more times and
+then produce `Ready(R)` exactly once:
+
+```text
+poll -> Pending
+poll -> Pending
+poll -> Ready(value)
+```
+
+This model explains stackless async lowering, but it is not required by the
+plain `async` effect. It becomes source-visible only when async is paired with a
+concrete yield protocol such as:
+
+```cos
+R with [async, yield[Pending]]
+```
+
+== Reschedule
+
+`reschedule()` is an async operation:
+
+```cos
+def reschedule(): Unit with async
+```
+
+It requests that the current async computation suspend and be run again later.
+In a stackless async implementation that uses `yield[Pending]`, it behaves like:
+
+```text
+schedule current activation for later
+yield Pending
+```
+
+The scheduling step is essential. Returning `Pending` without arranging a future
+resume or wakeup can permanently lose the activation.
+
+In a fiber-backed implementation, `reschedule()` may instead enqueue the current
+fiber and switch back to the scheduler. Both implementations preserve the same
+source-level `async` effect.
+
+== Return
+
+Returning from an async computation completes it with its result:
+
+```cos
+def answer(): i32 with async = {
+  42
+}
+```
+
+In a pending/ready protocol this is:
+
+```text
+Ready(42)
+```
+
+An async computation completes once. Polling or resuming a completed activation
+is an error unless a later runtime specification defines a different behavior.
+
+== Await
+
+`await` consumes an async computation and produces its completed value in the
+current async computation.
+
+Conceptual rule:
+
+```text
+await child:
+  if child is ready with value:
+    continue with value
+  if child is pending:
+    suspend the current computation
+```
+
+In a stackless implementation, the current frame records the state after the
+`await` and returns `Pending` when the child is pending. In a fiber-backed
+implementation, the current fiber yields to the scheduler until the child is
+ready.
+
+`await` does not catch residual effects such as `throw[E]`; those effects remain
+part of the surrounding computation unless a handler deals with them.
+
+== Async Through Yield
+
+An async handler may implement async suspension through a generator protocol:
+
+```cos
+R with [async, yield[Pending]]
+```
+
+Under this handler:
+
+- `reschedule()` schedules the current activation and yields `Pending`.
+- `await child` yields `Pending` when `child` is pending and continues when
+  `child` is ready.
+- `return value` completes with `Ready(value)`.
+
+Example:
+
+```cos
+def later(): i32 with [async, yield[Pending]] = {
+  reschedule()
+  42
+}
+```
+
+Conceptual state machine:
+
+```text
+state 0:
+  schedule current activation for later
+  state = 1
+  return Yield(Pending)
+
+state 1:
+  state = done
+  return Ready(42)
+```
+
+This is the explicit way to request stackless async lowering. The presence of
+`async` alone does not force this representation.
+
+== Lowering Requirements
+
+The annotation:
+
+```cos
+R with [async, yield[Pending]]
+```
+
+requires that all async suspension in the body be expressible through the chosen
+`yield[Pending]` protocol. If an async operation can only be implemented by a
+fiber or another runtime mechanism that cannot be translated to the yield
+protocol, the stackless lowering must fail with a diagnostic.
+
+In other words, `yield[Pending]` is a concrete lowering contract, not a magic
+conversion for arbitrary async runtimes.
+
+== Stackless and Stackful Implementations
+
+For:
+
+```cos
+R with async
+```
+
+a runtime may choose a stackless or stackful representation.
+
+A stackless implementation stores the current continuation as explicit state:
+
+```text
+frame {
+  state
+  params
+  locals live across suspension
+  child async state
+}
+```
+
+A stackful implementation stores the current continuation in a runtime-owned
+stack or stack segment:
+
+```text
+fiber {
+  stack
+  entry function
+  scheduler state
+}
+```
+
+If a fiber-backed async activation is first-class, it must be represented by an
+owned runtime handle, commonly a boxed object or arena handle. The public type
+should still be the async activation protocol, not `Box[Fiber]`.
+
+For:
+
+```cos
+R with [async, yield[Pending]]
+```
+
+the selected implementation must expose the yield protocol. The default native
+lowering should be stackless state-machine lowering when the body satisfies the
+lowering requirements.
+
+== Boxing
+
+Boxing is an implementation and storage concern:
+
+- A concrete stackless async frame may stay unboxed when it does not escape.
+- A stackless activation may be boxed for type erasure or long-lived storage.
+- A first-class fiber activation needs stable runtime ownership, usually a box,
+  reference-counted object, or runtime handle.
+
+The source effect `async` should not force the user-facing return type to name
+the chosen storage strategy.
+
+== Safety Across Async Suspension
+
+Any value live across an async suspension point is part of the continuation.
+Stackless implementations store it in a frame; stackful implementations keep it
+on a fiber stack. The safety rule is representation-independent:
+
+```text
+Values that remain live across suspension must be suspend-safe.
+```
+
+The first implementation should conservatively reject borrowed locals that
+remain live across `await` or `reschedule()` unless the type system proves the
+borrow cannot outlive its owner and cannot create an invalid self-reference.
+
+Detached async work has stricter requirements: it must not capture stack-only
+handlers or borrowed locals unless the captured values are owned, lifetime-safe,
+and runtime-safe for the detached execution context.

--- a/docs/cosmo/book.typ
+++ b/docs/cosmo/book.typ
@@ -16,6 +16,10 @@
     #prefix-chapter("syntax-bnf.typ")[BNF Specification]
     #prefix-chapter("trait.typ")[Trait Design]
     #prefix-chapter("ufcs.typ")[Method Call Design]
+    #prefix-chapter("../effect.typ")[Effect Design Notes]
+    #prefix-chapter("../async.typ")[Async Design Notes]
+    #prefix-chapter("../generator.typ")[Generator Design Notes]
+    #prefix-chapter("../mltt-typechecking-guidance.typ")[MLTT Type Checking Guidance]
   ],
 )
 

--- a/docs/effect.typ
+++ b/docs/effect.typ
@@ -2,300 +2,244 @@
 
 == Status
 
-This file records design notes for Cosmo effects. It is not yet a normative
-specification. The current goal is to keep the effect model explicit and avoid
-compiler magic or new surface syntax where a regular type-system rule can carry
-the same meaning.
+This file records design notes for Cosmo computation effects. It is not yet a
+normative specification. The current goal is to keep suspension and handler
+semantics explicit without forcing one runtime representation into source-level
+function types.
 
-Code snippets in this document are design sketches. A snippet that mentions
-future concepts such as `FnOnce`, `Owned`, `Send`, `Static`, or
-`ReifiableAcrossTask` is not committing to those exact names or syntax.
+The companion notes are:
 
-Current working assumptions:
+- `generator.typ`: the concrete `yield[Y]` protocol and stackless state-machine
+  lowering.
+- `async.typ`: the abstract `async` effect and the optional lowering of async
+  suspension through `yield[Pending]`.
 
-- `with` marks computation effects in type expressions.
-- Computations are second-class by default.
-- A computation containing `async` can be reified as a first-class future-like
-  value.
-- Other effects are not first-class by default unless they are explicitly boxed
-  or handled into an ordinary value.
+== Core Model
 
-The important distinction is between a computation that runs in the current
-lexical continuation and a value that can be stored, returned, scheduled, or
-moved to another thread.
-
-== Computation Types
-
-The preferred spelling for an effectful computation is:
+All functions and lambdas have one type shape:
 
 ```cos
-T with async
-T with throw[E]
-T with [async, throw[E]]
+A => R with E
 ```
 
-`T with async` is a type expression. It should not be spelled as `T async` or
-`async T`, because those forms look like type application and can become
-unstable if `T` later accepts type-level parameters.
-
-An alias can name a computation type:
+`A` is the parameter type or parameter tuple, `R` is the value produced when the
+computation completes, and `E` is an effect row. A function without effects has
+the shorter shape:
 
 ```cos
-def Future[T] = T with async
+A => R
 ```
 
-This means `Future[T]` is a source-level name for `T with async`, not necessarily
-the same thing as a concrete runtime object type. A backend may lower the default
-async representation to a concrete `Future<T>`, but the language-level type is
-still the computation type.
+The `with` clause describes computation behavior. It is not part of the ordinary
+value type `R`, and it should not be used to smuggle runtime representation
+choices into the user-facing return type.
 
-== First-Class Async
-
-An async computation may be reified as a future-like value:
+Examples:
 
 ```cos
-task: T => R with async
-
-val promises: Array[R with async] = ts.map(task)
-val results: Array[R] = await Future.all(promises)
+i32 => i32
+Path => String with async
+usize => Unit with yield[i32]
+Request => Response with [async, throw[HttpError]]
 ```
 
-`results` has the value type `Array[R]`. The ambient computation containing the
-`await` still has the `async` effect.
+`async` and `yield[Y]` are intentionally different effects:
 
-With a residual exception effect:
+- `async` is an abstract suspension effect. It says that a computation may
+  suspend, but it does not say whether that suspension is implemented by a
+  stackless frame, a fiber, a boxed runtime handle, a VM continuation, or another
+  representation.
+- `yield[Y]` is a concrete resumable protocol effect. It says that a computation
+  may produce zero or more `Y` payloads before completing with `R`. A computation
+  with `yield[Y]` has a defined generator protocol and is the source-facing way
+  to request stackless state-machine lowering.
+
+== Computation and Representation
+
+Effects describe computation semantics. Representations describe implementation
+strategy. The source type:
 
 ```cos
-task: T => R with [async, throw[E]]
-
-val promises: Array[R with [async, throw[E]]] = ts.map(task)
-val results: Array[R] = await Future.all(promises)
+R with async
 ```
 
-`results` is still `Array[R]`. The uncaught `throw[E]` belongs to the surrounding
-computation, not to the bound value:
+does not mean:
 
 ```cos
-def gather[T, R, E](ts: Array[T], task: T => R with [async, throw[E]]):
-  Array[R] with [async, throw[E]] = {
-  val promises = ts.map(task)
-  val results = await Future.all(promises)
-  results
+Generator[Pending, R]
+Task[R]
+Future[R]
+Box[Fiber]
+```
+
+A backend or runtime may use any of those representations when they preserve the
+observable `async` semantics. A public type should not need to change when the
+runtime switches between stackless and stackful execution.
+
+The source type:
+
+```cos
+R with yield[Y]
+```
+
+does commit to a generator-style protocol. See `generator.typ` for the complete
+`Yield(Y)` / `Ready(R)` model. In this design, `yield[Y]` is the explicit marker
+that a computation can be lowered as a stackless resumable activation.
+
+== Effect Inference
+
+Effects may be inferred from a function or lambda body:
+
+```cos
+def emit_one(value: i32): Unit = {
+  yield(value)
 }
 ```
 
-The intended row-polymorphic shape for `Future.all` is:
+The inferred type is:
 
 ```cos
-def Future.all[A, E](xs: Array[A with [async, ..E]]):
-  Array[A] with [async, ..E]
+i32 => Unit with yield[i32]
 ```
 
-`await` removes the `async` layer from the awaited computation and propagates the
-remaining row effects into the current computation. It does not catch exceptions.
+Likewise, a body that calls `reschedule()` or `await` will infer `async`:
 
-== Second-Class Computations
+```cos
+def later(): i32 = {
+  reschedule()
+  42
+}
+```
 
-Second-class computations are useful because they do not freely escape their
-handler scope. This gives effect handlers, borrowed resources, regions, and
-structured concurrency a clear lifetime.
+The inferred type is:
 
-The working rule is:
+```cos
+() => i32 with async
+```
+
+For public APIs, an implementation may later require explicit effect
+annotations so that adding `yield`, `async`, or another effect does not silently
+change a package boundary.
+
+== Explicit Effect Annotations
+
+An explicit `with` clause is a public computation contract. The implementation's
+inferred effects must fit inside the annotated effects.
+
+This is valid:
+
+```cos
+def empty(): Unit with yield[i32] = {
+  ()
+}
+```
+
+The body never yields, but the function is explicitly exposed as a computation
+that may use the `yield[i32]` protocol. It can be represented as a generator
+that immediately completes with `Ready(())`.
+
+This is invalid:
+
+```cos
+def invalid(): Unit with yield[i32] = {
+  yield("text")
+}
+```
+
+The body produces `yield[String]`, which does not satisfy the annotated
+`yield[i32]` contract.
+
+== Effect Widening
+
+A pure computation of type `T` may be widened to:
+
+```cos
+T with yield[Y]
+```
+
+This widening creates a computation that yields no values and completes
+immediately with the original `T`.
+
+Example:
+
+```cos
+def answer(): i32 with yield[Pending] = {
+  42
+}
+```
+
+The body computes an ordinary `i32`, but the annotated result type requests the
+`yield[Pending]` protocol. The widened activation has this behavior:
 
 ```text
-plain computation: runs in the current lexical continuation
-boxed/future computation: can be stored, returned, or scheduled
+resume #1 -> Ready(42)
 ```
 
-This lets ordinary higher-order functions use effectful callbacks without
-requiring every callback to become a heap-allocated or detached value.
+This rule is the explicit mechanism for forcing a value-producing computation
+into a resumable state-machine form without adding an ad hoc generator call
+syntax.
 
-The cost is that the language must say when a function parameter may escape.
-This is still unresolved.
+== Async and Yield Together
 
-== Row-Polymorphic Callbacks
-
-The desired simple signature for `map` is:
+A computation may carry both effects:
 
 ```cos
-def map[A, B](xs: Array[A], f: A => B): Array[B]
+R with [async, yield[Pending]]
 ```
 
-The hope is that this can be understood through row polymorphism rather than
-through a new contextual-block syntax. Operationally, a call such as:
+This means two things:
+
+- It has abstract async suspension semantics.
+- It also exposes a concrete yield protocol whose payload is `Pending`.
+
+An async handler may implement async suspension by translating each suspension
+point into `yield(Pending)`. Under that handler, a computation of type
+`R with [async, yield[Pending]]` can be lowered as a stackless state machine.
+
+The `yield` annotation does not magically make every async operation stackless.
+All async operations in the body must be expressible through the selected
+`yield[Pending]` protocol, or the compiler must reject the lowering. See
+`async.typ` for the async-specific rules.
+
+== Residual Effects
+
+A computation can have residual effects in addition to `yield` or `async`:
 
 ```cos
-def parse_all(xs: Array[String]): Array[Int] with throw[ParseError] = {
-  xs.map { x =>
-    parse_int(x)?
-  }
-}
+R with [yield[Y], throw[E]]
+R with [async, throw[E]]
+R with [async, yield[Pending], throw[E]]
 ```
 
-should behave like the explicit row-polymorphic form:
+Residual effects are not handled by the presence of `yield` alone. A generator
+or async runtime must either preserve them in its resume/poll operation or
+handle them before exposing the activation. The exact spelling of effect rows
+and residual propagation remains open.
 
-```cos
-def map[A, B, E](xs: Array[A], f: A => B with E): Array[B] with E
-```
+== Escape and Storage
 
-but without requiring every simple higher-order API to expose the row variable in
-surface syntax.
+Computations are direct-style by default. A first-class activation is created
+only when a computation is represented as a generator, async handle, fiber, or
+boxed runtime object.
 
-This is a promising direction, but only for callbacks that do not escape. If
-`map` stores `f`, returns it, sends it to another thread, or schedules it after
-the call returns, the callback can no longer borrow the caller's lexical effect
-context.
+Escaping activations need ownership and lifetime rules. In particular:
 
-== Escape Marking Problem
+- Stackless activations store live locals in an explicit frame.
+- Fiber-backed activations store a runtime-owned stack or stack segment.
+- Detached async work must not capture stack-only handlers or borrowed locals
+  unless the type system proves that the capture can outlive the task.
 
-The main unresolved issue is how to mark escaping callbacks without adding
-confusing new syntax or special compiler knowledge for individual functions.
-
-Examples that need a clear escape story:
-
-```cos
-def map[A, B](xs: Array[A], f: A => B): Array[B]
-```
-
-`f` should be usable with caller effects, because `map` calls it immediately and
-does not store it.
-
-```cos
-def register[A, B](f: A => B): Unit
-```
-
-If `register` stores `f`, the same signature is not enough. The type must say
-that `f` escapes.
-
-```cos
-def spawn(task: () => R with E): R with [async, ..E]
-```
-
-If `spawn` is scoped, the task may borrow from the current async scope, but the
-returned task handle must not escape that scope.
-
-```cos
-def spawn_detached(task: () => R with E): R with [async, ..E]
-```
-
-If `spawn_detached` detaches from the lexical scope, this signature is also not
-enough. The task must be closed over owned data, must not capture stack-only
-handlers, and must satisfy any thread-safety and lifetime requirements of the
-runtime.
-
-== Avoiding Detached Magic
-
-Introducing a type such as:
-
-```cos
-Detached[() => R with E]
-```
-
-is not preferred. It looks like a normal user-defined generic type, but it would
-need special compiler checks:
-
-- it must reject captured lexical handlers that cannot outlive the scope;
-- it must reject borrowed stack locals;
-- it must require owned or moved captures;
-- it may need `Send`, `Sync`, or runtime-specific thread-safety bounds;
-- it must decide which residual effects can cross a task boundary.
-
-Those checks are real type-system and closure-capture checks, but they should not
-be hidden behind a magic library type.
-
-A less magical shape would express `spawn_detached` in terms of ordinary closure
-and trait constraints:
-
-```cos
-def spawn_detached[R, E, F](task: F): R with [async, ..E]
-where
-  F: FnOnce[] => R with E,
-  F: Owned,
-  F: Send,
-  F: Static,
-  E: ReifiableAcrossTask
-```
-
-The exact spelling is unresolved because Cosmo does not yet have the final
-surface syntax for these bounds. The design constraint is clear: the compiler
-should check a general escape/capture rule, not recognize `spawn_detached` by
-name.
-
-== Scoped Spawn vs Detached Spawn
-
-Scoped spawn and detached spawn should have different safety rules.
-
-Scoped spawn:
-
-```cos
-with tokio {
-  val handle = spawn {
-    task()
-  }
-
-  await handle
-}
-```
-
-The spawned computation belongs to the current async scope. It may borrow
-handlers and values that are valid for that scope, but the handle must not escape
-the scope unless the task and its captures are promoted to a detached-safe form.
-
-Detached spawn:
-
-```cos
-with tokio {
-  val handle = spawn_detached {
-    task()
-  }
-}
-```
-
-The spelling above is intentionally incomplete. The detached task may outlive
-the lexical scope, so the signature must express that its closure is escaping,
-owned, and runtime-safe. The open question is how to express that without adding
-a new capture-mode syntax. Regardless of spelling, the detached task must not
-borrow stack-only handlers or local resources. If it needs a handler, that
-handler must be captured as an owned, spawn-safe value or the effect must remain
-in the future and be handled at `await`.
-
-For example, this should not be accepted without further ownership proof:
-
-```cos
-val some_use = new T
-
-with tokio(some_use) ExceptionHandler(some_use) {
-  spawn_detached {
-    my_task()
-  }
-}
-```
-
-The detached task could outlive `some_use` and the exception handler. A safe
-version must either use scoped spawn, await before the scope exits, or move owned
-spawn-safe handlers into the detached task.
+These rules are representation-independent safety constraints. A stackful fiber
+does not make a detached borrowed capture safe by itself.
 
 == Open Questions
 
 The following questions remain open:
 
-- Does `A => B` in a function parameter position always mean a non-escaping,
-  row-polymorphic callback, or does it mean a pure callback unless an effect row
-  is written explicitly?
-- How should an escaping callback be marked if the design avoids new contextual
-  block syntax?
-- Can escape be inferred from function bodies across module boundaries, or must
-  it be part of the public function signature?
-- What is the minimal non-magical spelling for `FnOnce`, ownership, `Send`, and
-  lifetime/static constraints?
-- Which effects are `ReifiableAcrossTask`? `throw[E]` can plausibly cross an
-  async boundary as a failed future, but `env[R]`, `state[S]`, regions, borrows,
-  and stack-only handlers probably cannot cross by default.
-- How should a scoped `JoinHandle` encode that it cannot escape its async scope?
-- Should `spawn { ... }` be scoped by default and require an explicit detached
-  operation for fire-and-forget work?
-
-The strongest current preference is to keep `map`-style APIs simple through
-row-polymorphic non-escaping callbacks, while making escaping and detached
-execution explicit through ordinary type and closure constraints rather than
-through special-purpose compiler magic.
+- What is the final surface spelling for row-polymorphic effect variables such
+  as `..E`?
+- Which effects are reifiable across detached async task boundaries?
+- How should escaping callbacks be marked in public function signatures?
+- Should public declarations require explicit effect annotations?
+- What is the exact ABI between residual effects and generator `resume` or async
+  `poll` operations?

--- a/docs/generator.typ
+++ b/docs/generator.typ
@@ -1,0 +1,293 @@
+= Generator Design Notes
+
+== Status
+
+This file records design notes for Cosmo generators. It is not yet a normative
+specification. It is self-contained, but it uses the general effect vocabulary
+from `effect.typ`.
+
+The central rule is:
+
+```text
+`yield[Y]` is the concrete resumable protocol effect.
+```
+
+When a computation has type:
+
+```cos
+R with yield[Y]
+```
+
+it may produce zero or more `Y` payloads and eventually complete with an `R`.
+This is the source-level protocol that gives the compiler a clear reason to
+lower the computation as a stackless state machine.
+
+== Function Types
+
+Functions and lambdas keep the unified shape:
+
+```cos
+A => R with E
+```
+
+A generator-capable function is not a different declaration kind. It is an
+ordinary function whose effect row contains `yield[Y]`:
+
+```cos
+def range(n: i32): Unit with yield[i32] = {
+  var i: i32 = 0
+  while (i < n) {
+    yield(i)
+    i = i + 1
+  }
+}
+```
+
+Its function type is:
+
+```cos
+i32 => Unit with yield[i32]
+```
+
+The same rule applies to lambdas:
+
+```cos
+val emit = (value: i32): Unit => {
+  yield(value)
+}
+```
+
+The inferred lambda type is:
+
+```cos
+i32 => Unit with yield[i32]
+```
+
+== The Yield Operation
+
+`yield(value)` is an effect operation:
+
+```cos
+def yield[Y](value: Y): Unit with yield[Y]
+```
+
+This signature is descriptive. The compiler may treat `yield` as a built-in
+operation, but it should type-check like an operation that adds `yield[Y]` to the
+current computation.
+
+Within a `R with yield[Y]` computation, each `yield(value)` suspends the current
+activation and presents `value` to the caller. Resuming the activation continues
+after that `yield`.
+
+== Generator Step Protocol
+
+The observable protocol is:
+
+```cos
+class GenStep[Y, R] {
+  case Yield(Y)
+  case Ready(R)
+}
+```
+
+A generator activation can be viewed as:
+
+```cos
+trait Generator[Y, R] {
+  def resume(&mut self): GenStep[Y, R]
+}
+```
+
+This trait is a protocol sketch, not a committed standard-library spelling. The
+important behavior is:
+
+```text
+resume -> Yield(Y)
+resume -> Yield(Y)
+...
+resume -> Ready(R)
+```
+
+After `Ready(R)`, the activation is complete. Resuming a completed activation is
+an error unless a later standard library explicitly defines a different
+post-completion behavior.
+
+== Pure Computation Widening
+
+A computation of type `T` can be widened to:
+
+```cos
+T with yield[Y]
+```
+
+The widened computation yields zero values and completes with the original `T`.
+
+Example:
+
+```cos
+def answer(): i32 with yield[String] = {
+  42
+}
+```
+
+The behavior is:
+
+```text
+resume #1 -> Ready(42)
+```
+
+This rule lets a programmer force stackless generator lowering through a type
+annotation without changing the body. The yield payload type still matters: it
+defines the protocol that would be used if the computation did suspend.
+
+== Inference and Annotation
+
+If a body contains `yield(value)`, the compiler infers `yield[type(value)]`:
+
+```cos
+def one(): Unit = {
+  yield(1)
+}
+```
+
+Inferred type:
+
+```cos
+() => Unit with yield[i32]
+```
+
+If the signature already contains `yield[Y]`, the body must satisfy that
+contract:
+
+```cos
+def ok(): Unit with yield[i32] = {
+  yield(1)
+}
+```
+
+This is invalid:
+
+```cos
+def invalid(): Unit with yield[i32] = {
+  yield("text")
+}
+```
+
+The initial design should reject multiple unrelated yield payload types in one
+computation unless the programmer explicitly wraps them in a common variant:
+
+```cos
+class Event {
+  case Number(i32)
+  case Text(String)
+}
+
+def mixed(): Unit with yield[Event] = {
+  yield(Event::Number(1))
+  yield(Event::Text("done"))
+}
+```
+
+== Lowering
+
+A computation with `yield[Y]` is lowered as a stackless state machine by default.
+The generated activation stores:
+
+- the current state label;
+- function parameters;
+- locals that remain live across a yield point;
+- pending child activations or residual operation state, if needed.
+
+Example source:
+
+```cos
+def two(): Unit with yield[i32] = {
+  yield(1)
+  yield(2)
+}
+```
+
+Conceptual state machine:
+
+```text
+state 0:
+  state = 1
+  return Yield(1)
+
+state 1:
+  state = 2
+  return Yield(2)
+
+state 2:
+  state = done
+  return Ready(())
+```
+
+The state machine is an implementation strategy for the `yield[Y]` protocol. It
+does not change the source function type.
+
+== Calls and Delegation
+
+This design does not require a special generator call syntax. The important type
+is still:
+
+```cos
+A => R with yield[Y]
+```
+
+When such a computation is represented as a first-class activation, it follows
+the `Generator[Y, R]` protocol described above. A later surface design may
+choose whether ordinary calls to `yield` computations automatically produce
+generator activations, or whether an explicit activation form is needed.
+
+If ordinary calls to `yield` computations produce activations by default, a
+generator that wants to forward another generator's yields needs explicit
+delegation:
+
+```cos
+def outer(): Unit with yield[i32] = {
+  yield(0)
+  yield from range(10)
+  yield(11)
+}
+```
+
+The exact spelling of `yield from` is not committed here. The requirement is
+that delegation must repeatedly resume the child activation, forward each
+`Yield(Y)`, and continue when the child returns `Ready(R)`.
+
+== Boxed Activations
+
+A generator activation may be stored behind a box or runtime handle:
+
+```cos
+Box[Generator[Y, R]]
+```
+
+Boxing is representation, not source semantics. A concrete stackless activation
+can often remain unboxed when it does not escape. A boxed activation is required
+when the value must be type-erased, stored heterogeneously, or outlive the stack
+frame that created it.
+
+== Safety Across Yield
+
+Stackless lowering moves live values across `yield` points into an activation
+frame. Borrow and lifetime rules must reject values that would create invalid
+self-references or references that outlive their owners.
+
+The first implementation should conservatively reject borrowed locals that
+remain live across a yield point unless the type system proves they are safe.
+
+Example shape to reject initially:
+
+```cos
+def bad(): Unit with yield[Unit] = {
+  var value: i32 = 1
+  val ref = &mut value
+  yield(())
+  use(ref)
+}
+```
+
+The same safety rule applies even if a runtime later provides a fiber-backed
+implementation of the generator protocol.

--- a/docs/mltt-typechecking-guidance.typ
+++ b/docs/mltt-typechecking-guidance.typ
@@ -1,0 +1,313 @@
+= MLTT Type Checking Guidance
+
+== Status
+
+This document is guidance for the experimental MLTT checker. It is not yet a
+normative language specification. Its purpose is to give implementers and
+reviewers a shared vocabulary before Cosmo grows dependent pattern matching,
+trait-aware checking, effect-aware checking, and object-safety checks.
+
+The key design rule is:
+
+```text
+MLTT is one checker profile, not the whole language.
+```
+
+Cosmo can host multiple checker profiles. A small MLTT checker is useful even
+when it rejects traits, effects, async, object dispatch, C++ imports, macros, and
+dependent pattern matching in its first version.
+
+== Why MLTT
+
+Martin-Lof type theory gives a compact dependent core:
+
+- `Type` universes classify types.
+- `Pi` types classify dependent functions.
+- `Sigma` types classify dependent pairs.
+- Inductive families classify indexed data such as `Vec[A, n]`.
+- Equality types classify proofs that two terms are propositionally equal.
+- Conversion checks definitional equality by reducing pure transparent terms.
+
+This is a good experimental core for Cosmo because it can support future
+dependent pattern matching without requiring every checker to become a proof
+assistant.
+
+== Surface And Core
+
+Keep two layers separate:
+
+```text
+surface Cosmo:
+  friendly syntax, traits, effects, async, objects, imports, pattern clauses
+
+MLTT core:
+  explicit binders, explicit terms, explicit conversion, explicit diagnostics
+```
+
+The checker should trust the core, not the surface syntax. Surface constructs are
+elaborated into core artifacts before or during checking.
+
+== Core Judgments
+
+The initial checker should be bidirectional:
+
+```text
+Γ |- t <= A        check term t against expected type A
+Γ |- t => A        infer type A for term t
+Γ |- A == B        definitional equality / conversion
+Γ |- E1 <= E2      effect-row inclusion, when effect profiles are added
+Γ |- O solved      trait or capability obligation, when trait profiles are added
+```
+
+The first MLTT profile only needs the first three judgments. Effect and trait
+judgments are listed because later profiles should layer them around the core
+instead of hiding them inside conversion.
+
+== Core Terms
+
+A useful first core has these shapes:
+
+```text
+Var(name or index)
+Universe(level)
+Pi(name, domain, body)
+Sigma(name, first, second)
+Lambda(name, annotation, body)
+Apply(function, argument)
+Pair(first, second)
+Fst(pair)
+Snd(pair)
+Let(name, value, body)
+Inductive(name, params, indices)
+Constructor(name, args)
+Eq(type, left, right)
+Refl(value)
+Neutral(head, spine)
+Error
+```
+
+Implementers can choose de Bruijn indices, de Bruijn levels, or stable local IDs.
+For Cosmo compiler code, stable IDs plus explicit context entries are easier to
+debug. For conversion and substitution, de Bruijn levels often make
+alpha-equivalence and reification back to core syntax cleaner.
+
+== Bidirectional Checking
+
+Use check mode when the expected type is known:
+
+```text
+check(lambda, Pi)
+check(pair, Sigma)
+check(constructor, expected inductive family)
+```
+
+Use infer mode when the term naturally exposes its type:
+
+```text
+infer(variable)
+infer(application)
+infer(projection)
+infer(annotated term)
+```
+
+This avoids pretending that a dependent language has complete inference. It also
+gives better diagnostics because the checker knows whether it was trying to
+check against a specific type or synthesize one.
+
+== Conversion
+
+Conversion answers:
+
+```text
+Are these two core terms definitionally equal?
+```
+
+The first implementation should only reduce:
+
+- beta-redexes from applying lambdas;
+- transparent pure lets;
+- transparent total definitions admitted by the MLTT profile;
+- eliminator or case reductions only after those features are introduced.
+
+It must not run:
+
+- async computations;
+- generator/yield computations;
+- throwing computations;
+- IO;
+- mutation;
+- arbitrary compile-time reflection;
+- general recursive definitions.
+
+This boundary keeps type checking deterministic and prevents effectful programs
+from deciding type equality.
+
+== Normalization Strategy
+
+Normalization is a service used by conversion. It is not the whole checker.
+
+The first MLTT implementation should expose a stable conversion API and use a
+small first-stage strategy:
+
+```text
+WHNF + structural comparison:
+  simpler to implement incrementally
+  enough for many early tests
+  can need repeated normalization in nested comparisons
+```
+
+This first profile can be named:
+
+```text
+mltt.whnf-conversion
+```
+
+Other normalization strategies need separate research before they become design
+commitments. This guidance intentionally does not evaluate or recommend a
+specific advanced strategy. Any later proposal should bring its own references,
+formal model, host-language assumptions, performance expectations, and
+conformance tests.
+
+== Universes
+
+Use predicative universe levels first:
+
+```text
+Type0 : Type1
+Type1 : Type2
+...
+```
+
+Do not add cumulativity unless it is a deliberate proposal:
+
+```text
+Type0 <= Type1
+```
+
+Cumulativity improves ergonomics but adds constraints and diagnostic complexity.
+Strict universe equality is easier for the first implementation.
+
+== Inductive Families
+
+Represent inductive families as declarations:
+
+```text
+Inductive Vec(A: Type0, n: Nat): Type0
+  Nil  : Vec(A, Z)
+  Cons : (k: Nat) -> A -> Vec(A, k) -> Vec(A, S(k))
+```
+
+Constructor checking compares the expected family with the constructor result.
+For dependent pattern matching, matching a constructor will later refine indices
+by unifying the scrutinee family with the constructor result.
+
+== Equality
+
+The first equality type can be intensional:
+
+```text
+Eq(A, x, y)
+```
+
+`Refl(x)` checks against `Eq(A, x, x)` when both sides are definitionally equal.
+
+Do not silently assume advanced equality principles such as K, UIP, univalence,
+or quotient equality. If Cosmo later accepts one of those principles, it should
+be an explicit proposal because it changes the theory and dependent pattern
+matching rules.
+
+== Metavariables
+
+Metavariables are useful for elaboration:
+
+```text
+?m : A in context Γ
+```
+
+The first checker should solve only conservative cases:
+
+- exact known term;
+- first-order constructor-shaped constraints;
+- simple pattern variables.
+
+Arbitrary higher-order unification should remain unsupported. When a
+metavariable cannot be solved, report a deterministic postponed or unsolved
+constraint instead of guessing.
+
+== Effects And Traits
+
+Effects and traits are not part of the first MLTT conversion relation.
+
+Later profiles can add:
+
+```text
+Γ |- effects(body) <= declared effects
+Γ |- T implements Trait
+Γ |- object-safe(Trait, ABI)
+```
+
+Those checks should produce obligations around the core checker. They should not
+turn definitional equality into trait search or effect execution.
+
+== Dependent Pattern Matching Preview
+
+Dependent pattern matching should elaborate into core case trees or eliminators.
+When matching:
+
+```text
+xs : Vec(A, S(n))
+```
+
+against `Nil`, the checker tries to unify:
+
+```text
+Vec(A, S(n)) == Vec(A, Z)
+```
+
+which fails because `S(n)` and `Z` do not unify. The branch is impossible.
+
+When matching against `Cons`, the branch learns:
+
+```text
+xs = Cons(k, head, tail)
+tail : Vec(A, k)
+S(k) == S(n)
+```
+
+and the expected result type is specialized under those refinements.
+
+This is why dependent pattern matching should be implemented as an elaborator
+over MLTT core metadata, not as ad hoc expression typing.
+
+== Implementation Shape
+
+Suggested modules:
+
+```text
+types/mltt/core.cos          term, type, binder, declaration data
+types/mltt/context.cos       local context and lookup
+types/mltt/diagnostic.cos    profile-aware diagnostics
+types/mltt/normalize.cos     first-stage normalization strategy
+types/mltt/convert.cos       definitional equality
+types/mltt/check.cos         bidirectional check/infer
+types/mltt/fixture.cos       small Nat/Vec examples
+```
+
+Keep functions small and explicit. Prefer helper functions for repeated
+diagnostic and context-extension logic. The checker should read top to bottom:
+infer a shape, validate it, emit obligations, return a typed artifact.
+
+== First Test Set
+
+Start with:
+
+- `Type0 : Type1`;
+- identity function checks against `(A: Type0) -> A -> A`;
+- application of identity infers the argument type;
+- pair checks against a Sigma type;
+- `Refl(x)` checks against `Eq(A, x, x)`;
+- mismatch between `Type0` and a non-universe reports a diagnostic;
+- effectful source is rejected by `mltt.core`;
+- trait source is rejected by `mltt.core`.
+
+After that, add Nat and Vec fixtures before dependent pattern matching.

--- a/openspec/changes/define-type-checker-theory-roadmap/.openspec.yaml
+++ b/openspec/changes/define-type-checker-theory-roadmap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/define-type-checker-theory-roadmap/README.md
+++ b/openspec/changes/define-type-checker-theory-roadmap/README.md
@@ -1,0 +1,3 @@
+# define-type-checker-theory-roadmap
+
+Define the long-term theory, normalization, value-model, and common checking-goal roadmap for modular Cosmo type checkers.

--- a/openspec/changes/define-type-checker-theory-roadmap/design.md
+++ b/openspec/changes/define-type-checker-theory-roadmap/design.md
@@ -1,0 +1,279 @@
+## Context
+
+Cosmo now has separate proposals for modular checker profiles, an MLTT checker,
+and dependent pattern elaboration. Those proposals correctly avoid forcing every
+checker to support every feature. The next issue is long-term coordination:
+
+- MLTT gives a compact dependent core, but it does not solve trait coherence,
+  effect handling, object safety, termination, erasure, or backend lowering by
+  itself.
+- Dependent pattern matching can refine indexed types, but it depends on a
+  particular fragment of unification, coverage checking, and equality theory.
+- Normalization techniques are not complete type checkers. They carry their own
+  formal assumptions, implementation models, and host-language constraints.
+- Trait solving, effect checking, and object safety each have their own goal
+  systems and performance risks.
+- Some theories are intentionally incomplete for the full language, and some are
+  too expensive to run in every compiler mode.
+
+The roadmap should make those limits explicit. A theory profile can be useful
+even if it only covers a subset, as long as the compiler knows how to test it and
+how to reject unsupported programs deterministically.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the long-term theory profile registry.
+- Define common checking goals shared by all checker profiles.
+- Define conformance levels for integration into cosmo0 and `packages/cosmoc`.
+- Separate normalization strategy profiles from type-system profiles.
+- Require stronger normalization strategies to declare their formal and
+  host-language assumptions before implementation.
+- Keep the MLTT first slice narrow while still leaving room for a stronger
+  normalization reference checker later.
+- Define a test-suite matrix that can evaluate partial checkers without
+  overclaiming support.
+
+**Non-Goals:**
+
+- Choose one final type theory for all of Cosmo.
+- Select a stronger normalization strategy for the first MLTT implementation.
+- Require dependent pattern matching before the MLTT core checker exists.
+- Require trait solving, effect checking, object safety, totality checking, or
+  erasure in the first MLTT checker.
+- Replace existing parser-subset type checking.
+- Fully specify final surface syntax for all advanced type-system features.
+
+## Decisions
+
+### Use Theory Profiles
+
+A theory profile records what a checker claims to implement:
+
+```text
+TheoryProfile:
+  id
+  owner checker profile
+  formal model
+  supported judgments
+  supported source/core features
+  unsupported features
+  invariants required for soundness
+  performance envelope
+  host/value-model assumptions
+  conformance suite groups
+```
+
+Initial profiles:
+
+```text
+common.harness
+common.simple-types
+mltt.core
+mltt.whnf-conversion
+mltt.inductive-families
+mltt.totality
+mltt.erasure
+dependent-pattern.constructor-refinement
+traits.coherent-solving
+effects.rows
+objects.safety
+```
+
+Alternative considered: one global "full type checker" profile. That hides the
+fact that different theories solve different problems and makes partial
+implementations look like failures.
+
+### Define Common Goals Before Theory-Specific Goals
+
+Every checker should implement or explicitly reject a small set of common goals:
+
+```text
+Goal.CheckModule
+Goal.ResolveDeclarations
+Goal.WellFormedType
+Goal.InferExpr
+Goal.CheckExpr
+Goal.Convert
+Goal.UnsupportedFeature
+Goal.ArtifactSummary
+```
+
+A checker can return unsupported for goals outside its scope, but the result must
+be deterministic and diagnostic-bearing.
+
+Theory-specific profiles can add:
+
+```text
+Goal.CheckCore
+Goal.InferCore
+Goal.Normalize
+Goal.CheckTelescope
+Goal.CheckInductiveFamily
+Goal.ElaboratePattern
+Goal.CheckCoverage
+Goal.SolveTraitObligation
+Goal.CheckEffectSubsumption
+Goal.CheckObjectSafety
+```
+
+Alternative considered: test only whole files. Whole-file tests are necessary
+for integration but too coarse to evaluate small theory slices.
+
+### Separate Normalization Strategies
+
+Normalization is a service used by conversion, not the whole checker. The first
+MLTT implementation should expose a stable conversion API and begin with a small
+WHNF-style strategy. Stronger strategies should be proposed only after a separate
+research pass clarifies their formal model, host-language requirements, and
+performance behavior.
+
+The roadmap distinguishes:
+
+```text
+mltt.whnf-conversion:
+  normalizes enough for first-stage conversion
+  lower implementation cost
+  suitable for small fixtures and staged implementation
+```
+
+Alternative considered: require a stronger normalization strategy immediately.
+That pushes unresolved theory and host-language representation choices into the
+first checker slice.
+
+### Require Host And Evaluation Model Contracts
+
+Any theory profile that evaluates terms must declare the implementation model it
+depends on.
+
+For evaluator-style normalization, a future profile may need to define:
+
+```text
+evaluation model:
+  represented evaluation values, if any
+  environment representation, if any
+  opaque and transparent definition handling
+  reification back to core syntax, if any
+```
+
+The host language must support the chosen representation deterministically.
+If the checker is written in the cosmo0 subset, the implementation model must be
+expressible using available core0 containers, arenas, IDs, references, and the
+subset's supported control-flow and data forms.
+
+Alternative considered: rely on host-language implementation details without a
+contract. That makes it hard to port the checker between Scala cosmo0 and
+Cosmo-written cosmoc.
+
+### Treat Performance As Part Of Profile Eligibility
+
+Each theory profile must state its expected complexity and bailout behavior:
+
+```text
+performance envelope:
+  expected input size
+  maximum normalization fuel or recursion depth
+  cache keys
+  cycle handling
+  deterministic timeout/overflow diagnostics
+  whether the profile is suitable for editor feedback
+  whether the profile is suitable for package compilation
+```
+
+This is not premature optimization. Dependent conversion, trait solving,
+coverage checking, and evaluator-style normalization can all become expensive. A
+profile that is correct but too slow may still be useful as a reference checker
+rather than the default compiler checker.
+
+Alternative considered: optimize after feature completion. That risks building a
+checker whose behavior cannot be used in the compiler pipeline.
+
+### Use Conformance Levels
+
+Profiles should graduate through levels:
+
+```text
+L0 documented:
+  profile, scope, and unsupported features are documented
+
+L1 goal-tested:
+  focused goal tests pass
+
+L2 fixture-tested:
+  source/core fixtures pass with deterministic diagnostics
+
+L3 integration-tested:
+  module/package tests pass and artifact summaries are stable
+
+L4 compiler-candidate:
+  performance envelope is measured and failure modes are deterministic
+```
+
+Alternative considered: binary "implemented/not implemented" status. That is not
+useful for long-running checker experiments.
+
+### Keep Theory Boundaries Visible In Diagnostics
+
+Diagnostics should say which profile rejected a program and why:
+
+```text
+profile: mltt.core
+code: cosmo.type.unsupported-effect-in-conversion
+reason: effectful term cannot be reduced by this conversion profile
+```
+
+This helps users and implementers distinguish invalid programs from unsupported
+checker experiments.
+
+Alternative considered: reuse generic type mismatch diagnostics for all
+rejections. That makes conformance tests vague and theory debugging harder.
+
+## Risks / Trade-offs
+
+- Too many profiles -> Mitigation: require owner, scope, tests, and conformance
+  level before adding a profile.
+- Roadmap feels abstract -> Mitigation: every profile must map to concrete goal
+  tests and fixture groups.
+- Stronger normalization research is delayed too long -> Mitigation: leave an
+  explicit roadmap slot and require future proposals to bring references and
+  conformance tests.
+- WHNF first slice becomes the de facto theory -> Mitigation: keep the conversion
+  API stable and explicitly list WHNF as a first implementation strategy, not the
+  final normalization story.
+- Evaluation-model contract blocks implementation -> Mitigation: require it only
+  for profiles that actually evaluate terms beyond the first-stage conversion
+  strategy; simple checkers can remain syntax-directed.
+- Partial support confuses integration -> Mitigation: conformance levels and
+  unsupported-feature diagnostics are required before integration.
+
+## Migration Plan
+
+1. Add this roadmap and spec requirements.
+2. Update the MLTT proposal so the first implementation targets
+   `mltt.core + mltt.whnf-conversion`, while stronger normalization strategies
+   are deferred to later research.
+3. Update MLTT guidance to describe normalization as a replaceable service and
+   avoid committing to an advanced strategy before research.
+4. Add a future `define-common-type-checker-goals` or equivalent implementation
+   change for the goal DSL and fixture manifest.
+5. Add conformance-level metadata to checker profiles.
+6. Add fixture groups for common goals, MLTT core, WHNF conversion, future
+   normalization strategies, dependent patterns, effects, traits, and object
+   safety.
+7. Promote profiles into package-level compiler integration only after they reach
+   the required conformance level.
+
+Rollback is additive: keep the roadmap as planning documentation and do not
+enable any profile as a compiler default until it passes conformance gates.
+
+## Open Questions
+
+- Which stronger normalization strategies should be evaluated first, and what
+  references are required before they become proposals?
+- Should the long-term conversion API support eta-conversion, and if so should it
+  be a separate proposal?
+- Should conformance levels be stored in OpenSpec, fixture manifests, package
+  metadata, or generated test reports?
+- What is the default fuel/overflow policy for normalization and trait solving?
+- Which profile level is required before a checker can run in the LSP?

--- a/openspec/changes/define-type-checker-theory-roadmap/proposal.md
+++ b/openspec/changes/define-type-checker-theory-roadmap/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Cosmo's type-checking work is moving from a single pragmatic checker toward a
+set of modular experiments: parser-subset checking, MLTT checking, dependent
+pattern elaboration, trait solving, effect checking, object safety, and
+normalization strategies. Each underlying theory covers only part of the final
+language and carries different performance and host-language assumptions, so the
+project needs a long-term roadmap before those experiments become incompatible.
+
+## What Changes
+
+- Define a long-term type-checker theory roadmap that separates common compiler
+  integration goals from optional theory-specific capabilities.
+- Introduce a theory profile registry for MLTT, dependent pattern matching,
+  trait solving, effect checking, object safety, normalization, totality, and
+  erasure experiments.
+- Define common checking goals and conformance expectations that every checker
+  profile must report against, even when it rejects a feature as unsupported.
+- Define normalization strategy profiles, including a first WHNF strategy and a
+  process for evaluating stronger strategies through separate research and
+  proposals.
+- Require each theory profile to document its scope, invariants, unsupported
+  features, performance envelope, host-language assumptions, and fixture coverage
+  before integration into the compiler pipeline.
+- Establish a test-suite matrix that can verify whether a checker is suitable
+  for integration without requiring every checker to implement every feature.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo-type-checker-theory-roadmap`: Defines long-term theory profiles,
+  common checking goals, normalization/value-model contracts, and conformance
+  suite requirements for modular Cosmo type checkers.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds roadmap-level OpenSpec requirements; it does not change compiler behavior
+  immediately.
+- Future MLTT, dependent pattern, trait, effect, object-safety, and normalization
+  implementations will need to declare their theory profile and conformance
+  level before becoming compiler integration candidates.
+- Existing checkers can remain narrow, but they must become explicit about which
+  common goals they support and which features they reject.

--- a/openspec/changes/define-type-checker-theory-roadmap/specs/cosmo-type-checker-theory-roadmap/spec.md
+++ b/openspec/changes/define-type-checker-theory-roadmap/specs/cosmo-type-checker-theory-roadmap/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Theory Profile Registry
+Cosmo SHALL maintain a registry of type-checker theory profiles. Each profile
+SHALL identify its formal model, supported judgments, supported features,
+unsupported features, soundness invariants, performance envelope, host/value-model
+assumptions when applicable, and conformance suite groups.
+
+#### Scenario: Profile declares scope and limits
+- **WHEN** a theory profile is registered
+- **THEN** the profile records the features it supports
+- **AND** the profile records the features it deliberately rejects
+- **AND** the profile records any invariants required for soundness
+
+#### Scenario: Partial theory is valid when declared
+- **WHEN** a checker implements only a documented subset of Cosmo's final type-system goals
+- **THEN** the checker may still participate in conformance tests for that subset
+- **AND** unsupported features are reported as unsupported rather than as internal errors
+
+### Requirement: Common Checking Goals
+Cosmo SHALL define common checking goals that every checker profile either
+implements or explicitly rejects.
+
+#### Scenario: Common goal is unsupported
+- **WHEN** a checker profile receives a common goal outside its declared scope
+- **THEN** the checker result reports an unsupported-goal or unsupported-feature diagnostic
+- **AND** the result identifies the checker profile that rejected the goal
+
+#### Scenario: Artifact summary is deterministic
+- **WHEN** a checker profile runs the same supported goal twice without source changes
+- **THEN** the checker produces the same artifact summary and diagnostic summary
+
+### Requirement: Normalization Strategy Profiles
+Cosmo SHALL model normalization strategies as separate profiles used by
+conversion rather than as implicit properties of all MLTT checkers.
+
+#### Scenario: First MLTT conversion uses a narrow normalization strategy
+- **WHEN** the first MLTT checker performs conversion
+- **THEN** it uses a declared first-stage normalization strategy such as `mltt.whnf-conversion`
+- **AND** it does not claim conformance to any unspecified stronger strategy
+
+#### Scenario: Future normalization strategy declares its model
+- **WHEN** a future normalization strategy profile is registered
+- **THEN** the profile declares the formal and implementation model it depends on
+- **AND** the profile declares host-language assumptions needed to implement that model
+
+### Requirement: Conformance Levels
+Cosmo SHALL classify checker profiles by conformance level before integrating
+them into package compilation or editor services.
+
+#### Scenario: Profile reaches goal-tested level
+- **WHEN** a checker profile passes focused goal tests for its declared feature set
+- **THEN** the profile may be marked goal-tested
+- **AND** the profile is not automatically eligible for package-level compiler integration
+
+#### Scenario: Profile reaches compiler-candidate level
+- **WHEN** a checker profile has deterministic diagnostics, deterministic artifacts, integration fixture coverage, and a documented performance envelope
+- **THEN** the profile may be considered a compiler-candidate
+
+### Requirement: Performance And Failure Modes
+Theory profiles SHALL document performance expectations and deterministic failure
+modes for expensive operations such as normalization, conversion, trait solving,
+coverage, and object-safety checks.
+
+#### Scenario: Normalization exceeds its limit
+- **WHEN** a normalization strategy exceeds its declared fuel, recursion, or cache limit
+- **THEN** the checker reports a deterministic normalization-limit diagnostic
+- **AND** the checker does not crash or produce nondeterministic typed artifacts

--- a/openspec/changes/define-type-checker-theory-roadmap/tasks.md
+++ b/openspec/changes/define-type-checker-theory-roadmap/tasks.md
@@ -1,0 +1,34 @@
+## 1. Roadmap Review
+
+- [ ] 1.1 Review the theory profile registry and remove profiles that are too speculative.
+- [ ] 1.2 Decide initial conformance levels for existing `cosmoc.basic-expr` and future `mltt.core`.
+- [ ] 1.3 Decide whether conformance metadata lives in OpenSpec, fixture manifests, or test reports.
+- [ ] 1.4 Decide the first performance envelope fields required for compiler integration.
+
+## 2. MLTT Alignment
+
+- [ ] 2.1 Update the MLTT proposal to target `mltt.core` plus a first WHNF conversion strategy.
+- [ ] 2.2 Move stronger normalization strategies out of the first MLTT implementation plan.
+- [ ] 2.3 Remove advanced normalization claims from the MLTT documentation until research is complete.
+- [ ] 2.4 Add explicit unsupported-feature diagnostics for effectful conversion and unsupported normalization profiles.
+
+## 3. Common Goal Suite
+
+- [ ] 3.1 Define the common checking goal names and result schema in a follow-up implementation change.
+- [ ] 3.2 Define fixture manifest fields for profile id, required features, goals, expected diagnostics, and artifact summaries.
+- [ ] 3.3 Add common harness fixtures that every checker must run.
+- [ ] 3.4 Add deterministic artifact-summary expectations for repeated checker runs.
+
+## 4. Normalization Profiles
+
+- [ ] 4.1 Define `mltt.whnf-conversion` goal tests.
+- [ ] 4.2 Reserve space for future normalization profiles without naming one before research.
+- [ ] 4.3 Define the minimum information a future normalization proposal must provide.
+- [ ] 4.4 Define deterministic overflow and fuel diagnostics for normalization.
+
+## 5. Integration Gates
+
+- [ ] 5.1 Define L0 through L4 profile conformance levels in checker metadata.
+- [ ] 5.2 Define which level is required for package checking.
+- [ ] 5.3 Define which level is required for LSP use.
+- [ ] 5.4 Add reporting that lists each checker profile, supported features, conformance level, and missing test groups.

--- a/openspec/changes/elaborate-dependent-pattern-matching/.openspec.yaml
+++ b/openspec/changes/elaborate-dependent-pattern-matching/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/elaborate-dependent-pattern-matching/README.md
+++ b/openspec/changes/elaborate-dependent-pattern-matching/README.md
@@ -1,0 +1,3 @@
+# elaborate-dependent-pattern-matching
+
+Define dependent pattern matching elaboration over MLTT-style typed cores without requiring every checker to support dependent patterns.

--- a/openspec/changes/elaborate-dependent-pattern-matching/design.md
+++ b/openspec/changes/elaborate-dependent-pattern-matching/design.md
@@ -1,0 +1,175 @@
+## Context
+
+Ordinary pattern matching chooses a branch based on runtime constructor shape.
+Dependent pattern matching also refines the type context. For an indexed family
+such as:
+
+```text
+Vec(A, n)
+```
+
+matching a value of type `Vec(A, S(n))` against `Nil` is impossible because the
+constructor result is `Vec(A, Z)`. Matching against `Cons` refines the branch
+context with the constructor fields and the equality between expected and actual
+indices.
+
+Cosmo should support this eventually, but not every checker needs it. A basic
+expression checker can reject dependent patterns; an MLTT checker can first
+support the core types; a later profile can add dependent pattern elaboration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define dependent pattern matching as an optional checker/elaborator capability.
+- Elaborate source pattern clauses into deterministic case trees or core
+  eliminator forms.
+- Use constructor unification to refine indexed types in branch contexts.
+- Detect impossible branches and missing coverage deterministically.
+- Preserve source spans for diagnostics.
+- Keep the first implementation small enough to be reviewed as an independent
+  thousand-line-scale slice.
+
+**Non-Goals:**
+
+- Implement dependent pattern matching in the first MLTT checker change.
+- Support arbitrary higher-order unification.
+- Support pattern synonyms, views, inaccessible/dot patterns, or with-abstraction
+  in the first slice.
+- Decide whether Cosmo assumes K/UIP.
+- Support object dispatch over dependent pattern methods.
+- Make dependent pattern matching available in cosmo0 source.
+
+## Decisions
+
+### Make Dependent Patterns A Profile Feature
+
+A checker profile must declare:
+
+```text
+supports dependent-pattern-elaboration: yes/no
+```
+
+If the profile does not support the feature, it must reject source with a
+diagnostic such as:
+
+```text
+cosmo.type.unsupported-dependent-pattern
+```
+
+Alternative considered: make dependent patterns part of all match typing. That
+would force every checker to support indexed unification and coverage.
+
+### Elaborate Through Constructor Metadata
+
+The elaborator should use inductive-family metadata:
+
+```text
+ConstructorDecl:
+  name
+  telescope
+  result family
+  result indices
+```
+
+For each constructor pattern, it unifies the scrutinee type with the constructor
+result type, extends the branch context with constructor fields, and specializes
+the expected branch result type under the solved refinements.
+
+Alternative considered: hard-code common families such as `Nat`, `Vec`, and
+`Fin`. That is useful for tests but not a real language design.
+
+### Generate Case Trees
+
+Pattern clauses should elaborate to deterministic case trees:
+
+```text
+case scrutinee of
+  Constructor(args) -> branch
+  ...
+```
+
+Case trees should be independent of source clause ordering where possible, but
+diagnostics must still point at source clauses. The case tree is the artifact
+later lowering stages consume.
+
+Alternative considered: type-check clauses directly and lower from surface
+syntax. That makes coverage, redundancy, and future optimization harder.
+
+### Keep Unification Conservative
+
+The first implementation should support:
+
+- constructor-head comparison;
+- first-order index variables;
+- definitional equality after allowed normalization;
+- occurs check;
+- failure-as-impossible for constructor index mismatch;
+- postponed constraints for unsupported cases.
+
+It should not support arbitrary higher-order unification.
+
+Alternative considered: import a full proof assistant unifier. That is too large
+for the first Cosmo implementation slice.
+
+### Treat Impossible Branches Explicitly
+
+An impossible branch is different from a runtime-unreachable branch. It is a
+branch whose pattern cannot match because constructor indices cannot unify with
+the scrutinee type.
+
+The checker should allow an explicit absurd marker later, but the first slice can
+start by detecting impossible generated branches during coverage.
+
+Alternative considered: require users to write all constructors and then ignore
+impossible ones. That harms diagnostics and obscures the dependent typing model.
+
+### Do Not Decide K/UIP In The First Slice
+
+Dependent pattern matching over equality can imply additional equality
+principles. The first proposal should avoid committing to K/UIP by limiting the
+initial feature to ordinary inductive-family constructor refinement and by
+rejecting advanced equality matching cases.
+
+Alternative considered: assume K/UIP globally. That may be acceptable for a
+systems language, but it should be a deliberate theory proposal.
+
+## Risks / Trade-offs
+
+- Dependent pattern elaboration becomes too broad -> Mitigation: gate it by
+  profile and start with constructor patterns only.
+- Coverage diagnostics become confusing -> Mitigation: keep source spans and
+  branch refinement summaries in diagnostics.
+- Unification gets stuck too often -> Mitigation: report postponed constraints
+  deterministically and keep examples within the supported fragment.
+- Theory commitment is hidden -> Mitigation: reject equality-pattern cases that
+  would require K/UIP until a separate proposal decides that principle.
+- Lowering depends on surface syntax -> Mitigation: lower from deterministic
+  case trees, not raw pattern clauses.
+
+## Migration Plan
+
+1. Add capability requirements and profile gating.
+2. Add source AST pattern metadata if current AST cannot represent constructor
+   patterns with spans and arguments cleanly.
+3. Add constructor metadata to the MLTT declaration environment.
+4. Implement a small unification/refinement module for family indices.
+5. Implement clause elaboration into case trees.
+6. Implement coverage and impossible-branch diagnostics.
+7. Add Nat and Vec fixtures.
+8. Add cosmo0 and cosmoc conformance tests that show unsupported profiles reject
+   dependent patterns while the dependent-pattern profile accepts the small
+   fragment.
+
+Rollback is additive: disable the dependent-pattern profile and keep ordinary
+match typing unchanged.
+
+## Open Questions
+
+- What source spelling should mark absurd branches?
+- Should inaccessible/dot patterns be part of the first accepted syntax?
+- Should coverage use a matrix algorithm from the start or a simpler
+  constructor-split worklist?
+- When should `with`-style dependent refinement be introduced?
+- Should Cosmo assume K/UIP, reject K-sensitive matches, or expose a theory
+  setting per profile?

--- a/openspec/changes/elaborate-dependent-pattern-matching/proposal.md
+++ b/openspec/changes/elaborate-dependent-pattern-matching/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Cosmo's eventual dependent pattern matching should refine indexed types such as
+`Vec[A, n]` without forcing every type checker profile to implement that feature.
+The language needs an elaboration proposal that can sit on top of MLTT-style core
+metadata and remain optional for simpler checker profiles.
+
+## What Changes
+
+- Define dependent pattern matching as an elaboration capability over typed core
+  declarations, constructor metadata, unification, and coverage checking.
+- Require checker profiles to declare whether they support dependent patterns.
+- Specify that unsupported dependent patterns are valid rejection results for
+  profiles that do not implement the capability.
+- Define the first implementation scope: constructor pattern elaboration,
+  index refinement, impossible-branch detection, deterministic case trees, and
+  coverage diagnostics.
+- Defer advanced features such as with-abstraction, equality pattern matching,
+  views, pattern synonyms, and without-K proof obligations.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo-dependent-pattern-elaboration`: Defines dependent pattern matching
+  elaboration over MLTT-style core metadata, including constructor refinement,
+  impossible cases, coverage, diagnostics, and profile gating.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a planning layer for dependent pattern matching without changing current
+  expression matching behavior.
+- Future implementation will affect parser AST pattern metadata, MLTT declaration
+  metadata, case-tree generation, coverage checking, and diagnostics.
+- Simpler checker profiles may continue to reject dependent patterns explicitly.

--- a/openspec/changes/elaborate-dependent-pattern-matching/specs/cosmo-dependent-pattern-elaboration/spec.md
+++ b/openspec/changes/elaborate-dependent-pattern-matching/specs/cosmo-dependent-pattern-elaboration/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Profile-Gated Dependent Patterns
+Dependent pattern matching SHALL be available only in checker profiles that
+declare support for dependent-pattern elaboration.
+
+#### Scenario: Unsupported profile rejects dependent pattern
+- **WHEN** a checker profile that does not support dependent patterns receives a dependent pattern match
+- **THEN** the checker reports an unsupported-dependent-pattern diagnostic
+- **AND** the rejection does not imply that the source is invalid for profiles that support dependent patterns
+
+#### Scenario: Supported profile elaborates dependent pattern
+- **WHEN** a checker profile with dependent-pattern support receives an accepted dependent pattern match
+- **THEN** the checker elaborates the match through constructor metadata and index refinement
+
+### Requirement: Constructor Refinement
+Dependent pattern elaboration SHALL refine branch contexts by unifying the
+scrutinee family type with the matched constructor result type.
+
+#### Scenario: Impossible constructor is detected
+- **WHEN** a pattern attempts to match a constructor whose result indices cannot unify with the scrutinee type
+- **THEN** the branch is marked impossible or rejected as unreachable according to the profile's accepted syntax
+
+#### Scenario: Constructor fields enter branch context
+- **WHEN** constructor index unification succeeds
+- **THEN** constructor fields are added to the branch context
+- **AND** the branch expected type is specialized by the solved index refinements
+
+### Requirement: Case Tree Artifact
+Dependent pattern elaboration SHALL produce a deterministic case-tree or
+equivalent core eliminator artifact for later stages.
+
+#### Scenario: Source clauses lower to case tree
+- **WHEN** accepted dependent pattern clauses are checked
+- **THEN** the checker output includes a deterministic case-tree artifact
+- **AND** diagnostics retain source spans from the original clauses
+
+### Requirement: Coverage Diagnostics
+Dependent pattern elaboration SHALL report missing, impossible, and redundant
+branches deterministically for the accepted pattern fragment.
+
+#### Scenario: Missing constructor is reported
+- **WHEN** coverage checking finds an uncovered constructor case that is not impossible under the refined indices
+- **THEN** the checker reports a missing-branch diagnostic with deterministic family and index display text
+
+#### Scenario: Advanced equality matching is rejected
+- **WHEN** a dependent pattern match would require equality-pattern reasoning outside the accepted fragment
+- **THEN** the checker reports an unsupported-equality-pattern diagnostic instead of assuming an equality principle

--- a/openspec/changes/elaborate-dependent-pattern-matching/tasks.md
+++ b/openspec/changes/elaborate-dependent-pattern-matching/tasks.md
@@ -1,0 +1,42 @@
+## 1. Profile And Spec
+
+- [ ] 1.1 Add profile metadata for dependent-pattern support.
+- [ ] 1.2 Add unsupported-dependent-pattern diagnostics for profiles that do not support the feature.
+- [ ] 1.3 Define the first accepted pattern fragment: constructor, variable, wildcard, and impossible cases.
+- [ ] 1.4 Define which equality-pattern cases remain rejected.
+
+## 2. Core Metadata
+
+- [ ] 2.1 Extend MLTT declaration metadata with constructor telescopes and result indices.
+- [ ] 2.2 Add deterministic display for indexed family types and constructor result types.
+- [ ] 2.3 Add fixture declarations for Nat.
+- [ ] 2.4 Add fixture declarations for Vec.
+
+## 3. Unification And Refinement
+
+- [ ] 3.1 Implement first-order constructor/index unification.
+- [ ] 3.2 Add occurs-check diagnostics for invalid metavariable solutions.
+- [ ] 3.3 Add impossible-branch detection from failed index unification.
+- [ ] 3.4 Add branch context refinement summaries for diagnostics and tests.
+
+## 4. Clause Elaboration
+
+- [ ] 4.1 Represent source pattern clauses with stable spans.
+- [ ] 4.2 Elaborate constructor patterns by extending the context with constructor fields.
+- [ ] 4.3 Specialize branch expected types after index refinement.
+- [ ] 4.4 Emit deterministic case-tree artifacts.
+
+## 5. Coverage
+
+- [ ] 5.1 Implement a constructor-split coverage worklist for the first fragment.
+- [ ] 5.2 Report missing branches with family/index display text.
+- [ ] 5.3 Report redundant branches when an earlier clause already covers the same refined space.
+- [ ] 5.4 Preserve source span information in coverage diagnostics.
+
+## 6. Validation
+
+- [ ] 6.1 Add accepted Vec `head` fixture where `Nil` is impossible.
+- [ ] 6.2 Add accepted Vec `append` fixture if transparent Nat addition exists.
+- [ ] 6.3 Add rejected fixture for a checker profile without dependent-pattern support.
+- [ ] 6.4 Add rejected fixture for an unsupported equality-pattern case.
+- [ ] 6.5 Run focused MLTT/dependent-pattern tests and existing basic checker tests.

--- a/openspec/changes/introduce-mltt-type-checker/.openspec.yaml
+++ b/openspec/changes/introduce-mltt-type-checker/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/introduce-mltt-type-checker/README.md
+++ b/openspec/changes/introduce-mltt-type-checker/README.md
@@ -1,0 +1,3 @@
+# introduce-mltt-type-checker
+
+Add an MLTT-oriented checker proposal, guidance documentation, and staged implementation plan for cosmo0 and cosmoc.

--- a/openspec/changes/introduce-mltt-type-checker/design.md
+++ b/openspec/changes/introduce-mltt-type-checker/design.md
@@ -1,0 +1,249 @@
+## Context
+
+The current cosmo1 type model covers bootstrap-oriented types: primitive types,
+user class types, function types, references, never, and error. That model is
+appropriate for staged compiler work, but it does not give a principled core for
+dependent pattern matching, type-level computation, or future proof-oriented
+experiments.
+
+Martin-Lof type theory is a useful first dependent core because it can be kept
+small:
+
+- universes classify types;
+- Pi types model dependent functions;
+- Sigma types model dependent pairs;
+- inductive families model indexed data such as `Vec[A, n]`;
+- equality types model propositional equality;
+- definitional equality is checked by normalization/conversion;
+- dependent pattern matching can later elaborate into eliminators or case trees.
+
+The goal is not to turn Cosmo into Agda, Idris, or Coq in one step. The goal is
+to build a small, modular checker that can be compared against other checkers and
+used to explore theory without making full Cosmo depend on every experiment.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add an `mltt.core` checker profile.
+- Define a compact core syntax suitable for implementation in both cosmo0-side
+  infrastructure and `packages/cosmoc`.
+- Use bidirectional type checking to keep inference local and diagnostics clear.
+- Use a conservative conversion API backed first by a declared WHNF-style
+  normalization strategy over pure, transparent terms.
+- Keep effectful computations out of definitional equality.
+- Keep the first implementation small enough to be a useful thousand-line-scale
+  experiment with clear comments.
+- Produce guidance documentation that explains the theory and implementation
+  choices.
+
+**Non-Goals:**
+
+- Support all Cosmo features in the first MLTT profile.
+- Support traits, effects, async, object safety, C++ imports, macros, reflection,
+  or staging in the first profile.
+- Support arbitrary higher-order unification.
+- Support general recursion in type-level computation.
+- Select or evaluate advanced normalization strategies in the first MLTT profile.
+- Implement dependent pattern matching in this change.
+- Commit to HoTT, cubical type theory, quotient types, sized types, or QTT.
+- Replace the existing parser-subset checker.
+
+## Decisions
+
+### Use A Small MLTT Core
+
+The first core should contain:
+
+```text
+Term:
+  Var
+  Universe(level)
+  Pi(name, domain, body)
+  Sigma(name, first, second)
+  Lambda(name, annotation, body)
+  Apply(function, argument)
+  Pair(first, second)
+  Fst(pair)
+  Snd(pair)
+  Let(name, value, body)
+  Inductive(name, params, indices)
+  Constructor(name, args)
+  Eq(type, left, right)
+  Refl(value)
+  Neutral(head, spine)
+  Error
+```
+
+This is enough to test dependent functions, simple dependent pairs, equality,
+and indexed data declarations without importing the whole source language.
+
+Alternative considered: directly extend the existing `CosmoType` enum. That
+would mix parser-subset types with a binder-heavy dependent core and make both
+harder to reason about.
+
+### Use Bidirectional Checking
+
+The checker should expose two mutually recursive modes:
+
+```text
+check(ctx, term, expected_type) -> CheckedTerm
+infer(ctx, term) -> (CheckedTerm, inferred_type)
+```
+
+Examples:
+
+- lambdas check against expected Pi types;
+- variables infer from the context;
+- applications infer the function type, then check the argument;
+- annotated terms can bridge from check mode to infer mode;
+- constructors usually check against an expected inductive-family type.
+
+Alternative considered: full inference. That is not a good fit for dependent
+types and would push too much work into unification.
+
+### Keep Conversion Separate
+
+Definitional equality should be a separate operation:
+
+```text
+convert(ctx, left_type, right_type, strategy) -> ConversionResult
+```
+
+The first implementation should use a declared first-stage strategy such as
+`mltt.whnf-conversion`: weak-head normalization plus structural comparison over
+pure, terminating, transparent terms. The conversion API should still be shaped
+so later normalization strategies can be evaluated without changing checker
+callers. This proposal deliberately avoids naming or committing to those later
+strategies.
+
+Alternative considered: compare raw syntax. That fails for ordinary dependent
+programs where `add(Z, n)` must be definitionally equal to `n`.
+
+Alternative considered: require a stronger normalization strategy in the first
+MLTT checker. That would make the first slice depend on theory and host-language
+representation choices that need separate research.
+
+### Keep Effects Out Of Definitional Equality
+
+The existing effect design treats `with E` as computation behavior. The MLTT
+core should respect that by requiring type-level computation to be pure. Terms
+with `async`, `yield`, `throw`, IO, mutation, or other unhandled effects cannot
+be reduced by conversion.
+
+This does not mean effects cannot exist in full Cosmo. It means the first MLTT
+conversion checker does not run effectful computations to decide type equality.
+
+Alternative considered: allow arbitrary compile-time execution during
+conversion. That makes type checking depend on runtime effects and threatens
+termination, determinism, and diagnostics.
+
+### Use Metavariables Conservatively
+
+The first MLTT checker should support metavariables only where they are needed
+for local elaboration:
+
+```text
+MetaVar:
+  id
+  context snapshot
+  expected type
+  solution optional
+```
+
+Solving should support first-order and simple pattern-like cases. Arbitrary
+higher-order unification is out of scope.
+
+Alternative considered: no metavariables. That makes even small implicit
+arguments and constructor elaboration awkward. Full higher-order unification is
+too large for the first slice.
+
+### Treat Inductive Families As Declarations, Not Magic Builtins
+
+The first implementation should represent inductive-family signatures as
+declaration metadata:
+
+```text
+InductiveDecl:
+  name
+  parameters
+  indices
+  constructors
+
+ConstructorDecl:
+  name
+  telescope
+  result family and indices
+```
+
+This lets `Vec[A, n]`, `Nat`, and `Fin[n]` be test declarations rather than
+hard-coded checker branches.
+
+Alternative considered: hard-code `Nat`, `Vec`, and `Fin`. That may be useful
+for smoke tests, but the checker architecture should not depend on it.
+
+### Keep Implementation Slices Small
+
+The first implementation should aim for roughly a thousand lines per slice:
+
+- core data and pretty printing;
+- context and diagnostics;
+- infer/check;
+- conversion and normalization;
+- a small declaration environment;
+- tests and fixtures.
+
+This is a budget guideline, not a hard size limit. The important property is
+that each slice can be reviewed independently and heavily commented.
+
+## Risks / Trade-offs
+
+- MLTT core diverges from surface Cosmo -> Mitigation: keep it behind the
+  `mltt.core` profile and require explicit elaboration.
+- Conversion becomes too powerful -> Mitigation: only pure, total, transparent
+  terms reduce.
+- Advanced normalization requirements leak into the first checker -> Mitigation:
+  first implement a WHNF-style strategy and require separate proposals for
+  stronger strategies.
+- Diagnostics become abstract -> Mitigation: keep source spans and elaboration
+  notes attached to core terms.
+- Metavariables become an implicit theorem prover -> Mitigation: support only
+  conservative local solving and report postponed constraints.
+- Universe design is under-specified -> Mitigation: start with predicative
+  universe levels and no cumulativity unless explicitly added.
+- cosmo0 cannot host the whole checker early -> Mitigation: define behavioral
+  conformance first, then implement the Cosmo-written version as staged source.
+
+## Migration Plan
+
+1. Add the guidance document and OpenSpec requirements.
+2. Add an `mltt.core` profile that rejects all source until the core input
+   format is available.
+3. Implement core data and display in `packages/cosmoc`.
+4. Implement context, diagnostics, and bidirectional checking for variables,
+   universes, Pi, lambda, application, and let.
+5. Add conversion with the first `mltt.whnf-conversion` strategy for
+   beta-reduction and transparent lets.
+6. Add Sigma and equality.
+7. Add inductive-family declaration metadata and small Nat/Vec fixtures.
+8. Add a cosmo0-side conformance harness or mirror implementation when the
+   Cosmo-written profile has stable behavior.
+9. Evaluate stronger normalization strategies only after a separate research
+   pass and proposal define the formal and implementation requirements.
+
+Rollback is additive: remove or disable the `mltt.core` profile and leave the
+existing `cosmoc.basic-expr` checker as the default.
+
+## Open Questions
+
+- Should the first universe policy include cumulativity or strict universe
+  equality only?
+- What exact WHNF cache key and fuel policy should the first conversion strategy
+  use?
+- How much implicit argument insertion should the first checker support?
+- Should totality checking be part of `mltt.core`, or a later
+  `mltt.totality` profile?
+- Should erased proof/index arguments be represented in the first core or added
+  after dependent pattern matching exists?
+- Which normalization strategies should be studied after the first WHNF-style
+  implementation, and what evidence is required before adopting one?

--- a/openspec/changes/introduce-mltt-type-checker/proposal.md
+++ b/openspec/changes/introduce-mltt-type-checker/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Cosmo needs a small dependent type-checking experiment that can support future
+dependent pattern matching without turning every checker into a full proof
+assistant. An MLTT-oriented core gives the project a principled place to model
+universes, dependent functions, inductive families, equality, conversion, and
+elaboration while preserving the existing staged bootstrap path.
+
+## What Changes
+
+- Introduce an experimental `mltt.core` checker profile built around a small
+  Martin-Lof type theory core.
+- Define a bidirectional checker architecture with separate checking,
+  inference, conversion, first-stage normalization, metavariable, and diagnostic
+  layers.
+- Define MLTT core data for universes, Pi types, Sigma types, variables, lambdas,
+  applications, lets, inductive-family references, constructors, equality, and
+  neutral terms.
+- Define implementation guidance for cosmo0 and `packages/cosmoc`, with the
+  initial implementation scoped to a small and well-commented core rather than
+  full language support.
+- Scope the first conversion implementation to a declared WHNF-style
+  normalization strategy and defer other normalization techniques to later
+  research and separate proposals.
+- Add MLTT type-checking guidance documentation covering concepts, implementation
+  trade-offs, feature boundaries, and future theory discussion points.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo-mltt-core`: Defines the MLTT core term/type model, universe policy,
+  purity boundary, and feature exclusions for the first MLTT checker.
+- `cosmo-mltt-bidirectional-checker`: Defines bidirectional checking,
+  conversion, normalization, diagnostics, and staged implementation behavior for
+  the MLTT profile.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds OpenSpec requirements and design notes for a new checker profile; it does
+  not replace the current `packages/cosmoc/src/types` checker.
+- Future implementation will add MLTT-oriented modules under `packages/cosmoc`
+  and a corresponding cosmo0-side experiment or conformance harness.
+- The first MLTT profile may reject traits, effects, async, object dispatch, C++
+  imports, general recursion, and dependent pattern matching until later
+  profiles add those capabilities.
+- The first MLTT profile does not claim conformance to any advanced
+  normalization strategy beyond its explicitly declared first-stage conversion
+  behavior.

--- a/openspec/changes/introduce-mltt-type-checker/specs/cosmo-mltt-bidirectional-checker/spec.md
+++ b/openspec/changes/introduce-mltt-type-checker/specs/cosmo-mltt-bidirectional-checker/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Bidirectional Checking
+The MLTT checker SHALL expose separate check and infer modes.
+
+#### Scenario: Lambda checks against Pi
+- **WHEN** a lambda expression is checked against a Pi type
+- **THEN** the checker extends the context with the Pi domain
+- **AND** checks the lambda body against the Pi body specialized by the parameter
+
+#### Scenario: Application infers through Pi
+- **WHEN** an application is inferred and the function infers a Pi type
+- **THEN** the checker checks the argument against the Pi domain
+- **AND** returns the Pi body specialized by the argument as the application type
+
+### Requirement: Conversion
+The MLTT checker SHALL use definitional equality when checking whether an
+inferred type satisfies an expected type. The first implementation SHALL perform
+conversion through a declared first-stage normalization strategy rather than
+through an unspecified evaluator.
+
+#### Scenario: Type mismatch after normalization
+- **WHEN** an inferred type and expected type are not definitionally equal after allowed normalization
+- **THEN** the checker reports a type mismatch diagnostic with deterministic display text
+
+#### Scenario: Beta-equivalent function types match
+- **WHEN** two types differ only by allowed beta reduction or transparent let expansion
+- **THEN** conversion accepts them as definitionally equal
+
+#### Scenario: Conversion result records strategy
+- **WHEN** conversion succeeds or fails in the first MLTT checker
+- **THEN** the checker can report the normalization strategy used for that conversion
+- **AND** the strategy is not reported as any stronger strategy unless that strategy is selected and implemented
+
+### Requirement: Conservative Metavariables
+The MLTT checker SHALL allow metavariables only as local elaboration aids and
+SHALL report postponed or unsolved constraints deterministically.
+
+#### Scenario: Metavariable remains unsolved
+- **WHEN** checking completes with an unsolved metavariable that affects a public typed artifact
+- **THEN** the checker reports an unsolved-constraint diagnostic
+
+#### Scenario: Higher-order unification is outside the first profile
+- **WHEN** solving a metavariable would require arbitrary higher-order unification
+- **THEN** the checker rejects or postpones the constraint instead of guessing a solution
+
+### Requirement: Deterministic Diagnostics
+MLTT checker diagnostics SHALL include profile id, source span when available,
+core context summary, and deterministic expected/actual display where applicable.
+
+#### Scenario: Unknown variable is reported
+- **WHEN** infer mode sees a variable not present in the MLTT context
+- **THEN** the checker reports an unknown-variable diagnostic
+- **AND** the diagnostic identifies the `mltt.core` profile

--- a/openspec/changes/introduce-mltt-type-checker/specs/cosmo-mltt-core/spec.md
+++ b/openspec/changes/introduce-mltt-type-checker/specs/cosmo-mltt-core/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: MLTT Core Profile
+Cosmo SHALL provide an experimental `mltt.core` checker profile for a small
+Martin-Lof type theory core. The profile SHALL be separate from existing
+parser-subset type checking and SHALL be allowed to reject full Cosmo features
+that are outside the MLTT core slice.
+
+#### Scenario: MLTT profile is selected
+- **WHEN** a fixture or package-check experiment selects `mltt.core`
+- **THEN** type checking uses the MLTT core profile
+- **AND** the result identifies the `mltt.core` checker profile
+
+#### Scenario: Unsupported full-language feature is rejected
+- **WHEN** `mltt.core` receives source that uses traits, async, object dispatch, C++ imports, macros, reflection, or staging before those features are admitted
+- **THEN** the checker reports an unsupported-feature diagnostic
+- **AND** the checker does not produce MLTT core artifacts for the rejected construct
+
+### Requirement: Core Term And Type Model
+The `mltt.core` profile SHALL represent universes, dependent functions,
+dependent pairs, variables, lambdas, applications, lets, equality, and
+inductive-family references as core data.
+
+#### Scenario: Dependent function is represented
+- **WHEN** the profile elaborates a dependent function type
+- **THEN** the core artifact represents a Pi binder with a domain and a body type scoped over the binder
+
+#### Scenario: Equality type is represented
+- **WHEN** the profile elaborates a propositional equality type
+- **THEN** the core artifact records the compared type, left term, and right term
+
+### Requirement: Pure Type-Level Computation Boundary
+The MLTT core SHALL only reduce pure, total, transparent definitions during
+definitional equality.
+
+#### Scenario: Effectful term is excluded from conversion
+- **WHEN** a term with `async`, `yield`, `throw`, mutation, IO, or another unhandled effect would be needed for type-level reduction
+- **THEN** conversion rejects or postpones the reduction with a diagnostic or constraint
+- **AND** the checker does not execute the effectful computation to decide type equality
+
+#### Scenario: Transparent pure let can reduce
+- **WHEN** conversion compares a transparent pure let-bound expression with its expanded form
+- **THEN** the checker may reduce the let during definitional equality
+
+### Requirement: First-Stage Normalization Boundary
+The first MLTT checker profile SHALL declare the normalization strategy used by
+conversion and SHALL NOT claim conformance to any stronger normalization strategy
+that has not been separately specified and implemented.
+
+#### Scenario: First-stage strategy is declared
+- **WHEN** `mltt.core` performs conversion in the first implementation stage
+- **THEN** the result identifies the first-stage normalization strategy such as `mltt.whnf-conversion`
+- **AND** the checker does not claim support for an unspecified stronger strategy
+
+#### Scenario: Stronger normalization profile is requested too early
+- **WHEN** a fixture requests a normalization profile that is not implemented by `mltt.core`
+- **THEN** the checker reports an unsupported-normalization-profile diagnostic
+- **AND** it does not silently fall back while claiming conformance to the requested strategy
+
+### Requirement: Inductive Family Metadata
+The MLTT profile SHALL represent inductive families through declaration
+metadata rather than hard-coded checker branches.
+
+#### Scenario: Constructor result records indices
+- **WHEN** a constructor declaration is loaded for an indexed family
+- **THEN** the declaration metadata records the constructor telescope and the family indices in the constructor result type

--- a/openspec/changes/introduce-mltt-type-checker/tasks.md
+++ b/openspec/changes/introduce-mltt-type-checker/tasks.md
@@ -1,0 +1,50 @@
+## 1. Documentation
+
+- [ ] 1.1 Add MLTT guidance covering concepts, checker shape, conversion, and implementation trade-offs.
+- [ ] 1.2 Cross-reference the guidance from the MLTT proposal or later book index.
+- [ ] 1.3 Add short examples for Pi, Sigma, equality, Nat, Vec, and conversion.
+- [ ] 1.4 Add a section explaining why effects, traits, and object safety are outside the first MLTT profile.
+- [ ] 1.5 Add a section explaining why advanced normalization strategies are deferred to separate research.
+
+## 2. Profile Scaffolding
+
+- [ ] 2.1 Add an `mltt.core` checker profile descriptor in `packages/cosmoc`.
+- [ ] 2.2 Add a cosmo0-side profile name or conformance marker for `mltt.core`.
+- [ ] 2.3 Add unsupported-feature diagnostics for traits, effects, async, object dispatch, and C++ imports under `mltt.core`.
+- [ ] 2.4 Add fixture metadata selecting `mltt.core`.
+
+## 3. Core Data
+
+- [ ] 3.1 Add MLTT core term and type data under `packages/cosmoc/src/types/mltt` or an equivalent module.
+- [ ] 3.2 Add context entries for local variables, definitions, and universe levels.
+- [ ] 3.3 Add declaration metadata for transparent definitions and inductive families.
+- [ ] 3.4 Add deterministic display helpers for core terms and types.
+
+## 4. Bidirectional Checker
+
+- [ ] 4.1 Implement `check` and `infer` entry points for variables, universes, Pi, lambda, application, and let.
+- [ ] 4.2 Implement diagnostics for unknown variables, non-function application, universe mismatch, and type mismatch.
+- [ ] 4.3 Implement simple metavariable records and conservative solving hooks.
+- [ ] 4.4 Add focused tests for check/infer behavior.
+
+## 5. Conversion And Normalization
+
+- [ ] 5.1 Implement the first `mltt.whnf-conversion` normalization strategy for the initial core.
+- [ ] 5.2 Implement conversion for beta-reduced functions, lets, universes, Pi, and variables.
+- [ ] 5.3 Reject effectful or non-transparent definitions during conversion.
+- [ ] 5.4 Add conversion tests for `add(Z, n)`-style transparent definitions once Nat fixtures exist.
+- [ ] 5.5 Add diagnostics that make unsupported normalization-profile selection explicit.
+
+## 6. Inductive Family Smoke Support
+
+- [ ] 6.1 Add declaration metadata for Nat.
+- [ ] 6.2 Add declaration metadata for Vec.
+- [ ] 6.3 Check simple Vec-indexed signatures without dependent pattern matching.
+- [ ] 6.4 Add diagnostics for impossible or unsupported constructor elaboration cases.
+
+## 7. cosmo0 And cosmoc Validation
+
+- [ ] 7.1 Add `packages/cosmoc` tests for the MLTT profile.
+- [ ] 7.2 Add cosmo0 conformance fixtures for the same accepted and rejected examples.
+- [ ] 7.3 Confirm the existing `cosmoc.basic-expr` checker remains the default for current parser-source tests.
+- [ ] 7.4 Document implementation gaps before enabling any package-level MLTT selection.

--- a/openspec/changes/modularize-type-checker-experiments/.openspec.yaml
+++ b/openspec/changes/modularize-type-checker-experiments/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/modularize-type-checker-experiments/README.md
+++ b/openspec/changes/modularize-type-checker-experiments/README.md
@@ -1,0 +1,3 @@
+# modularize-type-checker-experiments
+
+Define modular type checker architecture so cosmo0 and cosmoc can host multiple checking experiments with explicit feature profiles.

--- a/openspec/changes/modularize-type-checker-experiments/design.md
+++ b/openspec/changes/modularize-type-checker-experiments/design.md
@@ -1,0 +1,229 @@
+## Context
+
+Cosmo currently has a pragmatic type-checking path under
+`packages/cosmoc/src/types`. It models primitive, user, function, reference,
+never, and error types, then checks a parser-source subset of expressions. That
+path is intentionally narrow and useful for staged bootstrap work, but it is not
+the right shape for every future type-system experiment.
+
+The project now has several likely checker directions:
+
+- a parser-subset checker for staged cosmo1 bootstrap;
+- a cosmo0 subset checker that rejects full-language features before lowering;
+- an MLTT-oriented checker for dependent type experiments;
+- future trait/effect/object-safety checkers;
+- future dependent pattern matching elaborators that may only work over MLTT
+  core artifacts.
+
+Those checkers should be allowed to share syntax, name-resolution output,
+diagnostics, type stores, and test fixtures while still declaring different
+feature support. A checker that does not support traits, effects, dependent
+patterns, or object dispatch must reject those features explicitly instead of
+pretending to have checked them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a stable boundary between parsed/resolved source and type-checking
+  experiments.
+- Let a package, module, fixture, or test select a checker profile.
+- Let each checker declare supported features and unsupported features.
+- Keep unsupported-feature diagnostics first-class and testable.
+- Keep checker outputs deterministic and comparable across experiments.
+- Let cosmo0 and `packages/cosmoc` host the same conceptual checker profiles
+  even when their implementations are written in different languages.
+- Keep implementation slices small enough that a first profile can land in
+  roughly a thousand lines of design plus implementation work.
+
+**Non-Goals:**
+
+- Replace the existing expression checker immediately.
+- Require the MLTT checker to accept all Cosmo syntax.
+- Require every checker to support traits, effects, async, object safety,
+  dependent pattern matching, or C++ lowering.
+- Define final surface syntax for checker selection.
+- Make checker selection part of ordinary user-facing package semantics before
+  the experiment model is proven.
+
+## Decisions
+
+### Use Explicit Checker Profiles
+
+A checker profile is a named capability bundle:
+
+```text
+checker profile:
+  id
+  implementation owner
+  accepted source stage
+  supported features
+  rejected features
+  input artifact contract
+  output artifact contract
+  diagnostic namespace
+```
+
+Example profile names:
+
+```text
+cosmoc.basic-expr
+cosmo0.subset
+mltt.core
+mltt.patterns
+```
+
+This keeps the language feature question separate from the implementation
+question. `mltt.core` can reject traits and effects in its first stage while a
+later `mltt.effects` profile can accept effect rows.
+
+Alternative considered: use feature flags on one global checker. That makes the
+checker harder to reason about and encourages hidden interactions between
+experiments.
+
+### Standardize Checker Inputs
+
+The minimum checker input should be:
+
+```text
+TypedCheckInput:
+  package/module identity
+  syntax arenas
+  name-resolution output
+  declaration-signature output when available
+  selected checker profile
+  feature gates requested by the fixture or package
+```
+
+Different profiles can require additional inputs, but they must state those
+requirements in the profile. For example, dependent pattern matching may require
+constructor metadata and inductive-family declarations; the current basic
+expression checker does not.
+
+Alternative considered: each checker reads arbitrary compiler globals. That
+would make experiments fast initially but brittle and hard to compare.
+
+### Standardize Checker Outputs
+
+The minimum checker output should include:
+
+```text
+TypedCheckResult:
+  checker profile id
+  accepted/rejected status
+  diagnostics
+  typed artifacts produced
+  unsupported features encountered
+  implementation limits encountered
+```
+
+Typed artifacts can be profile-specific:
+
+- basic expression checker: typed expression map;
+- MLTT checker: elaborated core terms and inferred core types;
+- dependent pattern checker: case tree and coverage result.
+
+The shared result should not force every checker to use the same type store.
+Instead, each profile declares the artifact kind it produces.
+
+Alternative considered: force one global `TypedExpr` model. That would block MLTT
+and dependent pattern experiments because they need binders, universes,
+conversion, constraints, and elaboration metadata that are not part of the
+current parser-subset model.
+
+### Unsupported Features Are Expected Results
+
+Unsupported-feature diagnostics must be ordinary checker results:
+
+```text
+cosmo.type.unsupported-feature
+cosmo.type.unsupported-dependent-pattern
+cosmo.type.unsupported-effect-row
+cosmo.type.unsupported-trait-constraint
+```
+
+A checker must reject unsupported source before producing misleading typed
+artifacts. This is especially important for MLTT experiments: a small MLTT core
+checker can be valid and useful even if it rejects traits, async, object
+dispatch, and C++ imports in its first stage.
+
+Alternative considered: treat unsupported features as internal errors. That
+would make experiments look broken even when the checker is correctly scoped.
+
+### Keep cosmo0 and cosmoc Aligned but Not Identical
+
+cosmo0 and `packages/cosmoc` should expose the same conceptual profile names,
+but they do not need identical implementations at first.
+
+For example:
+
+```text
+cosmo0:
+  cosmo0.subset implemented in Scala
+
+packages/cosmoc:
+  cosmoc.basic-expr implemented in Cosmo source
+  mltt.core eventually implemented in Cosmo source
+```
+
+Profile conformance tests should define observable behavior, not require a
+shared codebase.
+
+Alternative considered: implement every checker once and call it from both
+cosmo0 and cosmoc. That is premature while cosmo1 is still bootstrapping.
+
+### Use Capability-Based Test Fixtures
+
+Fixtures should name the checker profile and expected result:
+
+```text
+fixture:
+  checker: mltt.core
+  expected: rejected
+  diagnostic: cosmo.type.unsupported-effect-row
+```
+
+This allows the same source file to be accepted by one checker and rejected by
+another when that is intentional.
+
+Alternative considered: one global expected result per fixture. That blocks
+checker comparison and makes experimental failures ambiguous.
+
+## Risks / Trade-offs
+
+- Profile sprawl -> Mitigation: require each profile to document supported
+  features, owner, and test fixture coverage.
+- Shared result shape becomes too generic -> Mitigation: keep only status,
+  diagnostics, and artifact tags shared; profile-specific typed data remains
+  profile-owned.
+- Users depend on experimental checker selection -> Mitigation: keep profile
+  selection under development/test metadata until a profile is promoted.
+- cosmo0 and cosmoc behavior diverges -> Mitigation: use conformance fixtures
+  that exercise observable diagnostics and typed artifact summaries.
+- Feature support becomes unclear -> Mitigation: unsupported-feature diagnostics
+  must be tested for every deliberately rejected major feature.
+
+## Migration Plan
+
+1. Define the modular checker profile requirements.
+2. Wrap the existing `packages/cosmoc/src/types/check.cos` behavior as the
+   `cosmoc.basic-expr` profile in documentation and tests.
+3. Add profile metadata to checker test helpers before changing package
+   semantics.
+4. Add cosmo0-side profile naming for the subset checker.
+5. Add MLTT profile scaffolding behind tests.
+6. Promote profile selection into package metadata only after at least two
+   profiles are implemented and fixture-tested.
+
+Rollback is additive: remove experimental profile metadata and keep the existing
+type-checking path as the default.
+
+## Open Questions
+
+- Should profile selection live in `cosmo.json`, test fixture metadata, or both?
+- Should profile IDs be user-facing, internal, or namespace-qualified by package?
+- What minimal artifact summary is enough for cross-profile comparison?
+- Which unsupported-feature diagnostic namespace should be shared across
+  cosmo0 and cosmoc?
+- Should checker profiles declare accepted effects and traits as independent
+  feature flags, or as named bundles?

--- a/openspec/changes/modularize-type-checker-experiments/proposal.md
+++ b/openspec/changes/modularize-type-checker-experiments/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Cosmo needs room to experiment with multiple type-checking strategies without
+forcing every checker to support the full language at once. The current
+`packages/cosmoc/src/types` path is useful for the parser-source subset, but the
+next stages need an explicit checker boundary so cosmo0, cosmoc, and future MLTT
+experiments can coexist.
+
+## What Changes
+
+- Define a modular type checker architecture with explicit checker identities,
+  feature profiles, inputs, outputs, diagnostics, and unsupported-feature
+  behavior.
+- Introduce a shared checker result shape that can represent success, ordinary
+  type errors, unsupported features, internal checker limitations, and lowered
+  typed artifacts.
+- Require each checker to declare the language features it supports rather than
+  silently accepting or partially checking unsupported source.
+- Keep the existing basic expression checker as the first "simple" checker
+  profile while allowing future MLTT, trait-aware, effect-aware, and dependent
+  pattern checkers to be added in parallel.
+- Define how cosmo0 and `packages/cosmoc` can select a checker profile for a
+  package, module, test fixture, or experiment.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo-type-checker-experiments`: Defines the modular checker boundary,
+  feature profile model, selection rules, diagnostics, and staged
+  implementation expectations for cosmo0 and cosmoc.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds OpenSpec requirements for checker modularity without changing existing
+  compiler behavior immediately.
+- Future implementation will affect `packages/cosmoc/src/types`, the cosmo0
+  Scala type-checking path, package metadata validation, and type-checking tests.
+- The existing parser-subset checker can remain in place, but it should be
+  wrapped as one checker profile instead of being treated as the only checking
+  architecture.

--- a/openspec/changes/modularize-type-checker-experiments/specs/cosmo-type-checker-experiments/spec.md
+++ b/openspec/changes/modularize-type-checker-experiments/specs/cosmo-type-checker-experiments/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Checker Profiles
+Cosmo type checking experiments SHALL be represented by named checker profiles.
+Each profile SHALL declare its supported language features, rejected language
+features, required inputs, produced artifact kind, and diagnostic namespace.
+
+#### Scenario: Profile declares accepted and rejected features
+- **WHEN** a checker profile is loaded by a test or package-check entry point
+- **THEN** the profile metadata identifies features the checker accepts
+- **AND** the profile metadata identifies features the checker deliberately rejects
+
+#### Scenario: Existing checker has a profile
+- **WHEN** the current `packages/cosmoc/src/types` expression checker is used
+- **THEN** its result identifies the `cosmoc.basic-expr` checker profile
+
+### Requirement: Profile-Aware Results
+A checker result SHALL identify the checker profile that produced it and SHALL
+distinguish successful typed artifacts, ordinary type errors, unsupported
+features, and implementation limits.
+
+#### Scenario: Unsupported source is rejected as a checker result
+- **WHEN** a profile sees a source construct outside its declared feature set
+- **THEN** the checker result contains an unsupported-feature diagnostic
+- **AND** the checker does not produce typed artifacts that pretend the construct was checked
+
+#### Scenario: Artifact kind is profile-owned
+- **WHEN** two checker profiles produce different typed artifact formats
+- **THEN** each result identifies its artifact kind
+- **AND** the shared result schema does not require both profiles to use one type-store representation
+
+### Requirement: cosmo0 And cosmoc Profile Alignment
+cosmo0 and `packages/cosmoc` SHALL use the same conceptual checker profile names
+for comparable behavior even when the implementations are written in different
+languages.
+
+#### Scenario: cosmo0 subset profile is selected
+- **WHEN** a cosmo0 subset-checking test selects the subset checker
+- **THEN** the observable result identifies the `cosmo0.subset` profile
+
+#### Scenario: Profile conformance is tested by behavior
+- **WHEN** two implementations claim the same conceptual checker behavior
+- **THEN** conformance is judged by accepted source, rejected source, diagnostics, and deterministic artifact summaries
+- **AND** conformance does not require a shared implementation
+
+### Requirement: Experimental Feature Isolation
+Checker profiles SHALL be allowed to reject features that other profiles accept.
+
+#### Scenario: MLTT profile rejects non-MLTT features
+- **WHEN** an MLTT-only profile receives source that uses traits, async, object dispatch, or C++ imports before that profile supports them
+- **THEN** the profile reports unsupported-feature diagnostics
+- **AND** the rejection does not imply that the same source is invalid for all checker profiles

--- a/openspec/changes/modularize-type-checker-experiments/tasks.md
+++ b/openspec/changes/modularize-type-checker-experiments/tasks.md
@@ -1,0 +1,34 @@
+## 1. Profile Model
+
+- [ ] 1.1 Define the checker profile data model in OpenSpec and test docs.
+- [ ] 1.2 Name the existing `packages/cosmoc/src/types/check.cos` behavior as `cosmoc.basic-expr`.
+- [ ] 1.3 Name the cosmo0 subset checker behavior as `cosmo0.subset`.
+- [ ] 1.4 Define the first unsupported-feature diagnostic code list shared by experiments.
+
+## 2. cosmoc Implementation
+
+- [ ] 2.1 Add a small checker-profile enum or descriptor module under `packages/cosmoc/src/types`.
+- [ ] 2.2 Wrap the current expression checker result with a profile id and artifact tag.
+- [ ] 2.3 Add test helper support for selecting `cosmoc.basic-expr`.
+- [ ] 2.4 Add negative tests that verify unsupported feature diagnostics are checker results, not internal errors.
+
+## 3. cosmo0 Implementation
+
+- [ ] 3.1 Add a cosmo0-side profile name for the subset checker.
+- [ ] 3.2 Emit profile-aware diagnostics for source rejected by the cosmo0 subset checker.
+- [ ] 3.3 Add fixture metadata or test harness parameters for checker profile selection.
+- [ ] 3.4 Confirm existing cosmo0 tests still run through the default profile.
+
+## 4. Experimental Profile Readiness
+
+- [ ] 4.1 Add empty `mltt.core` profile metadata without making it the default.
+- [ ] 4.2 Add fixture expectations for sources accepted by `cosmoc.basic-expr` but rejected by `mltt.core`.
+- [ ] 4.3 Add fixture expectations for sources rejected by `cosmoc.basic-expr` but reserved for later MLTT support.
+- [ ] 4.4 Document how a future checker declares support for effects, traits, object dispatch, and dependent patterns.
+
+## 5. Validation
+
+- [ ] 5.1 Run the focused `packages/cosmoc` type-checker tests.
+- [ ] 5.2 Run the cosmo0 subset checker tests.
+- [ ] 5.3 Add one profile-summary snapshot that proves typed artifacts remain deterministic.
+- [ ] 5.4 Document remaining profile-selection limitations.


### PR DESCRIPTION
## Summary
- Rewrite the effect notes around the unified `A => R with E` function model.
- Add self-contained async notes that keep `async` abstract and document optional `yield[Pending]` lowering.
- Add self-contained generator notes for `yield[Y]`, `Ready`/`Yield`, widening, stackless lowering, boxing, and safety.
- Add OpenSpec changes for modular type checker profiles, MLTT core checking, dependent-pattern elaboration, and the long-term type-checker theory roadmap.
- Add MLTT type-checking guidance for concepts, checker boundaries, first-stage conversion, and deferred advanced normalization research.
- Publish the new effect, async, generator, and MLTT guidance pages in the shiroa book navigation.

## Validation
- `typst compile docs/effect.typ /tmp/cosmo-effect.pdf`
- `typst compile docs/generator.typ /tmp/cosmo-generator.pdf`
- `typst compile docs/async.typ /tmp/cosmo-async.pdf`
- `typst compile docs/mltt-typechecking-guidance.typ /tmp/cosmo-mltt-typechecking-guidance.pdf`
- `shiroa build --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ --root . --path-to-root / --mode=static-html docs/cosmo`
- `openspec status --change modularize-type-checker-experiments`
- `openspec status --change introduce-mltt-type-checker`
- `openspec status --change define-type-checker-theory-roadmap`
- `openspec status --change elaborate-dependent-pattern-matching`