### PR TITLE
docs: fix design note book routes

### DIFF
--- a/docs/cosmo/async.typ
+++ b/docs/cosmo/async.typ
@@ -1,0 +1,5 @@
+#import "mod.typ": *
+
+#show: book-page.with(title: "Async Design Notes")
+
+#include "../async.typ"

--- a/docs/cosmo/book.typ
+++ b/docs/cosmo/book.typ
@@ -16,10 +16,10 @@
     #prefix-chapter("syntax-bnf.typ")[BNF Specification]
     #prefix-chapter("trait.typ")[Trait Design]
     #prefix-chapter("ufcs.typ")[Method Call Design]
-    #prefix-chapter("../effect.typ")[Effect Design Notes]
-    #prefix-chapter("../async.typ")[Async Design Notes]
-    #prefix-chapter("../generator.typ")[Generator Design Notes]
-    #prefix-chapter("../mltt-typechecking-guidance.typ")[MLTT Type Checking Guidance]
+    #prefix-chapter("effect.typ")[Effect Design Notes]
+    #prefix-chapter("async.typ")[Async Design Notes]
+    #prefix-chapter("generator.typ")[Generator Design Notes]
+    #prefix-chapter("mltt-typechecking-guidance.typ")[MLTT Type Checking Guidance]
   ],
 )
 

--- a/docs/cosmo/effect.typ
+++ b/docs/cosmo/effect.typ
@@ -1,0 +1,5 @@
+#import "mod.typ": *
+
+#show: book-page.with(title: "Effect Design Notes")
+
+#include "../effect.typ"

--- a/docs/cosmo/generator.typ
+++ b/docs/cosmo/generator.typ
@@ -1,0 +1,5 @@
+#import "mod.typ": *
+
+#show: book-page.with(title: "Generator Design Notes")
+
+#include "../generator.typ"

--- a/docs/cosmo/intro.typ
+++ b/docs/cosmo/intro.typ
@@ -8,3 +8,7 @@ Cosmo is a language replacing awful C++'s compile-time magics. This is only some
 - #cross-link("/syntax-bnf.typ")[BNF Specification]
 - #cross-link("/trait.typ")[Trait Design]
 - #cross-link("/ufcs.typ")[Method Call Design]
+- #cross-link("/effect.typ")[Effect Design Notes]
+- #cross-link("/async.typ")[Async Design Notes]
+- #cross-link("/generator.typ")[Generator Design Notes]
+- #cross-link("/mltt-typechecking-guidance.typ")[MLTT Type Checking Guidance]

--- a/docs/cosmo/mltt-typechecking-guidance.typ
+++ b/docs/cosmo/mltt-typechecking-guidance.typ
@@ -1,0 +1,5 @@
+#import "mod.typ": *
+
+#show: book-page.with(title: "MLTT Type Checking Guidance")
+
+#include "../mltt-typechecking-guidance.typ"


### PR DESCRIPTION
## Summary
- Add `docs/cosmo/*` wrapper pages for effect, async, generator, and MLTT type-checking guidance notes so shiroa emits book-root routes.
- Change book navigation from `../*.typ` chapters to book-root chapter files, avoiding generated `/../*.html` links.
- Add Introduction links to the newly published design note pages.

## Validation
- `shiroa build --font-path ./assets/typst-fonts/ --font-path ./assets/fonts/ --root . --path-to-root / --mode=static-html docs/cosmo`
- Verified generated files exist: `dist/docs/effect.html`, `dist/docs/async.html`, `dist/docs/generator.html`, `dist/docs/mltt-typechecking-guidance.html`
- Verified generated navigation links use `/effect.html`, `/async.html`, `/generator.html`, and `/mltt-typechecking-guidance.html`, not `/../*.html`
- `typst compile docs/cosmo/mltt-typechecking-guidance.typ /tmp/cosmo-mltt-site-page.pdf --root .`