### PR TITLE
feat: add MLTT core type checker

### DIFF
--- a/docs/cosmo/book.typ
+++ b/docs/cosmo/book.typ
@@ -20,6 +20,7 @@
     #prefix-chapter("async.typ")[Async Design Notes]
     #prefix-chapter("generator.typ")[Generator Design Notes]
     #prefix-chapter("mltt-typechecking-guidance.typ")[MLTT Type Checking Guidance]
+    #prefix-chapter("mltt-problem-ladder.typ")[MLTT Problem Ladder]
   ],
 )
 

--- a/docs/cosmo/intro.typ
+++ b/docs/cosmo/intro.typ
@@ -12,3 +12,4 @@ Cosmo is a language replacing awful C++'s compile-time magics. This is only some
 - #cross-link("/async.typ")[Async Design Notes]
 - #cross-link("/generator.typ")[Generator Design Notes]
 - #cross-link("/mltt-typechecking-guidance.typ")[MLTT Type Checking Guidance]
+- #cross-link("/mltt-problem-ladder.typ")[MLTT Problem Ladder]

--- a/docs/cosmo/mltt-problem-ladder.typ
+++ b/docs/cosmo/mltt-problem-ladder.typ
@@ -1,0 +1,5 @@
+#import "mod.typ": *
+
+#show: book-page.with(title: "MLTT Problem Ladder")
+
+#include "../mltt-problem-ladder.typ"

--- a/docs/cosmo0/testing.typ
+++ b/docs/cosmo0/testing.typ
@@ -45,7 +45,7 @@ Current diagnostic fixture coverage is indexed in `docs/cosmo0/syntax-corpus-mat
 
 == Checker Profile Tests
 
-Type-checking tests must identify the checker profile under test. The default cosmo0 source checker profile is `cosmo0.subset`; the current `packages/cosmoc/src/types` expression checker profile is `cosmoc.basic-expr`; the initial MLTT experiment placeholder is `mltt.core`.
+Type-checking tests must identify the checker profile under test. The default cosmo0 source checker profile is `cosmo0.subset`; the current `packages/cosmoc/src/types` expression checker profile is `cosmoc.basic-expr`; the initial MLTT core-data experiment is `mltt.core`.
 
 The `cosmo0.subset` profile declares support for dependent pattern matching and dependent-pattern elaboration. Simpler experimental profiles may still reject that feature explicitly; such rejections do not imply that the same source is outside cosmo0.
 
@@ -72,7 +72,7 @@ The shared unsupported-feature diagnostic codes are:
 - `cosmo.type.unsupported-cpp-import`
 - `cosmo.type.implementation-limit`
 
-Profile selection is currently a development and test-harness feature. `Cosmo0.checkWithProfile` and package `checkerProfile` metadata can select `cosmo0.subset`; experimental profiles such as `mltt.core` are isolated and return unsupported-feature diagnostics until their checker implementation exists.
+Profile selection is currently a development and test-harness feature. `Cosmo0.checkWithProfile` and package `checkerProfile` metadata can select `cosmo0.subset`; experimental profiles such as `mltt.core` stay isolated for ordinary source/package checking and return unsupported-feature diagnostics until a surface elaborator can produce their core artifacts. The MLTT core checker itself is tested through `packages/cosmoc/src/types/mltt/` fixture programs and the Scala mirror at `packages/cosmo0/src/main/scala/cosmo0/MlttTypeChecker.scala`.
 
 == Determinism Tests
 

--- a/docs/mltt-problem-ladder.typ
+++ b/docs/mltt-problem-ladder.typ
@@ -1,0 +1,175 @@
+= MLTT Problem Ladder
+
+== Status
+
+This page is a source-tagged problem ladder for the experimental `mltt.core`
+checker. It is a collection of implementation exercises and fixture candidates,
+not a normative Cosmo language specification. Each entry uses one of these
+statuses:
+
+- `supported-now`: the current `mltt.core` checker should have an executable
+  fixture or Scala mirror test.
+- `source-backed-future`: the problem is backed by external dependent-type
+  implementation material, but the current checker deliberately does not support
+  it yet.
+- `paper-exercise`: the problem is useful as a derivation or design exercise,
+  but it is not yet a compiler fixture.
+
+== Source Index
+
+- `elaboration-zoo`: #link("https://github.com/AndrasKovacs/elaboration-zoo")[Andras Kovacs, elaboration-zoo]. This is a sequence of small dependent type checking and elaboration implementations. It is the main source for evaluation representations, bidirectional checking, holes, implicit arguments, pruning, and first-class polymorphism.
+- `nbe-tutorial`: #link("https://davidchristiansen.dk/tutorials/nbe/")[David Christiansen, Checking Dependent Types with Normalization by Evaluation]. This is the main source for conversion, normalization, equality checking, holes, and project-style extensions such as vectors.
+- `cmu-dependency-notes`: #link("https://www.cs.cmu.edu/~rwh/courses/atpl/pdfs/dependency.pdf")[CMU ATPL dependency notes]. These notes are the source for Pi, Sigma, identity type rules, and eta-style exercises.
+- `agda-implicit-args`: #link("https://wiki.portal.chalmers.se/agda/ReferenceManual/FindingTheValuesOfImplicitArguments")[Agda reference manual, Finding the Values of Implicit Arguments]. This is a practical source for implicit argument metavariables and restricted pattern unification.
+- `lean-elaboration`: #link("https://leanprover-community.github.io/lean4-metaprogramming-book/main/02_overview.html")[Lean 4 Metaprogramming Book, elaboration overview]. This is a practical source for surface holes becoming metavariables during elaboration.
+- `practical-unification`: #link("https://research.chalmers.se/en/publication/519011")[Practical Unification for Dependent Type Checking]. This is the source for the boundary around higher-order unification and practical restrictions.
+- `pi-forall`: #link("https://arxiv.org/abs/2207.02129")[pi-forall paper] and #link("https://github.com/sweirich/pi-forall")[pi-forall repository]. These are sources for small dependently typed language implementation exercises beyond the current checker.
+- `radboud-exercises`: #link("https://www.cs.ru.nl/~herman/TT/opg6.pdf")[Radboud Type Theory Exercises 6]. This is a source for proof-term and derivation exercises.
+
+== Supported Now
+
+problem: `mltt-core-display`
+status: `supported-now`
+sources: `elaboration-zoo`, `nbe-tutorial`
+
+Exercise: build the same small core term set using explicit constructors and
+prove that display is deterministic for universes, Pi, Sigma, equality, Nat,
+and Vec. This is the smallest check that the implementation has a stable core
+syntax before type checking is involved.
+
+problem: `mltt-universe-variable`
+status: `supported-now`
+sources: `elaboration-zoo`, `cmu-dependency-notes`
+
+Exercise: infer `Type0 : Type1` and infer a variable from the local context.
+The context lookup case must report the `mltt.core` profile on unknown
+variables.
+
+problem: `mltt-pi-lambda-application`
+status: `supported-now`
+sources: `elaboration-zoo`, `cmu-dependency-notes`
+
+Exercise: check an identity lambda against a Pi type and infer an application
+through the Pi codomain substitution. Lambdas should use check mode when an
+expected Pi is available; applications should infer the function type and then
+check the argument.
+
+problem: `mltt-sigma-refl`
+status: `supported-now`
+sources: `cmu-dependency-notes`, `nbe-tutorial`
+
+Exercise: check a pair against a Sigma type and check `Refl(x)` against
+`Eq(A, x, x)`. The equality case should use conversion, not raw syntax, for the
+two endpoints.
+
+problem: `mltt-projection-whnf`
+status: `supported-now`
+sources: `nbe-tutorial`, `cmu-dependency-notes`
+
+Exercise: reduce `fst((x, y))` to `x` and `snd((x, y))` to `y` during WHNF
+conversion. This keeps dependent pair projections in the conversion relation
+without requiring a full normalizer.
+
+problem: `mltt-conversion-beta-let-def`
+status: `supported-now`
+sources: `nbe-tutorial`, `elaboration-zoo`
+
+Exercise: accept beta conversion, transparent let conversion, and transparent
+pure definition unfolding, such as an `add(Z, n)`-style fixture reducing to
+`n`.
+
+problem: `mltt-conversion-effect-boundary`
+status: `supported-now`
+sources: `nbe-tutorial`
+
+Exercise: reject conversion through opaque or effectful definitions, and reject
+unknown normalization strategy names. This preserves the design rule that
+definitional equality is pure, deterministic type-level computation.
+
+problem: `mltt-nat-vec-constructors`
+status: `supported-now`
+sources: `nbe-tutorial`, `agda-implicit-args`
+
+Exercise: record Nat and Vec declaration metadata, check `Z` and `S(Z)` against
+Nat, check `Nil` against `Vec(A, Z)`, and check `Cons(k, head, tail)` against
+`Vec(A, S(k))`. This is constructor-signature checking only; impossible branch
+analysis belongs to dependent pattern elaboration.
+
+problem: `mltt-meta-exact-higher-order-reject`
+status: `supported-now`
+sources: `elaboration-zoo`, `agda-implicit-args`, `practical-unification`
+
+Exercise: create a local metavariable with a context snapshot, solve it exactly
+when a known term is supplied, and reject arbitrary higher-order unification
+with a deterministic diagnostic.
+
+== Source-Backed Future Problems
+
+problem: `mltt-surface-holes`
+status: `source-backed-future`
+sources: `elaboration-zoo`, `lean-elaboration`, `nbe-tutorial`
+
+Exercise: elaborate a surface `_` hole into a metavariable that records the
+current context and expected type. The current checker has core metavariable
+records, but no surface elaborator that creates them from syntax.
+
+problem: `mltt-implicit-arguments`
+status: `source-backed-future`
+sources: `elaboration-zoo`, `agda-implicit-args`, `lean-elaboration`
+
+Exercise: insert implicit argument metavariables while elaborating a function
+call, then solve them from explicit arguments or the expected result type. The
+current core has no explicit/implicit Pi distinction.
+
+problem: `mltt-pruning-pattern-unification`
+status: `source-backed-future`
+sources: `elaboration-zoo`, `agda-implicit-args`, `practical-unification`
+
+Exercise: solve only restricted pattern constraints, prune unused metavariable
+dependencies, and postpone or reject non-pattern constraints. The current
+checker only exposes conservative exact solving and a higher-order rejection
+diagnostic.
+
+problem: `mltt-first-class-polymorphism`
+status: `source-backed-future`
+sources: `elaboration-zoo`, `pi-forall`
+
+Exercise: pass polymorphic values through the core while preserving explicit and
+implicit function boundaries. This is outside the current `mltt.core` term
+language.
+
+problem: `mltt-dependent-pattern-impossible-branch`
+status: `source-backed-future`
+sources: `nbe-tutorial`, `agda-implicit-args`
+
+Exercise: elaborate a match on `xs : Vec(A, S(n))` and mark the `Nil` branch as
+impossible by unifying `Vec(A, S(n))` with the constructor result `Vec(A, Z)`.
+This belongs to the dependent-pattern checker profile, not the first core
+checker.
+
+problem: `mltt-identity-eliminator-j`
+status: `source-backed-future`
+sources: `cmu-dependency-notes`
+
+Exercise: add the identity eliminator J and its beta rule while keeping the
+theory intensional unless a later proposal explicitly accepts additional
+equality principles.
+
+problem: `mltt-eta-cumulativity`
+status: `source-backed-future`
+sources: `cmu-dependency-notes`, `nbe-tutorial`
+
+Exercise: evaluate whether Pi/Sigma eta rules or universe cumulativity should be
+part of a later profile. The current checker keeps strict universe levels and
+does not add eta conversion.
+
+== Paper Exercises
+
+problem: `mltt-logic-proof-term-derivations`
+status: `paper-exercise`
+sources: `radboud-exercises`, `cmu-dependency-notes`
+
+Exercise: derive a proof term and context typing derivation for a small
+predicate-logic encoding. This is useful reviewer training for dependent
+judgments, but it should not become a compiler fixture until Cosmo has a surface
+syntax for those proof terms.

--- a/docs/mltt-typechecking-guidance.typ
+++ b/docs/mltt-typechecking-guidance.typ
@@ -7,6 +7,15 @@ normative language specification. Its purpose is to give implementers and
 reviewers a shared vocabulary before Cosmo grows dependent pattern matching,
 trait-aware checking, effect-aware checking, and object-safety checks.
 
+The first implementation slice lives under
+`packages/cosmoc/src/types/mltt/`, with a Scala-side mirror under
+`packages/cosmo0/src/main/scala/cosmo0/MlttTypeChecker.scala`. It provides
+explicit MLTT core data, profile-aware diagnostics, bidirectional check/infer
+entry points, conservative metavariable records, Nat/Vec metadata fixtures, and
+the first declared conversion strategy `mltt.whnf-conversion`. Selecting
+`mltt.core` for ordinary Cosmo source or package checking remains isolated until
+a surface elaborator can produce MLTT core artifacts.
+
 The key design rule is:
 
 ```text
@@ -90,6 +99,50 @@ Implementers can choose de Bruijn indices, de Bruijn levels, or stable local IDs
 For Cosmo compiler code, stable IDs plus explicit context entries are easier to
 debug. For conversion and substitution, de Bruijn levels often make
 alpha-equivalence and reification back to core syntax cleaner.
+
+== Short Examples
+
+Pi type:
+
+```text
+(A: Type0) -> (x: A) -> A
+```
+
+Sigma type:
+
+```text
+Sigma(x: A). B(x)
+```
+
+Equality type:
+
+```text
+Eq(A, x, x)
+Refl(x)
+```
+
+Nat metadata:
+
+```text
+Nat : Type0
+Z   : Nat
+S   : Nat -> Nat
+```
+
+Vec metadata:
+
+```text
+Vec(A: Type0, n: Nat) : Type0
+Nil  : Vec(A, Z)
+Cons : (k: Nat) -> A -> Vec(A, k) -> Vec(A, S(k))
+```
+
+Conversion:
+
+```text
+(fun x: A => x)(y) == y
+let z = y; z == y
+```
 
 == Bidirectional Checking
 

--- a/fixtures/cosmo0/package/mltt-core-profile/cosmo.json
+++ b/fixtures/cosmo0/package/mltt-core-profile/cosmo.json
@@ -1,0 +1,6 @@
+{
+  "name": "@cosmo0/package-mltt-core-profile",
+  "version": "0.0.0",
+  "target": "cosmo0",
+  "checkerProfile": "mltt.core"
+}

--- a/fixtures/cosmo0/package/mltt-core-profile/src/main.cos
+++ b/fixtures/cosmo0/package/mltt-core-profile/src/main.cos
@@ -1,0 +1,1 @@
+val answer = 42

--- a/openspec/changes/introduce-mltt-type-checker/tasks.md
+++ b/openspec/changes/introduce-mltt-type-checker/tasks.md
@@ -1,52 +1,52 @@
 ## 1. Documentation
 
-- [ ] 1.1 Add MLTT guidance covering concepts, checker shape, conversion, and implementation trade-offs.
-- [ ] 1.2 Cross-reference the guidance from the MLTT proposal or later book index.
-- [ ] 1.3 Add short examples for Pi, Sigma, equality, Nat, Vec, and conversion.
-- [ ] 1.4 Add a section explaining why effects, traits, and object safety are outside the first MLTT profile.
-- [ ] 1.5 Add a section explaining why advanced normalization strategies are deferred to separate research.
+- [x] 1.1 Add MLTT guidance covering concepts, checker shape, conversion, and implementation trade-offs.
+- [x] 1.2 Cross-reference the guidance from the MLTT proposal or later book index.
+- [x] 1.3 Add short examples for Pi, Sigma, equality, Nat, Vec, and conversion.
+- [x] 1.4 Add a section explaining why effects, traits, and object safety are outside the first MLTT profile.
+- [x] 1.5 Add a section explaining why advanced normalization strategies are deferred to separate research.
 
 ## 2. Profile Scaffolding
 
-- [ ] 2.1 Add an `mltt.core` checker profile descriptor in `packages/cosmoc`.
-- [ ] 2.2 Add a cosmo0-side profile name or conformance marker for `mltt.core`.
-- [ ] 2.3 Add unsupported-feature diagnostics for traits, effects, async, object dispatch, and C++ imports under `mltt.core`.
-- [ ] 2.4 Add fixture metadata selecting `mltt.core`.
-- [ ] 2.5 Add direct cosmo0-side profile-gate tests when a Scala reference implementation exists.
+- [x] 2.1 Add an `mltt.core` checker profile descriptor in `packages/cosmoc`.
+- [x] 2.2 Add a cosmo0-side profile name or conformance marker for `mltt.core`.
+- [x] 2.3 Add unsupported-feature diagnostics for traits, effects, async, object dispatch, and C++ imports under `mltt.core`.
+- [x] 2.4 Add fixture metadata selecting `mltt.core`.
+- [x] 2.5 Add direct cosmo0-side profile-gate tests when a Scala reference implementation exists.
 
 ## 3. Core Data
 
-- [ ] 3.1 Add MLTT core term and type data under `packages/cosmoc/src/types/mltt` or an equivalent module.
-- [ ] 3.2 Add context entries for local variables, definitions, and universe levels.
-- [ ] 3.3 Add declaration metadata for transparent definitions and inductive families.
-- [ ] 3.4 Add deterministic display helpers for core terms and types.
+- [x] 3.1 Add MLTT core term and type data under `packages/cosmoc/src/types/mltt` or an equivalent module.
+- [x] 3.2 Add context entries for local variables, definitions, and universe levels.
+- [x] 3.3 Add declaration metadata for transparent definitions and inductive families.
+- [x] 3.4 Add deterministic display helpers for core terms and types.
 
 ## 4. Bidirectional Checker
 
-- [ ] 4.1 Implement `check` and `infer` entry points for variables, universes, Pi, lambda, application, and let.
-- [ ] 4.2 Implement diagnostics for unknown variables, non-function application, universe mismatch, and type mismatch.
-- [ ] 4.3 Implement simple metavariable records and conservative solving hooks.
-- [ ] 4.4 Add focused tests for check/infer behavior.
+- [x] 4.1 Implement `check` and `infer` entry points for variables, universes, Pi, lambda, application, and let.
+- [x] 4.2 Implement diagnostics for unknown variables, non-function application, universe mismatch, and type mismatch.
+- [x] 4.3 Implement simple metavariable records and conservative solving hooks.
+- [x] 4.4 Add focused tests for check/infer behavior.
 
 ## 5. Conversion And Normalization
 
-- [ ] 5.1 Implement the first `mltt.whnf-conversion` normalization strategy for the initial core.
-- [ ] 5.2 Implement conversion for beta-reduced functions, lets, universes, Pi, and variables.
-- [ ] 5.3 Reject effectful or non-transparent definitions during conversion.
-- [ ] 5.4 Add conversion tests for `add(Z, n)`-style transparent definitions once Nat fixtures exist.
-- [ ] 5.5 Add diagnostics that make unsupported normalization-profile selection explicit.
+- [x] 5.1 Implement the first `mltt.whnf-conversion` normalization strategy for the initial core.
+- [x] 5.2 Implement conversion for beta-reduced functions, lets, universes, Pi, and variables.
+- [x] 5.3 Reject effectful or non-transparent definitions during conversion.
+- [x] 5.4 Add conversion tests for `add(Z, n)`-style transparent definitions once Nat fixtures exist.
+- [x] 5.5 Add diagnostics that make unsupported normalization-profile selection explicit.
 
 ## 6. Inductive Family Smoke Support
 
-- [ ] 6.1 Add declaration metadata for Nat.
-- [ ] 6.2 Add declaration metadata for Vec.
-- [ ] 6.3 Check simple Vec-indexed signatures without dependent pattern matching.
-- [ ] 6.4 Add diagnostics for impossible or unsupported constructor elaboration cases.
+- [x] 6.1 Add declaration metadata for Nat.
+- [x] 6.2 Add declaration metadata for Vec.
+- [x] 6.3 Check simple Vec-indexed signatures without dependent pattern matching.
+- [x] 6.4 Add diagnostics for impossible or unsupported constructor elaboration cases.
 
 ## 7. cosmo0 And cosmoc Validation
 
-- [ ] 7.1 Add `packages/cosmoc` tests for the MLTT profile.
-- [ ] 7.2 Add cosmo0 conformance fixtures or Scala mirror tests for the same accepted and rejected examples.
-- [ ] 7.3 Confirm the existing `cosmoc.basic-expr` checker remains the default for current parser-source tests.
-- [ ] 7.4 Document implementation gaps before enabling any package-level MLTT selection.
-- [ ] 7.5 Confirm cosmo0-side experiments remain profile-gated and do not expand the default cosmo0 source subset.
+- [x] 7.1 Add `packages/cosmoc` tests for the MLTT profile.
+- [x] 7.2 Add cosmo0 conformance fixtures or Scala mirror tests for the same accepted and rejected examples.
+- [x] 7.3 Confirm the existing `cosmoc.basic-expr` checker remains the default for current parser-source tests.
+- [x] 7.4 Document implementation gaps before enabling any package-level MLTT selection.
+- [x] 7.5 Confirm cosmo0-side experiments remain profile-gated and do not expand the default cosmo0 source subset.

--- a/openspec/changes/introduce-mltt-type-checker/tasks.md
+++ b/openspec/changes/introduce-mltt-type-checker/tasks.md
@@ -5,6 +5,7 @@
 - [x] 1.3 Add short examples for Pi, Sigma, equality, Nat, Vec, and conversion.
 - [x] 1.4 Add a section explaining why effects, traits, and object safety are outside the first MLTT profile.
 - [x] 1.5 Add a section explaining why advanced normalization strategies are deferred to separate research.
+- [x] 1.6 Add a source-tagged MLTT problem ladder that maps supported checker fixtures and future elaboration exercises.
 
 ## 2. Profile Scaffolding
 
@@ -50,3 +51,4 @@
 - [x] 7.3 Confirm the existing `cosmoc.basic-expr` checker remains the default for current parser-source tests.
 - [x] 7.4 Document implementation gaps before enabling any package-level MLTT selection.
 - [x] 7.5 Confirm cosmo0-side experiments remain profile-gated and do not expand the default cosmo0 source subset.
+- [x] 7.6 Add cosmo0 tests that keep the MLTT problem ladder source tags and supported entries executable.

--- a/packages/cosmo/src/test/scala/cosmo/Cosmo1MlttTypeCheckerTests.scala
+++ b/packages/cosmo/src/test/scala/cosmo/Cosmo1MlttTypeCheckerTests.scala
@@ -1,0 +1,61 @@
+package cosmo
+
+class Cosmo1MlttTypeCheckerTests extends TestBase:
+  private val sourceFiles = List(
+    "packages/cosmoc/src/types/profile.cos",
+    "packages/cosmoc/src/types/mltt/core.cos",
+    "packages/cosmoc/src/types/mltt/check.cos",
+    "packages/cosmoc/src/types/mltt/check_test.cos",
+  )
+
+  test("cosmoc MLTT checker source files parse") {
+    for (path <- sourceFiles) {
+      val source = NodeFs.readFileSync(path, "utf8").asInstanceOf[String]
+      val parsed = compiler.parse(source)
+      assert(parsed.isDefined, s"failed to parse MLTT checker source: $path")
+    }
+  }
+
+  test("cosmoc manifest includes MLTT checker implementation slice") {
+    val manifest =
+      NodeFs.readFileSync("packages/cosmoc/cosmo.json", "utf8").asInstanceOf[String]
+
+    assert(manifest.contains("\"types/mltt/core.cos\""))
+    assert(manifest.contains("\"types/mltt/check.cos\""))
+    assert(!manifest.contains("\"types/mltt/check_test.cos\""))
+  }
+
+  test("MLTT checker fixtures cover core data, checking, conversion, and profile diagnostics") {
+    val core =
+      NodeFs.readFileSync("packages/cosmoc/src/types/mltt/core.cos", "utf8").asInstanceOf[String]
+    val checker =
+      NodeFs.readFileSync("packages/cosmoc/src/types/mltt/check.cos", "utf8").asInstanceOf[String]
+    val fixtures =
+      NodeFs.readFileSync("packages/cosmoc/src/types/mltt/check_test.cos", "utf8").asInstanceOf[String]
+
+    assert(core.contains("class MlttTerm"))
+    assert(core.contains("case Pi(String, MlttTermId, MlttTermId)"))
+    assert(core.contains("case Sigma(String, MlttTermId, MlttTermId)"))
+    assert(core.contains("case Eq(MlttTermId, MlttTermId, MlttTermId)"))
+    assert(core.contains("class MlttContextEntry"))
+    assert(core.contains("class MlttInductiveDecl"))
+    assert(core.contains("class MlttMetaVar"))
+    assert(core.contains("def mltt_add_nat_fixture("))
+    assert(core.contains("def mltt_add_vec_fixture("))
+    assert(checker.contains("class MlttConversionResult"))
+    assert(checker.contains("def mltt_check("))
+    assert(checker.contains("def mltt_infer("))
+    assert(checker.contains("def mltt_convert_with_strategy("))
+    assert(checker.contains("def mltt_whnf("))
+    assert(checker.contains("mltt.whnf-conversion"))
+    assert(fixtures.contains("mltt_lambda_checks_against_pi"))
+    assert(fixtures.contains("mltt_application_infers_through_pi"))
+    assert(fixtures.contains("mltt_conversion_accepts_beta_and_let"))
+    assert(fixtures.contains("mltt_conversion_reduces_transparent_nat_definition"))
+    assert(fixtures.contains("mltt_conversion_rejects_effectful_definition"))
+    assert(fixtures.contains("mltt_conversion_rejects_unknown_normalization_profile"))
+    assert(fixtures.contains("mltt_vec_constructor_signatures_check_without_pattern_matching"))
+    assert(fixtures.contains("mltt_nat_and_vec_declaration_metadata_is_deterministic"))
+    assert(fixtures.contains("mltt_metavariables_are_local_and_reportable"))
+  }
+end Cosmo1MlttTypeCheckerTests

--- a/packages/cosmo0/src/main/scala/cosmo0/CheckerProfiles.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/CheckerProfiles.scala
@@ -36,11 +36,15 @@ object CheckerProfiles:
   val ImplementationLimitCode = "cosmo.type.implementation-limit"
 
   val EffectsFeature = "effects"
+  val AsyncFeature = "async"
   val TraitsFeature = "traits"
   val ObjectDispatchFeature = "object-dispatch"
   val DependentPatternsFeature = "dependent-patterns"
   val DependentPatternElaborationFeature = "dependent-pattern-elaboration"
   val CppImportsFeature = "cpp-imports"
+  val MacrosFeature = "macros"
+  val ReflectionFeature = "reflection"
+  val StagingFeature = "staging"
 
   val CosmocBasicExpr: CheckerProfile =
     CheckerProfile(
@@ -97,14 +101,25 @@ object CheckerProfiles:
         "mltt-core-terms",
         "universes",
         "pi-types",
+        "sigma-types",
+        "equality-types",
+        "let-reduction",
+        "nat-metadata",
+        "vec-metadata",
+        "metavariables",
         "conversion",
+        "whnf-conversion",
       ),
       Map(
         EffectsFeature -> UnsupportedEffectRowCode,
+        AsyncFeature -> UnsupportedEffectRowCode,
         TraitsFeature -> UnsupportedTraitConstraintCode,
         ObjectDispatchFeature -> UnsupportedObjectDispatchCode,
         DependentPatternsFeature -> UnsupportedDependentPatternCode,
         CppImportsFeature -> UnsupportedCppImportCode,
+        MacrosFeature -> UnsupportedFeatureCode,
+        ReflectionFeature -> UnsupportedFeatureCode,
+        StagingFeature -> UnsupportedFeatureCode,
       ),
     )
 
@@ -119,7 +134,14 @@ object CheckerProfiles:
         "mltt-core-terms",
         "universes",
         "pi-types",
+        "sigma-types",
+        "equality-types",
+        "let-reduction",
+        "nat-metadata",
+        "vec-metadata",
+        "metavariables",
         "conversion",
+        "whnf-conversion",
         DependentPatternsFeature,
         DependentPatternElaborationFeature,
         "inductive-family-constructors",
@@ -128,9 +150,13 @@ object CheckerProfiles:
       ),
       Map(
         EffectsFeature -> UnsupportedEffectRowCode,
+        AsyncFeature -> UnsupportedEffectRowCode,
         TraitsFeature -> UnsupportedTraitConstraintCode,
         ObjectDispatchFeature -> UnsupportedObjectDispatchCode,
         CppImportsFeature -> UnsupportedCppImportCode,
+        MacrosFeature -> UnsupportedFeatureCode,
+        ReflectionFeature -> UnsupportedFeatureCode,
+        StagingFeature -> UnsupportedFeatureCode,
       ),
     )
 

--- a/packages/cosmo0/src/main/scala/cosmo0/MlttTypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/MlttTypeChecker.scala
@@ -1,0 +1,1028 @@
+package cosmo0
+
+import scala.collection.mutable.ListBuffer
+
+enum MlttTerm:
+  case Var(name: String)
+  case Universe(level: Int)
+  case Pi(name: String, domain: Int, body: Int)
+  case Sigma(name: String, first: Int, second: Int)
+  case Lambda(name: String, annotation: Int, body: Int)
+  case Apply(function: Int, argument: Int)
+  case Pair(first: Int, second: Int)
+  case Fst(pair: Int)
+  case Snd(pair: Int)
+  case Let(name: String, value: Int, body: Int)
+  case Inductive(name: String, params: List[Int], indices: List[Int])
+  case Constructor(name: String, args: List[Int])
+  case Eq(valueType: Int, left: Int, right: Int)
+  case Refl(value: Int)
+  case Neutral(head: String, spine: List[Int])
+  case Meta(index: Int)
+  case Error
+
+final class MlttTermStore:
+  private val terms = ListBuffer.empty[MlttTerm]
+
+  def alloc(value: MlttTerm): Int =
+    val id = terms.length
+    terms += value
+    id
+
+  def termValue(id: Int): MlttTerm =
+    terms(id)
+
+  def allocVar(name: String): Int =
+    alloc(MlttTerm.Var(name))
+
+  def allocUniverse(level: Int): Int =
+    alloc(MlttTerm.Universe(level))
+
+  def allocPi(name: String, domain: Int, body: Int): Int =
+    alloc(MlttTerm.Pi(name, domain, body))
+
+  def allocSigma(name: String, first: Int, second: Int): Int =
+    alloc(MlttTerm.Sigma(name, first, second))
+
+  def allocLambda(name: String, annotation: Int, body: Int): Int =
+    alloc(MlttTerm.Lambda(name, annotation, body))
+
+  def allocApply(function: Int, argument: Int): Int =
+    alloc(MlttTerm.Apply(function, argument))
+
+  def allocPair(first: Int, second: Int): Int =
+    alloc(MlttTerm.Pair(first, second))
+
+  def allocFst(pair: Int): Int =
+    alloc(MlttTerm.Fst(pair))
+
+  def allocSnd(pair: Int): Int =
+    alloc(MlttTerm.Snd(pair))
+
+  def allocLet(name: String, value: Int, body: Int): Int =
+    alloc(MlttTerm.Let(name, value, body))
+
+  def allocInductive(name: String, params: List[Int] = Nil, indices: List[Int] = Nil): Int =
+    alloc(MlttTerm.Inductive(name, params, indices))
+
+  def allocConstructor(name: String, args: List[Int] = Nil): Int =
+    alloc(MlttTerm.Constructor(name, args))
+
+  def allocEq(valueType: Int, left: Int, right: Int): Int =
+    alloc(MlttTerm.Eq(valueType, left, right))
+
+  def allocRefl(value: Int): Int =
+    alloc(MlttTerm.Refl(value))
+
+  def allocNeutral(head: String, spine: List[Int] = Nil): Int =
+    alloc(MlttTerm.Neutral(head, spine))
+
+  def allocMeta(index: Int): Int =
+    alloc(MlttTerm.Meta(index))
+
+  def allocError(): Int =
+    alloc(MlttTerm.Error)
+
+  def size: Int =
+    terms.length
+
+final case class MlttContextEntry(
+    name: String,
+    valueType: Int,
+    value: Option[Int] = None,
+    transparent: Boolean = false,
+    pure: Boolean = true,
+    universeLevel: Int = 0,
+)
+
+final case class MlttContext(entries: List[MlttContextEntry] = Nil):
+  def lookup(name: String): Option[MlttContextEntry] =
+    entries.reverse.find(_.name == name)
+
+  def extendLocal(name: String, valueType: Int): MlttContext =
+    copy(entries = entries :+ MlttContextEntry(name, valueType))
+
+  def extendDefinition(
+      name: String,
+      valueType: Int,
+      value: Int,
+      transparent: Boolean,
+      pure: Boolean,
+  ): MlttContext =
+    copy(entries = entries :+ MlttContextEntry(name, valueType, Some(value), transparent, pure))
+
+  def summary: String =
+    if entries.isEmpty then "<empty>" else entries.map(_.name).mkString(", ")
+
+final case class MlttBinder(name: String, valueType: Int)
+
+final case class MlttDefinitionDecl(
+    name: String,
+    valueType: Int,
+    value: Int,
+    transparent: Boolean,
+    pure: Boolean,
+)
+
+final case class MlttConstructorDecl(
+    name: String,
+    telescope: List[MlttBinder],
+    result: Int,
+)
+
+final case class MlttInductiveDecl(
+    name: String,
+    parameters: List[MlttBinder],
+    indices: List[MlttBinder],
+    constructors: List[MlttConstructorDecl],
+)
+
+final class MlttDeclarationEnv:
+  private val definitions = ListBuffer.empty[MlttDefinitionDecl]
+  private val inductives = ListBuffer.empty[MlttInductiveDecl]
+
+  def addDefinition(decl: MlttDefinitionDecl): Unit =
+    definitions += decl
+
+  def addInductive(decl: MlttInductiveDecl): Unit =
+    inductives += decl
+
+  def findDefinition(name: String): Option[MlttDefinitionDecl] =
+    definitions.find(_.name == name)
+
+  def findInductive(name: String): Option[MlttInductiveDecl] =
+    inductives.find(_.name == name)
+
+  def findConstructor(name: String): Option[MlttConstructorDecl] =
+    inductives.iterator
+      .flatMap(_.constructors.iterator)
+      .find(_.name == name)
+
+final case class MlttMetaVar(
+    id: Int,
+    contextSummary: String,
+    expectedType: Int,
+    solution: Option[Int] = None,
+)
+
+final class MlttMetaStore:
+  private val metas = ListBuffer.empty[MlttMetaVar]
+
+  def newMeta(context: MlttContext, expectedType: Int): Int =
+    val id = metas.length
+    metas += MlttMetaVar(id, context.summary, expectedType)
+    id
+
+  def solveExact(id: Int, value: Int): Boolean =
+    if id < 0 || id >= metas.length then return false
+    val current = metas(id)
+    metas.update(id, current.copy(solution = Some(value)))
+    true
+
+  def hasUnsolvedPublicMeta: Boolean =
+    metas.exists(_.solution.isEmpty)
+
+  def all: List[MlttMetaVar] =
+    metas.toList
+
+final case class MlttDiagnostic(
+    code: String,
+    message: String,
+    span: Option[SourceSpan],
+    profileId: String,
+    contextSummary: String,
+    expected: String,
+    actual: String,
+)
+
+final case class MlttConversionResult(
+    ok: Boolean,
+    strategy: String,
+    diagnostics: List[MlttDiagnostic],
+):
+  def isOk: Boolean =
+    ok && diagnostics.isEmpty
+
+  def firstCode: String =
+    diagnostics.headOption.map(_.code).getOrElse("")
+
+final case class MlttInferResult(
+    profileId: String,
+    artifactKind: String,
+    term: Int,
+    valueType: Int,
+    diagnostics: List[MlttDiagnostic],
+    normalizationStrategy: String,
+):
+  def isOk: Boolean =
+    diagnostics.isEmpty
+
+  def firstCode: String =
+    diagnostics.headOption.map(_.code).getOrElse("")
+
+final case class MlttCheckResult(
+    profileId: String,
+    artifactKind: String,
+    term: Int,
+    valueType: Int,
+    diagnostics: List[MlttDiagnostic],
+    metas: MlttMetaStore,
+    status: String,
+    normalizationStrategy: String,
+):
+  def isOk: Boolean =
+    diagnostics.isEmpty
+
+  def firstCode: String =
+    diagnostics.headOption.map(_.code).getOrElse("")
+
+  def artifactSummary: String =
+    s"$profileId|$artifactKind|$status|$normalizationStrategy"
+
+object MlttTypeChecker:
+  val WhnfConversionStrategy = "mltt.whnf-conversion"
+  val UnknownVariableCode = "cosmo.type.mltt.unknown-variable"
+  val NonFunctionApplicationCode = "cosmo.type.mltt.non-function-application"
+  val UniverseMismatchCode = "cosmo.type.mltt.universe-mismatch"
+  val TypeMismatchCode = "cosmo.type.mltt.type-mismatch"
+  val UnsolvedConstraintCode = "cosmo.type.mltt.unsolved-constraint"
+  val UnsupportedNormalizationProfileCode = "cosmo.type.mltt.unsupported-normalization-profile"
+  val EffectfulConversionCode = "cosmo.type.mltt.effectful-conversion"
+  val UnsupportedInferenceCode = "cosmo.type.mltt.unsupported-inference"
+  val HigherOrderUnificationCode = "cosmo.type.mltt.higher-order-unification"
+
+  def termStore(): MlttTermStore =
+    MlttTermStore()
+
+  def context(): MlttContext =
+    MlttContext()
+
+  def declarationEnv(): MlttDeclarationEnv =
+    MlttDeclarationEnv()
+
+  def metaStore(): MlttMetaStore =
+    MlttMetaStore()
+
+  def infer(store: MlttTermStore, context: MlttContext, term: Int): MlttInferResult =
+    val diagnostics = ListBuffer.empty[MlttDiagnostic]
+    val valueType = inferTerm(store, context, term, diagnostics)
+    MlttInferResult(
+      CheckerProfiles.MlttCore.id,
+      CheckerProfiles.MlttCore.artifactKind,
+      term,
+      valueType,
+      diagnostics.toList,
+      WhnfConversionStrategy,
+    )
+
+  def check(store: MlttTermStore, context: MlttContext, term: Int, expected: Int): MlttCheckResult =
+    val diagnostics = ListBuffer.empty[MlttDiagnostic]
+    val metas = metaStore()
+    val valueType = checkTerm(store, context, term, expected, diagnostics)
+    reportUnsolvedMetas(context, metas, diagnostics)
+    MlttCheckResult(
+      CheckerProfiles.MlttCore.id,
+      CheckerProfiles.MlttCore.artifactKind,
+      term,
+      valueType,
+      diagnostics.toList,
+      metas,
+      if diagnostics.isEmpty then "accepted" else "rejected",
+      WhnfConversionStrategy,
+    )
+
+  def convert(
+      store: MlttTermStore,
+      context: MlttContext,
+      left: Int,
+      right: Int,
+      strategy: String = WhnfConversionStrategy,
+  ): MlttConversionResult =
+    val diagnostics = ListBuffer.empty[MlttDiagnostic]
+    if strategy != WhnfConversionStrategy then
+      diagnostics += diagnostic(
+        UnsupportedNormalizationProfileCode,
+        s"checker profile mltt.core does not implement normalization profile $strategy",
+        context,
+        WhnfConversionStrategy,
+        strategy,
+      )
+      return MlttConversionResult(ok = false, strategy, diagnostics.toList)
+
+    val ok = convertTerms(store, context, left, right, diagnostics)
+    if !ok && diagnostics.isEmpty then
+      diagnostics += diagnostic(
+        TypeMismatchCode,
+        "types are not definitionally equal after allowed normalization",
+        context,
+        display(store, left),
+        display(store, right),
+      )
+    MlttConversionResult(ok, strategy, diagnostics.toList)
+
+  def higherOrderUnificationDiagnostic(context: MlttContext): MlttDiagnostic =
+    diagnostic(
+      HigherOrderUnificationCode,
+      "arbitrary higher-order unification is outside mltt.core",
+      context,
+      "first-order pattern constraint",
+      "higher-order constraint",
+    )
+
+  def addNatFixture(store: MlttTermStore, env: MlttDeclarationEnv): Unit =
+    val type0 = store.allocUniverse(0)
+    val nat = store.allocInductive("Nat")
+    val z = MlttConstructorDecl("Z", Nil, nat)
+    val s = MlttConstructorDecl("S", List(MlttBinder("pred", nat)), nat)
+    env.addInductive(MlttInductiveDecl("Nat", Nil, Nil, List(z, s)))
+    env.addDefinition(MlttDefinitionDecl("Nat", type0, nat, transparent = true, pure = true))
+
+  def addVecFixture(store: MlttTermStore, env: MlttDeclarationEnv): Unit =
+    val type0 = store.allocUniverse(0)
+    val nat = store.allocInductive("Nat")
+    val a = store.allocVar("A")
+    val n = store.allocVar("n")
+    val k = store.allocVar("k")
+    val z = store.allocConstructor("Z")
+    val sK = store.allocConstructor("S", List(k))
+    val nilResult = store.allocInductive("Vec", List(a), List(z))
+    val tailType = store.allocInductive("Vec", List(a), List(k))
+    val consResult = store.allocInductive("Vec", List(a), List(sK))
+    val nil = MlttConstructorDecl("Nil", Nil, nilResult)
+    val cons =
+      MlttConstructorDecl(
+        "Cons",
+        List(
+          MlttBinder("k", nat),
+          MlttBinder("head", a),
+          MlttBinder("tail", tailType),
+        ),
+        consResult,
+      )
+    env.addInductive(
+      MlttInductiveDecl(
+        "Vec",
+        List(MlttBinder("A", type0)),
+        List(MlttBinder("n", nat)),
+        List(nil, cons),
+      ),
+    )
+    env.addDefinition(
+      MlttDefinitionDecl(
+        "Vec",
+        type0,
+        store.allocInductive("Vec", List(a), List(n)),
+        transparent = true,
+        pure = true,
+      ),
+    )
+
+  def display(store: MlttTermStore, id: Int): String =
+    store.termValue(id) match
+      case MlttTerm.Var(name) => name
+      case MlttTerm.Universe(level) => s"Type$level"
+      case MlttTerm.Pi(name, domain, body) =>
+        s"($name: ${display(store, domain)}) -> ${display(store, body)}"
+      case MlttTerm.Sigma(name, first, second) =>
+        s"Sigma($name: ${display(store, first)}). ${display(store, second)}"
+      case MlttTerm.Lambda(name, annotation, body) =>
+        s"fun $name: ${display(store, annotation)} => ${display(store, body)}"
+      case MlttTerm.Apply(function, argument) =>
+        s"${display(store, function)}(${display(store, argument)})"
+      case MlttTerm.Pair(first, second) =>
+        s"(${display(store, first)}, ${display(store, second)})"
+      case MlttTerm.Fst(pair) =>
+        s"fst(${display(store, pair)})"
+      case MlttTerm.Snd(pair) =>
+        s"snd(${display(store, pair)})"
+      case MlttTerm.Let(name, value, body) =>
+        s"let $name = ${display(store, value)}; ${display(store, body)}"
+      case MlttTerm.Inductive(name, params, indices) =>
+        headDisplay(store, name, params ::: indices)
+      case MlttTerm.Constructor(name, args) =>
+        headDisplay(store, name, args)
+      case MlttTerm.Eq(valueType, left, right) =>
+        s"Eq(${display(store, valueType)}, ${display(store, left)}, ${display(store, right)})"
+      case MlttTerm.Refl(value) =>
+        s"Refl(${display(store, value)})"
+      case MlttTerm.Neutral(head, spine) =>
+        headDisplay(store, head, spine)
+      case MlttTerm.Meta(index) =>
+        s"?m$index"
+      case MlttTerm.Error =>
+        "<error>"
+
+  private def headDisplay(store: MlttTermStore, name: String, args: List[Int]): String =
+    if args.isEmpty then name
+    else s"$name(${args.map(display(store, _)).mkString(", ")})"
+
+  private def diagnostic(
+      code: String,
+      message: String,
+      context: MlttContext,
+      expected: String,
+      actual: String,
+      span: Option[SourceSpan] = None,
+  ): MlttDiagnostic =
+    MlttDiagnostic(
+      code,
+      message,
+      span,
+      CheckerProfiles.MlttCore.id,
+      context.summary,
+      expected,
+      actual,
+    )
+
+  private def inferTerm(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    store.termValue(term) match
+      case MlttTerm.Var(name) =>
+        inferVar(store, context, name, diagnostics)
+      case MlttTerm.Universe(level) =>
+        store.allocUniverse(level + 1)
+      case MlttTerm.Pi(name, domain, body) =>
+        inferPiLike(store, context, name, domain, body, diagnostics)
+      case MlttTerm.Sigma(name, first, second) =>
+        inferPiLike(store, context, name, first, second, diagnostics)
+      case MlttTerm.Lambda(name, annotation, body) =>
+        inferLambda(store, context, name, annotation, body, diagnostics)
+      case MlttTerm.Apply(function, argument) =>
+        inferApply(store, context, term, function, argument, diagnostics)
+      case MlttTerm.Pair(_, _) =>
+        diagnostics += diagnostic(
+          UnsupportedInferenceCode,
+          "pair inference requires an expected Sigma type",
+          context,
+          "Sigma",
+          display(store, term),
+        )
+        store.allocError()
+      case MlttTerm.Fst(pair) =>
+        inferProjection(store, context, term, pair, diagnostics, first = true)
+      case MlttTerm.Snd(pair) =>
+        inferProjection(store, context, term, pair, diagnostics, first = false)
+      case MlttTerm.Let(name, value, body) =>
+        val valueType = inferTerm(store, context, value, diagnostics)
+        inferTerm(store, context.extendDefinition(name, valueType, value, transparent = true, pure = true), body, diagnostics)
+      case MlttTerm.Inductive(_, _, _) =>
+        store.allocUniverse(0)
+      case MlttTerm.Constructor(name, args) =>
+        inferConstructor(store, context, term, name, args, diagnostics)
+      case MlttTerm.Eq(valueType, left, right) =>
+        inferEq(store, context, valueType, left, right, diagnostics)
+      case MlttTerm.Refl(_) =>
+        diagnostics += diagnostic(
+          UnsupportedInferenceCode,
+          "Refl inference requires an expected equality type",
+          context,
+          "Eq",
+          display(store, term),
+        )
+        store.allocError()
+      case MlttTerm.Neutral(head, _) =>
+        diagnostics += diagnostic(
+          UnsupportedInferenceCode,
+          "neutral term inference requires an elaborated type annotation",
+          context,
+          "annotated neutral",
+          head,
+        )
+        store.allocError()
+      case MlttTerm.Meta(_) =>
+        diagnostics += diagnostic(
+          UnsolvedConstraintCode,
+          "metavariable cannot be inferred until it is solved",
+          context,
+          "solved metavariable",
+          display(store, term),
+        )
+        store.allocError()
+      case MlttTerm.Error =>
+        store.allocError()
+
+  private def inferVar(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    context.lookup(name) match
+      case Some(entry) => entry.valueType
+      case None =>
+        diagnostics += diagnostic(
+          UnknownVariableCode,
+          s"unknown variable $name",
+          context,
+          "bound local",
+          name,
+        )
+        store.allocError()
+
+  private def inferPiLike(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      domain: Int,
+      body: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    val domainType = inferTerm(store, context, domain, diagnostics)
+    val bodyType = inferTerm(store, context.extendLocal(name, domain), body, diagnostics)
+    val domainLevel = typeUniverseLevel(store, domainType)
+    val bodyLevel = typeUniverseLevel(store, bodyType)
+    (domainLevel, bodyLevel) match
+      case (Some(left), Some(right)) =>
+        store.allocUniverse(left.max(right))
+      case (None, _) =>
+        universeMismatch(store, context, domainType, diagnostics)
+        store.allocError()
+      case (_, None) =>
+        universeMismatch(store, context, bodyType, diagnostics)
+        store.allocError()
+
+  private def inferLambda(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      annotation: Int,
+      body: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    val annotationType = inferTerm(store, context, annotation, diagnostics)
+    if typeUniverseLevel(store, annotationType).isEmpty then
+      universeMismatch(store, context, annotationType, diagnostics)
+    val bodyType = inferTerm(store, context.extendLocal(name, annotation), body, diagnostics)
+    store.allocPi(name, annotation, bodyType)
+
+  private def inferApply(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      function: Int,
+      argument: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    val functionType = inferTerm(store, context, function, diagnostics)
+    val functionWhnf = whnf(store, context, functionType, diagnostics)
+    store.termValue(functionWhnf) match
+      case MlttTerm.Pi(name, domain, body) =>
+        checkTerm(store, context, argument, domain, diagnostics)
+        substitute(store, body, name, argument)
+      case MlttTerm.Error =>
+        store.allocError()
+      case _ =>
+        diagnostics += diagnostic(
+          NonFunctionApplicationCode,
+          "application callee does not have a Pi type",
+          context,
+          "Pi",
+          display(store, functionWhnf),
+        )
+        store.allocError()
+
+  private def inferProjection(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      pair: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+      first: Boolean,
+  ): Int =
+    val pairType = whnf(store, context, inferTerm(store, context, pair, diagnostics), diagnostics)
+    store.termValue(pairType) match
+      case MlttTerm.Sigma(name, firstType, secondType) =>
+        if first then firstType else substitute(store, secondType, name, store.allocFst(pair))
+      case MlttTerm.Error =>
+        store.allocError()
+      case _ =>
+        diagnostics += diagnostic(
+          TypeMismatchCode,
+          "projection target does not have a Sigma type",
+          context,
+          "Sigma",
+          display(store, pairType),
+        )
+        store.allocError()
+
+  private def inferConstructor(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      name: String,
+      args: List[Int],
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    if name == "Z" && args.isEmpty then return store.allocInductive("Nat")
+    if name == "S" && args.length == 1 then
+      val nat = store.allocInductive("Nat")
+      checkTerm(store, context, args.head, nat, diagnostics)
+      return nat
+    diagnostics += diagnostic(
+      UnsupportedInferenceCode,
+      "constructor inference requires an expected inductive family",
+      context,
+      "constructor type",
+      display(store, term),
+    )
+    store.allocError()
+
+  private def inferEq(
+      store: MlttTermStore,
+      context: MlttContext,
+      valueType: Int,
+      left: Int,
+      right: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    val valueTypeType = inferTerm(store, context, valueType, diagnostics)
+    if typeUniverseLevel(store, valueTypeType).isEmpty then
+      universeMismatch(store, context, valueTypeType, diagnostics)
+    checkTerm(store, context, left, valueType, diagnostics)
+    checkTerm(store, context, right, valueType, diagnostics)
+    store.allocUniverse(0)
+
+  private def checkTerm(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      expected: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Int =
+    val expectedWhnf = whnf(store, context, expected, diagnostics)
+    store.termValue(term) match
+      case MlttTerm.Lambda(name, _, body) if checkLambda(store, context, name, body, expectedWhnf, diagnostics) =>
+        return expected
+      case MlttTerm.Pair(first, second) if checkPair(store, context, first, second, expectedWhnf, diagnostics) =>
+        return expected
+      case MlttTerm.Refl(value) if checkRefl(store, context, value, expectedWhnf, diagnostics) =>
+        return expected
+      case MlttTerm.Constructor(name, args) if checkConstructor(store, context, name, args, expectedWhnf, diagnostics) =>
+        return expected
+      case MlttTerm.Error =>
+        return store.allocError()
+      case _ =>
+
+    val inferred = inferTerm(store, context, term, diagnostics)
+    val converted = convert(store, context, inferred, expected)
+    diagnostics ++= converted.diagnostics
+    if !converted.isOk then
+      diagnostics += diagnostic(
+        TypeMismatchCode,
+        "type mismatch",
+        context,
+        display(store, expected),
+        display(store, inferred),
+      )
+    expected
+
+  private def checkLambda(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      body: Int,
+      expected: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    store.termValue(expected) match
+      case MlttTerm.Pi(expectedName, domain, codomain) =>
+        val bodyType = substitute(store, codomain, expectedName, store.allocVar(name))
+        checkTerm(store, context.extendLocal(name, domain), body, bodyType, diagnostics)
+        true
+      case MlttTerm.Error => true
+      case _ => false
+
+  private def checkPair(
+      store: MlttTermStore,
+      context: MlttContext,
+      first: Int,
+      second: Int,
+      expected: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    store.termValue(expected) match
+      case MlttTerm.Sigma(name, firstType, secondType) =>
+        checkTerm(store, context, first, firstType, diagnostics)
+        checkTerm(store, context, second, substitute(store, secondType, name, first), diagnostics)
+        true
+      case MlttTerm.Error => true
+      case _ => false
+
+  private def checkRefl(
+      store: MlttTermStore,
+      context: MlttContext,
+      value: Int,
+      expected: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    store.termValue(expected) match
+      case MlttTerm.Eq(valueType, left, right) =>
+        checkTerm(store, context, value, valueType, diagnostics)
+        val leftOk = convert(store, context, value, left)
+        val rightOk = convert(store, context, value, right)
+        diagnostics ++= leftOk.diagnostics
+        diagnostics ++= rightOk.diagnostics
+        leftOk.isOk && rightOk.isOk
+      case MlttTerm.Error => true
+      case _ => false
+
+  private def checkConstructor(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      args: List[Int],
+      expected: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    store.termValue(expected) match
+      case MlttTerm.Inductive("Nat", _, _) =>
+        checkNatConstructor(store, context, name, args, expected, diagnostics)
+      case MlttTerm.Inductive("Vec", params, indices) =>
+        checkVecConstructor(store, context, name, args, params, indices, diagnostics)
+      case MlttTerm.Error => true
+      case _ => false
+
+  private def checkNatConstructor(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      args: List[Int],
+      expected: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    if name == "Z" && args.isEmpty then true
+    else if name == "S" && args.length == 1 then
+      checkTerm(store, context, args.head, expected, diagnostics)
+      true
+    else false
+
+  private def checkVecConstructor(
+      store: MlttTermStore,
+      context: MlttContext,
+      name: String,
+      args: List[Int],
+      params: List[Int],
+      indices: List[Int],
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    if params.length != 1 || indices.length != 1 then return false
+    if name == "Nil" && args.isEmpty then return isConstructor(store, indices.head, "Z", 0)
+    if name == "Cons" && args.length == 3 then
+      return checkVecConsConstructor(store, context, args, params.head, indices.head, diagnostics)
+    false
+
+  private def checkVecConsConstructor(
+      store: MlttTermStore,
+      context: MlttContext,
+      args: List[Int],
+      elementType: Int,
+      index: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    store.termValue(index) match
+      case MlttTerm.Constructor("S", predecessor :: Nil) =>
+        val nat = store.allocInductive("Nat")
+        checkTerm(store, context, args(0), nat, diagnostics)
+        checkTerm(store, context, args(1), elementType, diagnostics)
+        val tailType = store.allocInductive("Vec", List(elementType), List(predecessor))
+        checkTerm(store, context, args(2), tailType, diagnostics)
+        val lengthOk = convert(store, context, args(0), predecessor)
+        diagnostics ++= lengthOk.diagnostics
+        lengthOk.isOk
+      case _ => false
+
+  private def isConstructor(store: MlttTermStore, term: Int, name: String, arity: Int): Boolean =
+    store.termValue(term) match
+      case MlttTerm.Constructor(ctorName, args) => ctorName == name && args.length == arity
+      case _ => false
+
+  private def convertTerms(
+      store: MlttTermStore,
+      context: MlttContext,
+      left: Int,
+      right: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    if sameTerm(store, left, right) then return true
+    val leftWhnf = whnf(store, context, left, diagnostics)
+    val rightWhnf = whnf(store, context, right, diagnostics)
+    if sameTerm(store, leftWhnf, rightWhnf) then return true
+
+    (store.termValue(leftWhnf), store.termValue(rightWhnf)) match
+      case (MlttTerm.Pi(_, leftDomain, leftBody), MlttTerm.Pi(_, rightDomain, rightBody)) =>
+        convertTerms(store, context, leftDomain, rightDomain, diagnostics) &&
+          convertTerms(store, context, leftBody, rightBody, diagnostics)
+      case (MlttTerm.Sigma(_, leftFirst, leftSecond), MlttTerm.Sigma(_, rightFirst, rightSecond)) =>
+        convertTerms(store, context, leftFirst, rightFirst, diagnostics) &&
+          convertTerms(store, context, leftSecond, rightSecond, diagnostics)
+      case (MlttTerm.Apply(leftFunction, leftArgument), MlttTerm.Apply(rightFunction, rightArgument)) =>
+        convertTerms(store, context, leftFunction, rightFunction, diagnostics) &&
+          convertTerms(store, context, leftArgument, rightArgument, diagnostics)
+      case (MlttTerm.Inductive(leftName, leftParams, leftIndices), MlttTerm.Inductive(rightName, rightParams, rightIndices)) =>
+        leftName == rightName &&
+          convertTermLists(store, context, leftParams, rightParams, diagnostics) &&
+          convertTermLists(store, context, leftIndices, rightIndices, diagnostics)
+      case (MlttTerm.Constructor(leftName, leftArgs), MlttTerm.Constructor(rightName, rightArgs)) =>
+        leftName == rightName && convertTermLists(store, context, leftArgs, rightArgs, diagnostics)
+      case (MlttTerm.Eq(leftType, leftLeft, leftRight), MlttTerm.Eq(rightType, rightLeft, rightRight)) =>
+        convertTerms(store, context, leftType, rightType, diagnostics) &&
+          convertTerms(store, context, leftLeft, rightLeft, diagnostics) &&
+          convertTerms(store, context, leftRight, rightRight, diagnostics)
+      case (MlttTerm.Error, _) | (_, MlttTerm.Error) => true
+      case _ => false
+
+  private def convertTermLists(
+      store: MlttTermStore,
+      context: MlttContext,
+      left: List[Int],
+      right: List[Int],
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Boolean =
+    left.length == right.length &&
+      left.zip(right).forall { case (leftTerm, rightTerm) =>
+        convertTerms(store, context, leftTerm, rightTerm, diagnostics)
+      }
+
+  private def whnf(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+      fuel: Int = 64,
+  ): Int =
+    if fuel <= 0 then return term
+    store.termValue(term) match
+      case MlttTerm.Var(name) =>
+        whnfVar(store, context, term, name, diagnostics, fuel)
+      case MlttTerm.Apply(function, argument) =>
+        whnfApply(store, context, term, function, argument, diagnostics, fuel)
+      case MlttTerm.Let(name, value, body) =>
+        whnf(store, context, substitute(store, body, name, value), diagnostics, fuel - 1)
+      case MlttTerm.Fst(pair) =>
+        whnfFst(store, context, term, pair, diagnostics, fuel)
+      case MlttTerm.Snd(pair) =>
+        whnfSnd(store, context, term, pair, diagnostics, fuel)
+      case _ => term
+
+  private def whnfVar(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      name: String,
+      diagnostics: ListBuffer[MlttDiagnostic],
+      fuel: Int,
+  ): Int =
+    context.lookup(name).flatMap(_.value) match
+      case Some(value) =>
+        val entry = context.lookup(name).get
+        if entry.transparent && entry.pure then whnf(store, context, value, diagnostics, fuel - 1)
+        else
+          diagnostics += diagnostic(
+            EffectfulConversionCode,
+            "conversion cannot reduce an opaque or effectful definition",
+            context,
+            "transparent pure definition",
+            name,
+          )
+          term
+      case None => term
+
+  private def whnfApply(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      function: Int,
+      argument: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+      fuel: Int,
+  ): Int =
+    store.termValue(whnf(store, context, function, diagnostics, fuel - 1)) match
+      case MlttTerm.Lambda(name, _, body) =>
+        whnf(store, context, substitute(store, body, name, argument), diagnostics, fuel - 1)
+      case _ => term
+
+  private def whnfFst(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      pair: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+      fuel: Int,
+  ): Int =
+    store.termValue(whnf(store, context, pair, diagnostics, fuel - 1)) match
+      case MlttTerm.Pair(first, _) => whnf(store, context, first, diagnostics, fuel - 1)
+      case _ => term
+
+  private def whnfSnd(
+      store: MlttTermStore,
+      context: MlttContext,
+      term: Int,
+      pair: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+      fuel: Int,
+  ): Int =
+    store.termValue(whnf(store, context, pair, diagnostics, fuel - 1)) match
+      case MlttTerm.Pair(_, second) => whnf(store, context, second, diagnostics, fuel - 1)
+      case _ => term
+
+  private def substitute(store: MlttTermStore, term: Int, name: String, replacement: Int): Int =
+    store.termValue(term) match
+      case MlttTerm.Var(varName) =>
+        if varName == name then replacement else store.allocVar(varName)
+      case MlttTerm.Universe(level) =>
+        store.allocUniverse(level)
+      case MlttTerm.Pi(param, domain, body) =>
+        val nextDomain = substitute(store, domain, name, replacement)
+        val nextBody = if param == name then body else substitute(store, body, name, replacement)
+        store.allocPi(param, nextDomain, nextBody)
+      case MlttTerm.Sigma(param, first, second) =>
+        val nextFirst = substitute(store, first, name, replacement)
+        val nextSecond = if param == name then second else substitute(store, second, name, replacement)
+        store.allocSigma(param, nextFirst, nextSecond)
+      case MlttTerm.Lambda(param, annotation, body) =>
+        val nextAnnotation = substitute(store, annotation, name, replacement)
+        val nextBody = if param == name then body else substitute(store, body, name, replacement)
+        store.allocLambda(param, nextAnnotation, nextBody)
+      case MlttTerm.Apply(function, argument) =>
+        store.allocApply(
+          substitute(store, function, name, replacement),
+          substitute(store, argument, name, replacement),
+        )
+      case MlttTerm.Pair(first, second) =>
+        store.allocPair(
+          substitute(store, first, name, replacement),
+          substitute(store, second, name, replacement),
+        )
+      case MlttTerm.Fst(pair) =>
+        store.allocFst(substitute(store, pair, name, replacement))
+      case MlttTerm.Snd(pair) =>
+        store.allocSnd(substitute(store, pair, name, replacement))
+      case MlttTerm.Let(localName, value, body) =>
+        val nextValue = substitute(store, value, name, replacement)
+        val nextBody = if localName == name then body else substitute(store, body, name, replacement)
+        store.allocLet(localName, nextValue, nextBody)
+      case MlttTerm.Inductive(inductiveName, params, indices) =>
+        store.allocInductive(
+          inductiveName,
+          params.map(substitute(store, _, name, replacement)),
+          indices.map(substitute(store, _, name, replacement)),
+        )
+      case MlttTerm.Constructor(ctorName, args) =>
+        store.allocConstructor(ctorName, args.map(substitute(store, _, name, replacement)))
+      case MlttTerm.Eq(valueType, left, right) =>
+        store.allocEq(
+          substitute(store, valueType, name, replacement),
+          substitute(store, left, name, replacement),
+          substitute(store, right, name, replacement),
+        )
+      case MlttTerm.Refl(value) =>
+        store.allocRefl(substitute(store, value, name, replacement))
+      case MlttTerm.Neutral(head, spine) =>
+        store.allocNeutral(head, spine.map(substitute(store, _, name, replacement)))
+      case MlttTerm.Meta(index) =>
+        store.allocMeta(index)
+      case MlttTerm.Error =>
+        store.allocError()
+
+  private def sameTerm(store: MlttTermStore, left: Int, right: Int): Boolean =
+    display(store, left) == display(store, right)
+
+  private def universeLevelOfTerm(store: MlttTermStore, id: Int): Option[Int] =
+    store.termValue(id) match
+      case MlttTerm.Universe(level) => Some(level)
+      case _ => None
+
+  private def typeUniverseLevel(store: MlttTermStore, inferredType: Int): Option[Int] =
+    universeLevelOfTerm(store, inferredType).map(level => (level - 1).max(0))
+
+  private def universeMismatch(
+      store: MlttTermStore,
+      context: MlttContext,
+      actual: Int,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Unit =
+    diagnostics += diagnostic(
+      UniverseMismatchCode,
+      "expected a universe-classified type",
+      context,
+      "Type",
+      display(store, actual),
+    )
+
+  private def reportUnsolvedMetas(
+      context: MlttContext,
+      metas: MlttMetaStore,
+      diagnostics: ListBuffer[MlttDiagnostic],
+  ): Unit =
+    if metas.hasUnsolvedPublicMeta then
+      diagnostics += diagnostic(
+        UnsolvedConstraintCode,
+        "checking completed with an unsolved metavariable",
+        context,
+        "solved constraints",
+        "unsolved metavariable",
+      )

--- a/packages/cosmo0/src/test/scala/cosmo0/CheckerProfileTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/CheckerProfileTests.scala
@@ -24,10 +24,18 @@ class CheckerProfileTests extends munit.FunSuite:
 
     assertEquals(mltt.id, "mltt.core")
     assertEquals(mltt.artifactKind, "mltt-core-term")
+    assert(mltt.supports("sigma-types"))
+    assert(mltt.supports("equality-types"))
+    assert(mltt.supports("whnf-conversion"))
     assertEquals(
       mltt.rejectedFeatureCode(CheckerProfiles.ObjectDispatchFeature),
       CheckerProfiles.UnsupportedObjectDispatchCode,
     )
+    assertEquals(
+      mltt.rejectedFeatureCode(CheckerProfiles.AsyncFeature),
+      CheckerProfiles.UnsupportedEffectRowCode,
+    )
+    assert(mltt.rejects(CheckerProfiles.StagingFeature))
     assert(!mltt.supports(CheckerProfiles.DependentPatternElaborationFeature))
     assertEquals(dependent.id, "mltt.dependent-patterns")
     assertEquals(dependent.artifactKind, "mltt-case-tree")
@@ -108,6 +116,19 @@ class CheckerProfileTests extends munit.FunSuite:
     assertEquals(result.phase, Phase.Check)
     assertEquals(result.status, PhaseStatus.Unsupported)
     assertEquals(result.diagnostics.head.code, CheckerProfiles.UnsupportedObjectDispatchCode)
+
+  test("fixture metadata can select the experimental MLTT profile"):
+    val loaded = Cosmo0().loadPackage("fixtures/cosmo0/package/mltt-core-profile")
+
+    assertEquals(loaded.phase, Phase.Check)
+    assert(loaded.isSuccess, s"MLTT profile fixture failed to load: ${loaded.diagnostics}")
+    assertEquals(loaded.value.get.metadata.checkerProfile, Some(CheckerProfiles.MlttCore.id))
+
+    val checked = Cosmo0().checkPackage(loaded.value.get)
+
+    assertEquals(checked.phase, Phase.Check)
+    assertEquals(checked.status, PhaseStatus.Unsupported)
+    assertEquals(checked.diagnostics.head.code, CheckerProfiles.UnsupportedObjectDispatchCode)
 
   test("typed artifact profile summary is deterministic"):
     val first = Cosmo0().check("val answer = 42").value.get.typed.checkerArtifactSummary

--- a/packages/cosmo0/src/test/scala/cosmo0/Cosmo1MlttTypeCheckerTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/Cosmo1MlttTypeCheckerTests.scala
@@ -1,0 +1,134 @@
+package cosmo0
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+class Cosmo1MlttTypeCheckerTests extends munit.FunSuite:
+  private val spanPath = "packages/cosmoc/src/source/span.cos"
+  private val profilePath = "packages/cosmoc/src/types/profile.cos"
+  private val corePath = "packages/cosmoc/src/types/mltt/core.cos"
+  private val checkPath = "packages/cosmoc/src/types/mltt/check.cos"
+  private val checkTestPath = "packages/cosmoc/src/types/mltt/check_test.cos"
+
+  test("cosmo1 MLTT checker source compiles"):
+    val source = combineSources(
+      List(
+        spanPath,
+        profilePath,
+        corePath,
+        checkPath,
+        checkTestPath,
+      ),
+    )
+
+    val compiled = Cosmo0().compile(SourceFile(checkTestPath, source))
+
+    assertEquals(compiled.phase, Phase.Compile)
+    assert(
+      compiled.isSuccess,
+      s"cosmo1 MLTT checker compile failed with diagnostics: ${compiled.diagnostics.map(d => (d.code, d.message, d.span.map(span => span.start -> span.end)))}",
+    )
+    val output = compiled.value.get.output
+    assert(output.contains("struct MlttTerm"))
+    assert(output.contains("struct MlttContextEntry"))
+    assert(output.contains("struct MlttInductiveDecl"))
+    assert(output.contains("struct MlttConversionResult"))
+    assert(output.contains("inline MlttCheckResult mltt_check("))
+    assert(output.contains("inline MlttInferResult mltt_infer("))
+    assert(output.contains("inline MlttConversionResult mltt_convert_with_strategy("))
+    assert(output.contains("inline bool mltt_lambda_checks_against_pi()"))
+    assert(output.contains("inline bool mltt_conversion_accepts_beta_and_let()"))
+    assert(output.contains("inline bool mltt_conversion_reduces_transparent_nat_definition()"))
+    assert(output.contains("inline bool mltt_conversion_rejects_effectful_definition()"))
+    assert(output.contains("inline bool mltt_vec_constructor_signatures_check_without_pattern_matching()"))
+    assert(output.contains("inline bool mltt_nat_and_vec_declaration_metadata_is_deterministic()"))
+    assert(output.contains("cosmo.type.mltt.unsupported-normalization-profile"))
+    assert(output.contains("cosmo.type.mltt.effectful-conversion"))
+    assert(output.contains("mltt.whnf-conversion"))
+    assert(output.contains("int main()"))
+
+  test("cosmo1 MLTT checker fixture executable passes"):
+    val compiled = compileMlttTestProgram()
+
+    assert(
+      compiled.isSuccess,
+      s"cosmo1 MLTT checker compile failed with diagnostics: ${compiled.diagnostics.map(d => (d.code, d.message, d.span.map(span => span.start -> span.end)))}",
+    )
+
+    val compiler = cxxCompiler().getOrElse(fail("no C++ compiler found for MLTT fixture execution test"))
+    MlttNodeFs.mkdirSync("target/cosmo1-mltt-tests", js.Dynamic.literal("recursive" -> true))
+    val sourcePath = "target/cosmo1-mltt-tests/mltt_check_test.cpp"
+    val executablePath = "target/cosmo1-mltt-tests/mltt_check_test"
+    MlttNodeFs.writeFileSync(sourcePath, compiled.value.get.output)
+
+    val compile = MlttNodeSpawnSync(
+      compiler,
+      js.Array("-std=c++17", NlohmannJsonDependency.includeArg, sourcePath, "-o", executablePath),
+      js.Dynamic.literal(encoding = "utf8"),
+    )
+    assertEquals(
+      compile.status.toOption,
+      Some(0),
+      s"C++ compiler rejected MLTT fixture output with $compiler\n${compile.stderr.getOrElse("")}",
+    )
+
+    val run = MlttNodeSpawnSync(
+      executablePath,
+      js.Array(),
+      js.Dynamic.literal(encoding = "utf8"),
+    )
+    assertEquals(
+      run.status.toOption,
+      Some(0),
+      s"MLTT fixture executable failed\nstdout:\n${run.stdout.getOrElse("")}\nstderr:\n${run.stderr.getOrElse("")}",
+    )
+
+  private def compileMlttTestProgram(): Result[CompiledModule] =
+    val source = combineSources(
+      List(
+        spanPath,
+        profilePath,
+        corePath,
+        checkPath,
+        checkTestPath,
+      ),
+    )
+    Cosmo0().compile(SourceFile(checkTestPath, source))
+
+  private def cxxCompiler(): Option[String] =
+    List("c++", "g++", "clang++").find { command =>
+      val result = MlttNodeSpawnSync(
+        command,
+        js.Array("--version"),
+        js.Dynamic.literal(encoding = "utf8"),
+      )
+      result.status.toOption.contains(0)
+    }
+
+  private def combineSources(paths: List[String]): String =
+    paths.map(readCosmoSource).mkString("\n")
+
+  private def readCosmoSource(path: String): String =
+    ParserFixtureManifest
+      .readFile(path)
+      .linesIterator
+      .filterNot(_.startsWith("import "))
+      .mkString("\n")
+end Cosmo1MlttTypeCheckerTests
+
+@js.native
+@JSImport("node:child_process", "spawnSync")
+private object MlttNodeSpawnSync extends js.Object:
+  def apply(command: String, args: js.Array[String], options: js.Any): MlttNodeSpawnSyncResult = js.native
+
+@js.native
+private trait MlttNodeSpawnSyncResult extends js.Object:
+  val status: js.UndefOr[Int] = js.native
+  val stdout: js.UndefOr[String] = js.native
+  val stderr: js.UndefOr[String] = js.native
+
+@js.native
+@JSImport("node:fs",JSImport.Namespace)
+private object MlttNodeFs extends js.Object:
+  def mkdirSync(path: String, options: js.Any): Unit = js.native
+  def writeFileSync(path: String, data: String): Unit = js.native

--- a/packages/cosmo0/src/test/scala/cosmo0/MlttProblemLadderTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/MlttProblemLadderTests.scala
@@ -1,0 +1,250 @@
+package cosmo0
+
+class MlttProblemLadderTests extends munit.FunSuite:
+  private final case class SupportedProblem(id: String, run: () => Boolean)
+
+  private val supportedProblems = List(
+    SupportedProblem("mltt-core-display", () => coreDisplay()),
+    SupportedProblem("mltt-universe-variable", () => universeVariable()),
+    SupportedProblem("mltt-pi-lambda-application", () => piLambdaApplication()),
+    SupportedProblem("mltt-sigma-refl", () => sigmaRefl()),
+    SupportedProblem("mltt-projection-whnf", () => projectionWhnf()),
+    SupportedProblem("mltt-conversion-beta-let-def", () => conversionBetaLetDef()),
+    SupportedProblem("mltt-conversion-effect-boundary", () => conversionEffectBoundary()),
+    SupportedProblem("mltt-nat-vec-constructors", () => natVecConstructors()),
+    SupportedProblem("mltt-meta-exact-higher-order-reject", () => metaExactHigherOrderReject()),
+  )
+
+  private val futureProblemIds = List(
+    "mltt-surface-holes",
+    "mltt-implicit-arguments",
+    "mltt-pruning-pattern-unification",
+    "mltt-first-class-polymorphism",
+    "mltt-dependent-pattern-impossible-branch",
+    "mltt-identity-eliminator-j",
+    "mltt-eta-cumulativity",
+  )
+
+  private val sourceUrls = List(
+    "https://github.com/AndrasKovacs/elaboration-zoo",
+    "https://davidchristiansen.dk/tutorials/nbe/",
+    "https://www.cs.cmu.edu/~rwh/courses/atpl/pdfs/dependency.pdf",
+    "https://wiki.portal.chalmers.se/agda/ReferenceManual/FindingTheValuesOfImplicitArguments",
+    "https://leanprover-community.github.io/lean4-metaprogramming-book/main/02_overview.html",
+    "https://research.chalmers.se/en/publication/519011",
+    "https://arxiv.org/abs/2207.02129",
+    "https://github.com/sweirich/pi-forall",
+    "https://www.cs.ru.nl/~herman/TT/opg6.pdf",
+  )
+
+  test("MLTT problem ladder doc is source-tagged and linked from the book"):
+    val doc = ParserFixtureManifest.readFile("docs/mltt-problem-ladder.typ")
+    val wrapper = ParserFixtureManifest.readFile("docs/cosmo/mltt-problem-ladder.typ")
+    val book = ParserFixtureManifest.readFile("docs/cosmo/book.typ")
+    val intro = ParserFixtureManifest.readFile("docs/cosmo/intro.typ")
+
+    assert(wrapper.contains("#include \"../mltt-problem-ladder.typ\""))
+    assert(book.contains("#prefix-chapter(\"mltt-problem-ladder.typ\")[MLTT Problem Ladder]"))
+    assert(intro.contains("#cross-link(\"/mltt-problem-ladder.typ\")[MLTT Problem Ladder]"))
+    sourceUrls.foreach(url => assert(doc.contains(url), s"missing MLTT source URL: $url"))
+    supportedProblems.foreach(problem => assertProblemBlock(doc, problem.id, "supported-now"))
+    futureProblemIds.foreach(id => assertProblemBlock(doc, id, "source-backed-future"))
+    assertProblemBlock(doc, "mltt-logic-proof-term-derivations", "paper-exercise")
+
+  test("supported MLTT problem ladder entries execute against the Scala checker"):
+    supportedProblems.foreach: problem =>
+      assert(problem.run(), s"supported MLTT problem failed: ${problem.id}")
+
+  private def assertProblemBlock(doc: String, id: String, status: String): Unit =
+    val marker = s"problem: `$id`"
+    val start = doc.indexOf(marker)
+    assert(start >= 0, s"missing MLTT problem marker: $id")
+
+    val next = doc.indexOf("problem: `", start + marker.length)
+    val block = if next < 0 then doc.substring(start) else doc.substring(start, next)
+    assert(block.contains(s"status: `$status`"), s"wrong or missing status for MLTT problem: $id")
+    assert(block.contains("sources:"), s"missing source tag for MLTT problem: $id")
+
+  private def coreDisplay(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val n = store.allocVar("n")
+    val vec = store.allocInductive("Vec", List(a), List(n))
+    val pi = store.allocPi("x", a, a)
+    val sigma = store.allocSigma("x", a, a)
+    val eq = store.allocEq(a, n, n)
+
+    MlttTypeChecker.display(store, type0) == "Type0" &&
+      MlttTypeChecker.display(store, pi) == "(x: A) -> A" &&
+      MlttTypeChecker.display(store, sigma) == "Sigma(x: A). A" &&
+      MlttTypeChecker.display(store, eq) == "Eq(A, n, n)" &&
+      MlttTypeChecker.display(store, vec) == "Vec(A, n)"
+
+  private def universeVariable(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val universe = MlttTypeChecker.infer(store, MlttTypeChecker.context(), type0)
+    val context = MlttTypeChecker.context().extendLocal("A", type0)
+    val variable = MlttTypeChecker.infer(store, context, store.allocVar("A"))
+    val missing = MlttTypeChecker.infer(store, MlttTypeChecker.context(), store.allocVar("missing"))
+
+    universe.isOk &&
+      MlttTypeChecker.display(store, universe.valueType) == "Type1" &&
+      variable.isOk &&
+      MlttTypeChecker.display(store, variable.valueType) == "Type0" &&
+      !missing.isOk &&
+      missing.firstCode == MlttTypeChecker.UnknownVariableCode &&
+      missing.diagnostics.head.profileId == CheckerProfiles.MlttCore.id
+
+  private def piLambdaApplication(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val context = MlttTypeChecker.context()
+      .extendLocal("A", type0)
+      .extendLocal("y", a)
+    val x = store.allocVar("x")
+    val lambda = store.allocLambda("x", a, x)
+    val pi = store.allocPi("x", a, a)
+    val checked = MlttTypeChecker.check(store, context, lambda, pi)
+    val inferred = MlttTypeChecker.infer(store, context, store.allocApply(lambda, store.allocVar("y")))
+
+    checked.isOk &&
+      checked.artifactSummary == "mltt.core|mltt-core-term|accepted|mltt.whnf-conversion" &&
+      inferred.isOk &&
+      MlttTypeChecker.display(store, inferred.valueType) == "A"
+
+  private def sigmaRefl(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val x = store.allocVar("x")
+    val context = MlttTypeChecker.context()
+      .extendLocal("A", type0)
+      .extendLocal("x", a)
+    val sigma = store.allocSigma("left", a, a)
+    val pair = store.allocPair(x, x)
+    val eq = store.allocEq(a, x, x)
+    val refl = store.allocRefl(x)
+
+    MlttTypeChecker.check(store, context, pair, sigma).isOk &&
+      MlttTypeChecker.check(store, context, refl, eq).isOk
+
+  private def projectionWhnf(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val x = store.allocVar("x")
+    val y = store.allocVar("y")
+    val context = MlttTypeChecker.context()
+      .extendLocal("A", type0)
+      .extendLocal("x", a)
+      .extendLocal("y", a)
+    val pair = store.allocPair(x, y)
+    val fst = store.allocFst(pair)
+    val snd = store.allocSnd(pair)
+
+    MlttTypeChecker.convert(store, context, fst, x).isOk &&
+      MlttTypeChecker.convert(store, context, snd, y).isOk
+
+  private def conversionBetaLetDef(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val context = MlttTypeChecker.context()
+      .extendLocal("A", type0)
+      .extendLocal("y", a)
+    val x = store.allocVar("x")
+    val lambda = store.allocLambda("x", a, x)
+    val y = store.allocVar("y")
+    val beta = store.allocApply(lambda, y)
+    val letTerm = store.allocLet("z", y, store.allocVar("z"))
+    val nat = store.allocInductive("Nat")
+    val n = store.allocVar("n")
+    val natContext = MlttTypeChecker.context()
+      .extendLocal("n", nat)
+      .extendDefinition("add_Z_n", nat, n, transparent = true, pure = true)
+    val addZN = store.allocVar("add_Z_n")
+
+    MlttTypeChecker.convert(store, context, beta, y).isOk &&
+      MlttTypeChecker.convert(store, context, letTerm, y).isOk &&
+      MlttTypeChecker.convert(store, natContext, addZN, n).isOk
+
+  private def conversionEffectBoundary(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val y = store.allocVar("y")
+    val context = MlttTypeChecker.context()
+      .extendLocal("A", type0)
+      .extendLocal("y", a)
+      .extendDefinition("effectful", a, y, transparent = false, pure = false)
+    val effectful = store.allocVar("effectful")
+    val effectfulResult = MlttTypeChecker.convert(store, context, effectful, y)
+    val strategyResult =
+      MlttTypeChecker.convert(store, MlttTypeChecker.context(), type0, type0, "mltt.full-normalization")
+
+    !effectfulResult.isOk &&
+      effectfulResult.firstCode == MlttTypeChecker.EffectfulConversionCode &&
+      !strategyResult.isOk &&
+      strategyResult.firstCode == MlttTypeChecker.UnsupportedNormalizationProfileCode
+
+  private def natVecConstructors(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val env = MlttTypeChecker.declarationEnv()
+    MlttTypeChecker.addNatFixture(store, env)
+    MlttTypeChecker.addVecFixture(store, env)
+
+    val natMetadataOk =
+      env.findInductive("Nat").exists(_.constructors.map(_.name) == List("Z", "S"))
+    val vecMetadataOk =
+      env.findInductive("Vec").exists: vec =>
+        vec.parameters.map(_.name) == List("A") &&
+          vec.indices.map(_.name) == List("n") &&
+          MlttTypeChecker.display(store, vec.constructors.head.result) == "Vec(A, Z)" &&
+          MlttTypeChecker.display(store, vec.constructors(1).result) == "Vec(A, S(k))"
+    if !natMetadataOk || !vecMetadataOk then return false
+
+    val type0 = store.allocUniverse(0)
+    val nat = store.allocInductive("Nat")
+    val z = store.allocConstructor("Z")
+    val sZ = store.allocConstructor("S", List(z))
+    val natChecks = MlttTypeChecker.check(store, MlttTypeChecker.context(), sZ, nat).isOk
+
+    val a = store.allocVar("A")
+    val k = store.allocVar("k")
+    val head = store.allocVar("head")
+    val tail = store.allocVar("tail")
+    val tailType = store.allocInductive("Vec", List(a), List(k))
+    val vecContext = MlttTypeChecker.context()
+      .extendLocal("A", type0)
+      .extendLocal("k", nat)
+      .extendLocal("head", a)
+      .extendLocal("tail", tailType)
+    val vecAZ = store.allocInductive("Vec", List(a), List(z))
+    val nil = store.allocConstructor("Nil")
+    val sK = store.allocConstructor("S", List(k))
+    val vecASK = store.allocInductive("Vec", List(a), List(sK))
+    val cons = store.allocConstructor("Cons", List(k, head, tail))
+
+    natChecks &&
+      MlttTypeChecker.check(store, vecContext, nil, vecAZ).isOk &&
+      MlttTypeChecker.check(store, vecContext, cons, vecASK).isOk
+
+  private def metaExactHigherOrderReject(): Boolean =
+    val store = MlttTypeChecker.termStore()
+    val metas = MlttTypeChecker.metaStore()
+    val type0 = store.allocUniverse(0)
+    val metaId = metas.newMeta(MlttTypeChecker.context(), type0)
+    val metaTerm = store.allocMeta(metaId)
+    val diagnostic = MlttTypeChecker.higherOrderUnificationDiagnostic(MlttTypeChecker.context())
+
+    metaId == 0 &&
+      MlttTypeChecker.display(store, metaTerm) == "?m0" &&
+      metas.hasUnsolvedPublicMeta &&
+      metas.solveExact(metaId, type0) &&
+      !metas.hasUnsolvedPublicMeta &&
+      diagnostic.code == MlttTypeChecker.HigherOrderUnificationCode &&
+      diagnostic.expected == "first-order pattern constraint"
+end MlttProblemLadderTests

--- a/packages/cosmo0/src/test/scala/cosmo0/MlttTypeCheckerTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/MlttTypeCheckerTests.scala
@@ -1,0 +1,177 @@
+package cosmo0
+
+class MlttTypeCheckerTests extends munit.FunSuite:
+  test("Scala MLTT core display covers Pi, Sigma, equality, Nat, and Vec"):
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val n = store.allocVar("n")
+    val vec = store.allocInductive("Vec", List(a), List(n))
+    val pi = store.allocPi("x", a, a)
+    val sigma = store.allocSigma("x", a, a)
+    val eq = store.allocEq(a, n, n)
+
+    assertEquals(MlttTypeChecker.display(store, type0), "Type0")
+    assertEquals(MlttTypeChecker.display(store, pi), "(x: A) -> A")
+    assertEquals(MlttTypeChecker.display(store, sigma), "Sigma(x: A). A")
+    assertEquals(MlttTypeChecker.display(store, eq), "Eq(A, n, n)")
+    assertEquals(MlttTypeChecker.display(store, vec), "Vec(A, n)")
+
+  test("Scala MLTT checker infers universes and variables"):
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val universe = MlttTypeChecker.infer(store, MlttTypeChecker.context(), type0)
+    val context = MlttTypeChecker.context().extendLocal("A", type0)
+    val a = store.allocVar("A")
+    val variable = MlttTypeChecker.infer(store, context, a)
+
+    assert(universe.isOk)
+    assertEquals(MlttTypeChecker.display(store, universe.valueType), "Type1")
+    assert(variable.isOk)
+    assertEquals(MlttTypeChecker.display(store, variable.valueType), "Type0")
+
+  test("Scala MLTT checker checks lambdas and infers applications through Pi"):
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    var context = MlttTypeChecker.context().extendLocal("A", type0)
+    context = context.extendLocal("y", a)
+
+    val x = store.allocVar("x")
+    val lambda = store.allocLambda("x", a, x)
+    val pi = store.allocPi("x", a, a)
+    val checked = MlttTypeChecker.check(store, context, lambda, pi)
+
+    val y = store.allocVar("y")
+    val apply = store.allocApply(lambda, y)
+    val inferred = MlttTypeChecker.infer(store, context, apply)
+
+    assert(checked.isOk)
+    assertEquals(checked.profileId, CheckerProfiles.MlttCore.id)
+    assertEquals(checked.artifactKind, "mltt-core-term")
+    assertEquals(checked.artifactSummary, "mltt.core|mltt-core-term|accepted|mltt.whnf-conversion")
+    assert(inferred.isOk)
+    assertEquals(MlttTypeChecker.display(store, inferred.valueType), "A")
+
+  test("Scala MLTT checker reports deterministic unknown variable and non-function diagnostics"):
+    val store = MlttTypeChecker.termStore()
+    val missing = store.allocVar("missing")
+    val missingResult = MlttTypeChecker.infer(store, MlttTypeChecker.context(), missing)
+
+    val type0 = store.allocUniverse(0)
+    val apply = store.allocApply(type0, type0)
+    val applyResult = MlttTypeChecker.infer(store, MlttTypeChecker.context(), apply)
+
+    assert(!missingResult.isOk)
+    assertEquals(missingResult.firstCode, MlttTypeChecker.UnknownVariableCode)
+    assertEquals(missingResult.diagnostics.head.profileId, CheckerProfiles.MlttCore.id)
+    assertEquals(missingResult.diagnostics.head.contextSummary, "<empty>")
+    assert(!applyResult.isOk)
+    assertEquals(applyResult.firstCode, MlttTypeChecker.NonFunctionApplicationCode)
+
+  test("Scala MLTT conversion accepts beta, lets, and transparent Nat-style definitions"):
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    var context = MlttTypeChecker.context().extendLocal("A", type0)
+    context = context.extendLocal("y", a)
+
+    val x = store.allocVar("x")
+    val lambda = store.allocLambda("x", a, x)
+    val y = store.allocVar("y")
+    val beta = store.allocApply(lambda, y)
+    val letTerm = store.allocLet("z", y, store.allocVar("z"))
+    val nat = store.allocInductive("Nat")
+    val n = store.allocVar("n")
+    val natContext = MlttTypeChecker.context()
+      .extendLocal("n", nat)
+      .extendDefinition("add_Z_n", nat, n, transparent = true, pure = true)
+    val addZN = store.allocVar("add_Z_n")
+
+    assert(MlttTypeChecker.convert(store, context, beta, y).isOk)
+    assert(MlttTypeChecker.convert(store, context, letTerm, y).isOk)
+    assert(MlttTypeChecker.convert(store, natContext, addZN, n).isOk)
+
+  test("Scala MLTT conversion rejects effectful definitions and unknown strategies"):
+    val store = MlttTypeChecker.termStore()
+    val a = store.allocVar("A")
+    val y = store.allocVar("y")
+    val context = MlttTypeChecker.context()
+      .extendLocal("y", a)
+      .extendDefinition("effectful", a, y, transparent = false, pure = false)
+    val effectful = store.allocVar("effectful")
+    val effectfulResult = MlttTypeChecker.convert(store, context, effectful, y)
+    val type0 = store.allocUniverse(0)
+    val strategyResult =
+      MlttTypeChecker.convert(store, MlttTypeChecker.context(), type0, type0, "mltt.full-normalization")
+
+    assert(!effectfulResult.isOk)
+    assertEquals(effectfulResult.firstCode, MlttTypeChecker.EffectfulConversionCode)
+    assert(!strategyResult.isOk)
+    assertEquals(strategyResult.firstCode, MlttTypeChecker.UnsupportedNormalizationProfileCode)
+
+  test("Scala MLTT checker handles Sigma pairs, Refl, Nat, and Vec constructor signatures"):
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val x = store.allocVar("x")
+    var context = MlttTypeChecker.context().extendLocal("A", type0)
+    context = context.extendLocal("x", a)
+    val sigma = store.allocSigma("left", a, a)
+    val pair = store.allocPair(x, x)
+    val eq = store.allocEq(a, x, x)
+    val refl = store.allocRefl(x)
+
+    assert(MlttTypeChecker.check(store, context, pair, sigma).isOk)
+    assert(MlttTypeChecker.check(store, context, refl, eq).isOk)
+
+    val nat = store.allocInductive("Nat")
+    val z = store.allocConstructor("Z")
+    val sZ = store.allocConstructor("S", List(z))
+    assert(MlttTypeChecker.check(store, MlttTypeChecker.context(), sZ, nat).isOk)
+
+    val k = store.allocVar("k")
+    val head = store.allocVar("head")
+    val tail = store.allocVar("tail")
+    var vecContext = MlttTypeChecker.context().extendLocal("A", type0)
+    vecContext = vecContext.extendLocal("k", nat)
+    vecContext = vecContext.extendLocal("head", a)
+    val tailType = store.allocInductive("Vec", List(a), List(k))
+    vecContext = vecContext.extendLocal("tail", tailType)
+    val vecAZ = store.allocInductive("Vec", List(a), List(z))
+    val nil = store.allocConstructor("Nil")
+    val sK = store.allocConstructor("S", List(k))
+    val vecASK = store.allocInductive("Vec", List(a), List(sK))
+    val cons = store.allocConstructor("Cons", List(k, head, tail))
+
+    assert(MlttTypeChecker.check(store, vecContext, nil, vecAZ).isOk)
+    assert(MlttTypeChecker.check(store, vecContext, cons, vecASK).isOk)
+
+  test("Scala MLTT declaration metadata and metavariables match the cosmoc profile shape"):
+    val store = MlttTypeChecker.termStore()
+    val env = MlttTypeChecker.declarationEnv()
+    MlttTypeChecker.addNatFixture(store, env)
+    MlttTypeChecker.addVecFixture(store, env)
+
+    val nat = env.findInductive("Nat").get
+    val vec = env.findInductive("Vec").get
+    assertEquals(nat.constructors.map(_.name), List("Z", "S"))
+    assertEquals(vec.parameters.map(_.name), List("A"))
+    assertEquals(vec.indices.map(_.name), List("n"))
+    assertEquals(MlttTypeChecker.display(store, vec.constructors.head.result), "Vec(A, Z)")
+    assertEquals(MlttTypeChecker.display(store, vec.constructors(1).result), "Vec(A, S(k))")
+
+    val metas = MlttTypeChecker.metaStore()
+    val type0 = store.allocUniverse(0)
+    val metaId = metas.newMeta(MlttTypeChecker.context(), type0)
+    val metaTerm = store.allocMeta(metaId)
+    assertEquals(metaId, 0)
+    assertEquals(MlttTypeChecker.display(store, metaTerm), "?m0")
+    assert(metas.hasUnsolvedPublicMeta)
+    assert(metas.solveExact(metaId, type0))
+    assert(!metas.hasUnsolvedPublicMeta)
+
+    val diagnostic = MlttTypeChecker.higherOrderUnificationDiagnostic(MlttTypeChecker.context())
+    assertEquals(diagnostic.code, MlttTypeChecker.HigherOrderUnificationCode)
+    assertEquals(diagnostic.profileId, CheckerProfiles.MlttCore.id)
+end MlttTypeCheckerTests

--- a/packages/cosmo0/src/test/scala/cosmo0/PackagePipelineTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/PackagePipelineTests.scala
@@ -186,6 +186,8 @@ class PackagePipelineTests extends munit.FunSuite:
           "package/module_graph.cos",
           "types/model.cos",
           "types/profile.cos",
+          "types/mltt/core.cos",
+          "types/mltt/check.cos",
           "types/declaration_resolution.cos",
           "types/dependent_pattern.cos",
           "types/check.cos",
@@ -224,6 +226,8 @@ class PackagePipelineTests extends munit.FunSuite:
         List("types", "check"),
         List("types", "declaration_resolution"),
         List("types", "dependent_pattern"),
+        List("types", "mltt", "check"),
+        List("types", "mltt", "core"),
         List("types", "model"),
         List("types", "profile"),
       ),
@@ -269,6 +273,8 @@ class PackagePipelineTests extends munit.FunSuite:
         "types/profile",
         "types/check",
         "types/dependent_pattern",
+        "types/mltt/core",
+        "types/mltt/check",
       ),
     )
 

--- a/packages/cosmoc/cosmo.json
+++ b/packages/cosmoc/cosmo.json
@@ -26,6 +26,8 @@
     "package/module_graph.cos",
     "types/model.cos",
     "types/profile.cos",
+    "types/mltt/core.cos",
+    "types/mltt/check.cos",
     "types/declaration_resolution.cos",
     "types/dependent_pattern.cos",
     "types/check.cos",

--- a/packages/cosmoc/src/types/check.cos
+++ b/packages/cosmoc/src/types/check.cos
@@ -2971,6 +2971,9 @@ def checker_unsupported_feature_from_text(text: String): String = {
   if (text == checker_feature_effects() or text == "effect-row") {
     return checker_feature_effects()
   }
+  if (text == checker_feature_async()) {
+    return checker_feature_async()
+  }
   if (text == checker_feature_traits() or text == "trait-constraint") {
     return checker_feature_traits()
   }
@@ -2979,6 +2982,15 @@ def checker_unsupported_feature_from_text(text: String): String = {
   }
   if (text == checker_feature_cpp_imports() or text == "cpp-import") {
     return checker_feature_cpp_imports()
+  }
+  if (text == checker_feature_macros() or text == "macro") {
+    return checker_feature_macros()
+  }
+  if (text == checker_feature_reflection() or text == "reflect") {
+    return checker_feature_reflection()
+  }
+  if (text == checker_feature_staging() or text == "stage") {
+    return checker_feature_staging()
   }
   text
 }

--- a/packages/cosmoc/src/types/mltt/check.cos
+++ b/packages/cosmoc/src/types/mltt/check.cos
@@ -1,0 +1,1970 @@
+import source.span
+import types.mltt.core
+import types.profile
+
+class MlttDiagnostic {
+  val code: String
+  val message: String
+  val span: Span
+  val profile_id: String
+  val context_summary: String
+  val expected: String
+  val actual: String
+}
+
+class MlttConversionResult {
+  val ok: Bool
+  val strategy: String
+  val diagnostics: Vec[MlttDiagnostic]
+
+  def is_ok(&self): Bool = {
+    self.ok and self.diagnostics.is_empty()
+  }
+
+  def first_code(&self): String = {
+    if (self.diagnostics.is_empty()) {
+      return ""
+    }
+    self.diagnostics.get(0).code
+  }
+}
+
+class MlttInferResult {
+  val profile_id: String
+  val artifact_kind: String
+  val term: MlttTermId
+  val typ: MlttTermId
+  val diagnostics: Vec[MlttDiagnostic]
+  val normalization_strategy: String
+
+  def is_ok(&self): Bool = {
+    self.diagnostics.is_empty()
+  }
+
+  def first_code(&self): String = {
+    if (self.diagnostics.is_empty()) {
+      return ""
+    }
+    self.diagnostics.get(0).code
+  }
+}
+
+class MlttCheckResult {
+  val profile_id: String
+  val artifact_kind: String
+  val term: MlttTermId
+  val typ: MlttTermId
+  val diagnostics: Vec[MlttDiagnostic]
+  val metas: MlttMetaStore
+  val status: String
+  val normalization_strategy: String
+
+  def is_ok(&self): Bool = {
+    self.diagnostics.is_empty()
+  }
+
+  def first_code(&self): String = {
+    if (self.diagnostics.is_empty()) {
+      return ""
+    }
+    self.diagnostics.get(0).code
+  }
+
+  def artifact_summary(&self): String = {
+    self.profile_id
+      .concat("|")
+      .concat(self.artifact_kind)
+      .concat("|")
+      .concat(self.status)
+      .concat("|")
+      .concat(self.normalization_strategy)
+  }
+}
+
+def mltt_whnf_conversion_strategy(): String = {
+  "mltt.whnf-conversion"
+}
+
+def mltt_unknown_variable_code(): String = {
+  "cosmo.type.mltt.unknown-variable"
+}
+
+def mltt_non_function_application_code(): String = {
+  "cosmo.type.mltt.non-function-application"
+}
+
+def mltt_universe_mismatch_code(): String = {
+  "cosmo.type.mltt.universe-mismatch"
+}
+
+def mltt_type_mismatch_code(): String = {
+  "cosmo.type.mltt.type-mismatch"
+}
+
+def mltt_unsolved_constraint_code(): String = {
+  "cosmo.type.mltt.unsolved-constraint"
+}
+
+def mltt_unsupported_normalization_profile_code(): String = {
+  "cosmo.type.mltt.unsupported-normalization-profile"
+}
+
+def mltt_effectful_conversion_code(): String = {
+  "cosmo.type.mltt.effectful-conversion"
+}
+
+def mltt_unsupported_inference_code(): String = {
+  "cosmo.type.mltt.unsupported-inference"
+}
+
+def mltt_higher_order_unification_code(): String = {
+  "cosmo.type.mltt.higher-order-unification"
+}
+
+def mltt_diagnostic(
+  code: String,
+  message: String,
+  span: Span,
+  context: &MlttContext,
+  expected: String,
+  actual: String
+): MlttDiagnostic = {
+  MlttDiagnostic(
+    code,
+    message,
+    span,
+    checker_profile_mltt_core_id(),
+    context.summary(),
+    expected,
+    actual
+  )
+}
+
+def mltt_push_diagnostic(
+  diagnostics: &mut Vec[MlttDiagnostic],
+  code: String,
+  message: String,
+  span: Span,
+  context: &MlttContext,
+  expected: String,
+  actual: String
+): Unit = {
+  diagnostics.push(mltt_diagnostic(code, message, span, context, expected, actual))
+}
+
+def mltt_copy_diagnostics(from: &Vec[MlttDiagnostic], to: &mut Vec[MlttDiagnostic]): Unit = {
+  var index: usize = 0;
+  while (index < from.len()) {
+    to.push(from.get(index));
+    index = index + 1
+  }
+}
+
+def mltt_convert(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left: MlttTermId,
+  right: MlttTermId
+): MlttConversionResult = {
+  mltt_convert_with_strategy(store, context, left, right, mltt_whnf_conversion_strategy())
+}
+
+def mltt_convert_with_strategy(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left: MlttTermId,
+  right: MlttTermId,
+  strategy: String
+): MlttConversionResult = {
+  val diagnostics = Vec[MlttDiagnostic]();
+  if (strategy != mltt_whnf_conversion_strategy()) {
+    mltt_push_diagnostic(
+      diagnostics,
+      mltt_unsupported_normalization_profile_code(),
+      "checker profile mltt.core does not implement normalization profile ".concat(strategy),
+      make_span(0, 0),
+      context,
+      mltt_whnf_conversion_strategy(),
+      strategy
+    );
+    return MlttConversionResult(false, strategy, diagnostics)
+  }
+
+  val ok = mltt_convert_terms(store, context, left, right, diagnostics);
+  if (!ok and diagnostics.is_empty()) {
+    mltt_push_diagnostic(
+      diagnostics,
+      mltt_type_mismatch_code(),
+      "types are not definitionally equal after allowed normalization",
+      make_span(0, 0),
+      context,
+      mltt_term_display(store, left),
+      mltt_term_display(store, right)
+    )
+  }
+  MlttConversionResult(ok, strategy, diagnostics)
+}
+
+def mltt_convert_terms(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left: MlttTermId,
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  if (mltt_terms_equal(store, left, right)) {
+    return true
+  }
+
+  val left_whnf = mltt_whnf(store, context, left, diagnostics);
+  val right_whnf = mltt_whnf(store, context, right, diagnostics);
+  if (mltt_terms_equal(store, left_whnf, right_whnf)) {
+    return true
+  }
+
+  val left_value = store.term_value(left_whnf);
+  left_value match {
+    case MlttTerm.Pi(left_name, left_domain, left_body) => {
+      mltt_convert_pi_like(store, context, left_name, left_domain, left_body, right_whnf, diagnostics, false)
+    }
+    case MlttTerm.Sigma(left_name, left_first, left_second) => {
+      mltt_convert_pi_like(store, context, left_name, left_first, left_second, right_whnf, diagnostics, true)
+    }
+    case MlttTerm.Apply(left_function, left_argument) => {
+      mltt_convert_apply(store, context, left_function, left_argument, right_whnf, diagnostics)
+    }
+    case MlttTerm.Inductive(left_name, left_params, left_indices) => {
+      mltt_convert_inductive(store, context, left_name, left_params, left_indices, right_whnf, diagnostics)
+    }
+    case MlttTerm.Constructor(left_name, left_args) => {
+      mltt_convert_constructor(store, context, left_name, left_args, right_whnf, diagnostics)
+    }
+    case MlttTerm.Eq(left_type, left_left, left_right) => {
+      mltt_convert_eq(store, context, left_type, left_left, left_right, right_whnf, diagnostics)
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_convert_pi_like(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left_name: String,
+  left_domain: MlttTermId,
+  left_body: MlttTermId,
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  sigma: Bool
+): Bool = {
+  val right_value = store.term_value(right);
+  right_value match {
+    case MlttTerm.Pi(right_name, right_domain, right_body) => {
+      if (sigma) {
+        return false
+      }
+      mltt_convert_terms(store, context, left_domain, right_domain, diagnostics) and
+        mltt_convert_terms(store, context, left_body, right_body, diagnostics)
+    }
+    case MlttTerm.Sigma(right_name, right_first, right_second) => {
+      if (!sigma) {
+        return false
+      }
+      mltt_convert_terms(store, context, left_domain, right_first, diagnostics) and
+        mltt_convert_terms(store, context, left_body, right_second, diagnostics)
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Constructor(name, args) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_convert_apply(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left_function: MlttTermId,
+  left_argument: MlttTermId,
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val right_value = store.term_value(right);
+  right_value match {
+    case MlttTerm.Apply(right_function, right_argument) => {
+      mltt_convert_terms(store, context, left_function, right_function, diagnostics) and
+        mltt_convert_terms(store, context, left_argument, right_argument, diagnostics)
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Constructor(name, args) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_convert_inductive(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left_name: String,
+  left_params: &Vec[MlttTermId],
+  left_indices: &Vec[MlttTermId],
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val right_value = store.term_value(right);
+  right_value match {
+    case MlttTerm.Inductive(right_name, right_params, right_indices) => {
+      left_name == right_name and
+        mltt_convert_term_lists(store, context, left_params, right_params, diagnostics) and
+        mltt_convert_term_lists(store, context, left_indices, right_indices, diagnostics)
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Constructor(name, args) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_convert_constructor(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left_name: String,
+  left_args: &Vec[MlttTermId],
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val right_value = store.term_value(right);
+  right_value match {
+    case MlttTerm.Constructor(right_name, right_args) => {
+      left_name == right_name and mltt_convert_term_lists(store, context, left_args, right_args, diagnostics)
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_convert_eq(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left_type: MlttTermId,
+  left_left: MlttTermId,
+  left_right: MlttTermId,
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val right_value = store.term_value(right);
+  right_value match {
+    case MlttTerm.Eq(right_type, right_left, right_right) => {
+      mltt_convert_terms(store, context, left_type, right_type, diagnostics) and
+        mltt_convert_terms(store, context, left_left, right_left, diagnostics) and
+        mltt_convert_terms(store, context, left_right, right_right, diagnostics)
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Constructor(name, args) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_convert_term_lists(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  left: &Vec[MlttTermId],
+  right: &Vec[MlttTermId],
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  if (left.len() != right.len()) {
+    return false
+  }
+  var index: usize = 0;
+  while (index < left.len()) {
+    if (!mltt_convert_terms(store, context, left.get(index), right.get(index), diagnostics)) {
+      return false
+    }
+    index = index + 1
+  }
+  true
+}
+
+def mltt_whnf(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  mltt_whnf_fuel(store, context, term, diagnostics, 64)
+}
+
+def mltt_whnf_fuel(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  fuel: usize
+): MlttTermId = {
+  if (fuel == 0) {
+    return term
+  }
+
+  val value = store.term_value(term);
+  value match {
+    case MlttTerm.Var(name) => {
+      mltt_whnf_var(store, context, term, name, diagnostics, fuel)
+    }
+    case MlttTerm.Apply(function, argument) => {
+      mltt_whnf_apply(store, context, term, function, argument, diagnostics, fuel)
+    }
+    case MlttTerm.Let(name, local_value, body) => {
+      val substituted = mltt_substitute(store, body, name, local_value);
+      mltt_whnf_fuel(store, context, substituted, diagnostics, fuel - 1)
+    }
+    case MlttTerm.Fst(pair) => {
+      mltt_whnf_fst(store, context, term, pair, diagnostics, fuel)
+    }
+    case MlttTerm.Snd(pair) => {
+      mltt_whnf_snd(store, context, term, pair, diagnostics, fuel)
+    }
+    case MlttTerm.Universe(level) => {
+      term
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      term
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      term
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      term
+    }
+    case MlttTerm.Pair(first, second) => {
+      term
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      term
+    }
+    case MlttTerm.Constructor(name, args) => {
+      term
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      term
+    }
+    case MlttTerm.Refl(value) => {
+      term
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      term
+    }
+    case MlttTerm.Meta(index) => {
+      term
+    }
+    case MlttTerm.Error => {
+      term
+    }
+  }
+}
+
+def mltt_whnf_var(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  name: String,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  fuel: usize
+): MlttTermId = {
+  val maybe_entry = context.lookup(name);
+  maybe_entry match {
+    case Option[MlttContextEntry]::Some(entry) => {
+      entry.value match {
+        case Option[MlttTermId]::Some(value) => {
+          if (entry.transparent and entry.pure) {
+            return mltt_whnf_fuel(store, context, value, diagnostics, fuel - 1)
+          }
+          mltt_push_diagnostic(
+            diagnostics,
+            mltt_effectful_conversion_code(),
+            "conversion cannot reduce an opaque or effectful definition",
+            make_span(0, 0),
+            context,
+            "transparent pure definition",
+            name
+          );
+          term
+        }
+        case Option[MlttTermId]::None => {
+          term
+        }
+      }
+    }
+    case Option[MlttContextEntry]::None => {
+      term
+    }
+  }
+}
+
+def mltt_whnf_apply(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  function: MlttTermId,
+  argument: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  fuel: usize
+): MlttTermId = {
+  val function_whnf = mltt_whnf_fuel(store, context, function, diagnostics, fuel - 1);
+  val function_value = store.term_value(function_whnf);
+  function_value match {
+    case MlttTerm.Lambda(name, annotation, body) => {
+      val substituted = mltt_substitute(store, body, name, argument);
+      mltt_whnf_fuel(store, context, substituted, diagnostics, fuel - 1)
+    }
+    case MlttTerm.Var(name) => {
+      term
+    }
+    case MlttTerm.Universe(level) => {
+      term
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      term
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      term
+    }
+    case MlttTerm.Apply(inner_function, inner_argument) => {
+      term
+    }
+    case MlttTerm.Pair(first, second) => {
+      term
+    }
+    case MlttTerm.Fst(pair) => {
+      term
+    }
+    case MlttTerm.Snd(pair) => {
+      term
+    }
+    case MlttTerm.Let(name, value, body) => {
+      term
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      term
+    }
+    case MlttTerm.Constructor(name, args) => {
+      term
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      term
+    }
+    case MlttTerm.Refl(value) => {
+      term
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      term
+    }
+    case MlttTerm.Meta(index) => {
+      term
+    }
+    case MlttTerm.Error => {
+      term
+    }
+  }
+}
+
+def mltt_whnf_fst(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  pair: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  fuel: usize
+): MlttTermId = {
+  val pair_whnf = mltt_whnf_fuel(store, context, pair, diagnostics, fuel - 1);
+  val pair_value = store.term_value(pair_whnf);
+  pair_value match {
+    case MlttTerm.Pair(first, second) => {
+      mltt_whnf_fuel(store, context, first, diagnostics, fuel - 1)
+    }
+    case MlttTerm.Var(name) => {
+      term
+    }
+    case MlttTerm.Universe(level) => {
+      term
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      term
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      term
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      term
+    }
+    case MlttTerm.Apply(function, argument) => {
+      term
+    }
+    case MlttTerm.Fst(inner_pair) => {
+      term
+    }
+    case MlttTerm.Snd(inner_pair) => {
+      term
+    }
+    case MlttTerm.Let(name, value, body) => {
+      term
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      term
+    }
+    case MlttTerm.Constructor(name, args) => {
+      term
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      term
+    }
+    case MlttTerm.Refl(value) => {
+      term
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      term
+    }
+    case MlttTerm.Meta(index) => {
+      term
+    }
+    case MlttTerm.Error => {
+      term
+    }
+  }
+}
+
+def mltt_whnf_snd(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  pair: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  fuel: usize
+): MlttTermId = {
+  val pair_whnf = mltt_whnf_fuel(store, context, pair, diagnostics, fuel - 1);
+  val pair_value = store.term_value(pair_whnf);
+  pair_value match {
+    case MlttTerm.Pair(first, second) => {
+      mltt_whnf_fuel(store, context, second, diagnostics, fuel - 1)
+    }
+    case MlttTerm.Var(name) => {
+      term
+    }
+    case MlttTerm.Universe(level) => {
+      term
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      term
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      term
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      term
+    }
+    case MlttTerm.Apply(function, argument) => {
+      term
+    }
+    case MlttTerm.Fst(inner_pair) => {
+      term
+    }
+    case MlttTerm.Snd(inner_pair) => {
+      term
+    }
+    case MlttTerm.Let(name, value, body) => {
+      term
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      term
+    }
+    case MlttTerm.Constructor(name, args) => {
+      term
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      term
+    }
+    case MlttTerm.Refl(value) => {
+      term
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      term
+    }
+    case MlttTerm.Meta(index) => {
+      term
+    }
+    case MlttTerm.Error => {
+      term
+    }
+  }
+}
+
+def mltt_infer(store: &mut MlttTermStore, context: &MlttContext, term: MlttTermId): MlttInferResult = {
+  val diagnostics = Vec[MlttDiagnostic]();
+  val typ = mltt_infer_term(store, context, term, diagnostics);
+  MlttInferResult(
+    checker_profile_mltt_core_id(),
+    checker_artifact_mltt_core_term(),
+    term,
+    typ,
+    diagnostics,
+    mltt_whnf_conversion_strategy()
+  )
+}
+
+def mltt_check(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  expected: MlttTermId
+): MlttCheckResult = {
+  val diagnostics = Vec[MlttDiagnostic]();
+  val metas = mltt_meta_store();
+  val typ = mltt_check_term(store, context, term, expected, diagnostics);
+  mltt_report_unsolved_metas(store, context, metas, diagnostics);
+  MlttCheckResult(
+    checker_profile_mltt_core_id(),
+    checker_artifact_mltt_core_term(),
+    term,
+    typ,
+    diagnostics,
+    metas,
+    mltt_check_status(diagnostics),
+    mltt_whnf_conversion_strategy()
+  )
+}
+
+def mltt_infer_term(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  val value = store.term_value(term);
+  value match {
+    case MlttTerm.Var(name) => {
+      mltt_infer_var(store, context, term, name, diagnostics)
+    }
+    case MlttTerm.Universe(level) => {
+      store.alloc_universe(level + 1)
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      mltt_infer_pi_like(store, context, name, domain, body, diagnostics, false)
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      mltt_infer_pi_like(store, context, name, first, second, diagnostics, true)
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      mltt_infer_lambda(store, context, name, annotation, body, diagnostics)
+    }
+    case MlttTerm.Apply(function, argument) => {
+      mltt_infer_apply(store, context, term, function, argument, diagnostics)
+    }
+    case MlttTerm.Pair(first, second) => {
+      mltt_push_diagnostic(
+        diagnostics,
+        mltt_unsupported_inference_code(),
+        "pair inference requires an expected Sigma type",
+        make_span(0, 0),
+        context,
+        "Sigma",
+        mltt_term_display(store, term)
+      );
+      store.alloc_error()
+    }
+    case MlttTerm.Fst(pair) => {
+      mltt_infer_projection(store, context, term, pair, diagnostics, true)
+    }
+    case MlttTerm.Snd(pair) => {
+      mltt_infer_projection(store, context, term, pair, diagnostics, false)
+    }
+    case MlttTerm.Let(name, local_value, body) => {
+      val local_type = mltt_infer_term(store, context, local_value, diagnostics);
+      val next_context = mltt_context_extend_definition(context, name, local_type, local_value, true, true);
+      mltt_infer_term(store, next_context, body, diagnostics)
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      store.alloc_universe(0)
+    }
+    case MlttTerm.Constructor(name, args) => {
+      mltt_infer_constructor(store, context, term, name, args, diagnostics)
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      mltt_infer_eq(store, context, term, typ, left, right, diagnostics)
+    }
+    case MlttTerm.Refl(value) => {
+      mltt_push_diagnostic(
+        diagnostics,
+        mltt_unsupported_inference_code(),
+        "Refl inference requires an expected equality type",
+        make_span(0, 0),
+        context,
+        "Eq",
+        mltt_term_display(store, term)
+      );
+      store.alloc_error()
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      mltt_push_diagnostic(
+        diagnostics,
+        mltt_unsupported_inference_code(),
+        "neutral term inference requires an elaborated type annotation",
+        make_span(0, 0),
+        context,
+        "annotated neutral",
+        head
+      );
+      store.alloc_error()
+    }
+    case MlttTerm.Meta(index) => {
+      mltt_push_diagnostic(
+        diagnostics,
+        mltt_unsolved_constraint_code(),
+        "metavariable cannot be inferred until it is solved",
+        make_span(0, 0),
+        context,
+        "solved metavariable",
+        mltt_term_display(store, term)
+      );
+      store.alloc_error()
+    }
+    case MlttTerm.Error => {
+      store.alloc_error()
+    }
+  }
+}
+
+def mltt_infer_var(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  name: String,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  val maybe_entry = context.lookup(name);
+  maybe_entry match {
+    case Option[MlttContextEntry]::Some(entry) => {
+      entry.typ
+    }
+    case Option[MlttContextEntry]::None => {
+      mltt_push_diagnostic(
+        diagnostics,
+        mltt_unknown_variable_code(),
+        "unknown variable ".concat(name),
+        make_span(0, 0),
+        context,
+        "bound local",
+        name
+      );
+      store.alloc_error()
+    }
+  }
+}
+
+def mltt_infer_pi_like(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  name: String,
+  domain: MlttTermId,
+  body: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  sigma: Bool
+): MlttTermId = {
+  val domain_type = mltt_infer_term(store, context, domain, diagnostics);
+  val next_context = mltt_context_extend_local(context, name, domain);
+  val body_type = mltt_infer_term(store, next_context, body, diagnostics);
+  val domain_level = mltt_type_universe_level(store, domain_type);
+  val body_level = mltt_type_universe_level(store, body_type);
+  domain_level match {
+    case Option[usize]::Some(left_level) => {
+      body_level match {
+        case Option[usize]::Some(right_level) => {
+          store.alloc_universe(mltt_max_usize(left_level, right_level))
+        }
+        case Option[usize]::None => {
+          mltt_universe_mismatch(store, context, diagnostics, body_type);
+          store.alloc_error()
+        }
+      }
+    }
+    case Option[usize]::None => {
+      mltt_universe_mismatch(store, context, diagnostics, domain_type);
+      store.alloc_error()
+    }
+  }
+}
+
+def mltt_infer_lambda(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  name: String,
+  annotation: MlttTermId,
+  body: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  val annotation_type = mltt_infer_term(store, context, annotation, diagnostics);
+  val maybe_level = mltt_type_universe_level(store, annotation_type);
+  maybe_level match {
+    case Option[usize]::Some(level) => {
+    }
+    case Option[usize]::None => {
+      mltt_universe_mismatch(store, context, diagnostics, annotation_type)
+    }
+  }
+  val next_context = mltt_context_extend_local(context, name, annotation);
+  val body_type = mltt_infer_term(store, next_context, body, diagnostics);
+  store.alloc_pi(name, annotation, body_type)
+}
+
+def mltt_infer_apply(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  function: MlttTermId,
+  argument: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  val function_type = mltt_infer_term(store, context, function, diagnostics);
+  val function_type_whnf = mltt_whnf(store, context, function_type, diagnostics);
+  val function_value = store.term_value(function_type_whnf);
+  function_value match {
+    case MlttTerm.Pi(name, domain, body) => {
+      mltt_check_term(store, context, argument, domain, diagnostics);
+      mltt_substitute(store, body, name, argument)
+    }
+    case MlttTerm.Var(name) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Universe(level) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Apply(inner_function, inner_argument) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Pair(first, second) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Fst(pair) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Snd(pair) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Let(name, value, body) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Constructor(name, args) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Refl(value) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Meta(index) => {
+      mltt_non_function_application(store, context, term, function_type_whnf, diagnostics)
+    }
+    case MlttTerm.Error => {
+      store.alloc_error()
+    }
+  }
+}
+
+def mltt_infer_projection(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  pair: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  first: Bool
+): MlttTermId = {
+  val pair_type = mltt_infer_term(store, context, pair, diagnostics);
+  val pair_type_whnf = mltt_whnf(store, context, pair_type, diagnostics);
+  val pair_value = store.term_value(pair_type_whnf);
+  pair_value match {
+    case MlttTerm.Sigma(name, first_type, second_type) => {
+      if (first) {
+        return first_type
+      }
+      val projected_first = store.alloc_fst(pair);
+      mltt_substitute(store, second_type, name, projected_first)
+    }
+    case MlttTerm.Var(name) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Universe(level) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Apply(function, argument) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Pair(first_value, second_value) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Fst(inner_pair) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Snd(inner_pair) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Let(name, value, body) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Constructor(name, args) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Refl(value) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Meta(index) => {
+      mltt_non_sigma_projection(store, context, term, pair_type_whnf, diagnostics)
+    }
+    case MlttTerm.Error => {
+      store.alloc_error()
+    }
+  }
+}
+
+def mltt_infer_constructor(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  name: String,
+  args: &Vec[MlttTermId],
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  if (name == "Z" and args.is_empty()) {
+    return store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]())
+  }
+  if (name == "S" and args.len() == 1) {
+    val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+    mltt_check_term(store, context, args.get(0), nat, diagnostics);
+    return nat
+  }
+  mltt_push_diagnostic(
+    diagnostics,
+    mltt_unsupported_inference_code(),
+    "constructor inference requires an expected inductive family",
+    make_span(0, 0),
+    context,
+    "constructor type",
+    mltt_term_display(store, term)
+  );
+  store.alloc_error()
+}
+
+def mltt_infer_eq(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  typ: MlttTermId,
+  left: MlttTermId,
+  right: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  val type_type = mltt_infer_term(store, context, typ, diagnostics);
+  val maybe_level = mltt_type_universe_level(store, type_type);
+  maybe_level match {
+    case Option[usize]::Some(level) => {
+    }
+    case Option[usize]::None => {
+      mltt_universe_mismatch(store, context, diagnostics, type_type)
+    }
+  }
+  mltt_check_term(store, context, left, typ, diagnostics);
+  mltt_check_term(store, context, right, typ, diagnostics);
+  store.alloc_universe(0)
+}
+
+def mltt_check_term(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  expected: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  val term_value = store.term_value(term);
+  val expected_whnf = mltt_whnf(store, context, expected, diagnostics);
+  term_value match {
+    case MlttTerm.Lambda(name, annotation, body) => {
+      if (mltt_check_lambda(store, context, name, body, expected_whnf, diagnostics)) {
+        return expected
+      }
+    }
+    case MlttTerm.Pair(first, second) => {
+      if (mltt_check_pair(store, context, first, second, expected_whnf, diagnostics)) {
+        return expected
+      }
+    }
+    case MlttTerm.Refl(value) => {
+      if (mltt_check_refl(store, context, value, expected_whnf, diagnostics)) {
+        return expected
+      }
+    }
+    case MlttTerm.Constructor(name, args) => {
+      if (mltt_check_constructor(store, context, term, name, args, expected_whnf, diagnostics)) {
+        return expected
+      }
+    }
+    case MlttTerm.Var(name) => {
+    }
+    case MlttTerm.Universe(level) => {
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+    }
+    case MlttTerm.Apply(function, argument) => {
+    }
+    case MlttTerm.Fst(pair) => {
+    }
+    case MlttTerm.Snd(pair) => {
+    }
+    case MlttTerm.Let(name, value, body) => {
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+    }
+    case MlttTerm.Neutral(head, spine) => {
+    }
+    case MlttTerm.Meta(index) => {
+    }
+    case MlttTerm.Error => {
+      return store.alloc_error()
+    }
+  }
+
+  val inferred = mltt_infer_term(store, context, term, diagnostics);
+  val converted = mltt_convert(store, context, inferred, expected);
+  mltt_copy_diagnostics(converted.diagnostics, diagnostics);
+  if (!converted.is_ok()) {
+    mltt_push_diagnostic(
+      diagnostics,
+      mltt_type_mismatch_code(),
+      "type mismatch",
+      make_span(0, 0),
+      context,
+      mltt_term_display(store, expected),
+      mltt_term_display(store, inferred)
+    )
+  }
+  expected
+}
+
+def mltt_check_lambda(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  name: String,
+  body: MlttTermId,
+  expected: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val expected_value = store.term_value(expected);
+  expected_value match {
+    case MlttTerm.Pi(expected_name, domain, codomain) => {
+      val param = store.alloc_var(name);
+      val body_type = mltt_substitute(store, codomain, expected_name, param);
+      val next_context = mltt_context_extend_local(context, name, domain);
+      mltt_check_term(store, next_context, body, body_type, diagnostics);
+      true
+    }
+    case MlttTerm.Var(var_name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Sigma(sigma_name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(lambda_name, annotation, lambda_body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(let_name, value, let_body) => {
+      false
+    }
+    case MlttTerm.Inductive(inductive_name, params, indices) => {
+      false
+    }
+    case MlttTerm.Constructor(ctor_name, args) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_check_pair(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  first: MlttTermId,
+  second: MlttTermId,
+  expected: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val expected_value = store.term_value(expected);
+  expected_value match {
+    case MlttTerm.Sigma(name, first_type, second_type) => {
+      mltt_check_term(store, context, first, first_type, diagnostics);
+      val second_expected = mltt_substitute(store, second_type, name, first);
+      mltt_check_term(store, context, second, second_expected, diagnostics);
+      true
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(left, right) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Constructor(name, args) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_check_refl(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  value: MlttTermId,
+  expected: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val expected_value = store.term_value(expected);
+  expected_value match {
+    case MlttTerm.Eq(typ, left, right) => {
+      mltt_check_term(store, context, value, typ, diagnostics);
+      val left_ok = mltt_convert(store, context, value, left);
+      val right_ok = mltt_convert(store, context, value, right);
+      mltt_copy_diagnostics(left_ok.diagnostics, diagnostics);
+      mltt_copy_diagnostics(right_ok.diagnostics, diagnostics);
+      left_ok.is_ok() and right_ok.is_ok()
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Constructor(name, args) => {
+      false
+    }
+    case MlttTerm.Refl(inner_value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_check_constructor(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  name: String,
+  args: &Vec[MlttTermId],
+  expected: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val expected_value = store.term_value(expected);
+  expected_value match {
+    case MlttTerm.Inductive(family, params, indices) => {
+      if (family == "Nat") {
+        return mltt_check_nat_constructor(store, context, name, args, expected, diagnostics)
+      }
+      if (family == "Vec") {
+        return mltt_check_vec_constructor(store, context, name, args, params, indices, diagnostics)
+      }
+      false
+    }
+    case MlttTerm.Var(var_name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(pi_name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(sigma_name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(lambda_name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(let_name, value, body) => {
+      false
+    }
+    case MlttTerm.Constructor(ctor_name, ctor_args) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_check_nat_constructor(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  name: String,
+  args: &Vec[MlttTermId],
+  expected: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  if (name == "Z" and args.is_empty()) {
+    return true
+  }
+  if (name == "S" and args.len() == 1) {
+    mltt_check_term(store, context, args.get(0), expected, diagnostics);
+    return true
+  }
+  false
+}
+
+def mltt_check_vec_constructor(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  name: String,
+  args: &Vec[MlttTermId],
+  params: &Vec[MlttTermId],
+  indices: &Vec[MlttTermId],
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  if (params.len() != 1 or indices.len() != 1) {
+    return false
+  }
+  if (name == "Nil" and args.is_empty()) {
+    return mltt_term_is_constructor(store, indices.get(0), "Z", 0)
+  }
+  if (name == "Cons" and args.len() == 3) {
+    return mltt_check_vec_cons_constructor(store, context, args, params.get(0), indices.get(0), diagnostics)
+  }
+  false
+}
+
+def mltt_check_vec_cons_constructor(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  args: &Vec[MlttTermId],
+  element_type: MlttTermId,
+  index: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Bool = {
+  val index_value = store.term_value(index);
+  index_value match {
+    case MlttTerm.Constructor(name, successor_args) => {
+      if (name != "S" or successor_args.len() != 1) {
+        return false
+      }
+      val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+      val length_arg = args.get(0);
+      val head_arg = args.get(1);
+      val tail_arg = args.get(2);
+      mltt_check_term(store, context, length_arg, nat, diagnostics);
+      mltt_check_term(store, context, head_arg, element_type, diagnostics);
+      val tail_indices = Vec[MlttTermId]();
+      tail_indices.push(successor_args.get(0));
+      val tail_type = store.alloc_inductive("Vec", mltt_single_term(element_type), tail_indices);
+      mltt_check_term(store, context, tail_arg, tail_type, diagnostics);
+      val converted = mltt_convert(store, context, length_arg, successor_args.get(0));
+      mltt_copy_diagnostics(converted.diagnostics, diagnostics);
+      converted.is_ok()
+    }
+    case MlttTerm.Var(name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      true
+    }
+  }
+}
+
+def mltt_term_is_constructor(store: &MlttTermStore, term: MlttTermId, name: String, arity: usize): Bool = {
+  val value = store.term_value(term);
+  value match {
+    case MlttTerm.Constructor(ctor_name, args) => {
+      ctor_name == name and args.len() == arity
+    }
+    case MlttTerm.Var(var_name) => {
+      false
+    }
+    case MlttTerm.Universe(level) => {
+      false
+    }
+    case MlttTerm.Pi(param, domain, body) => {
+      false
+    }
+    case MlttTerm.Sigma(param, first, second) => {
+      false
+    }
+    case MlttTerm.Lambda(param, annotation, body) => {
+      false
+    }
+    case MlttTerm.Apply(function, argument) => {
+      false
+    }
+    case MlttTerm.Pair(first, second) => {
+      false
+    }
+    case MlttTerm.Fst(pair) => {
+      false
+    }
+    case MlttTerm.Snd(pair) => {
+      false
+    }
+    case MlttTerm.Let(local_name, value, body) => {
+      false
+    }
+    case MlttTerm.Inductive(inductive_name, params, indices) => {
+      false
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      false
+    }
+    case MlttTerm.Refl(value) => {
+      false
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      false
+    }
+    case MlttTerm.Meta(index) => {
+      false
+    }
+    case MlttTerm.Error => {
+      false
+    }
+  }
+}
+
+def mltt_universe_mismatch(
+  store: &MlttTermStore,
+  context: &MlttContext,
+  diagnostics: &mut Vec[MlttDiagnostic],
+  actual: MlttTermId
+): Unit = {
+  mltt_push_diagnostic(
+    diagnostics,
+    mltt_universe_mismatch_code(),
+    "expected a universe-classified type",
+    make_span(0, 0),
+    context,
+    "Type",
+    mltt_term_display(store, actual)
+  )
+}
+
+def mltt_non_function_application(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  actual_type: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  mltt_push_diagnostic(
+    diagnostics,
+    mltt_non_function_application_code(),
+    "application callee does not have a Pi type",
+    make_span(0, 0),
+    context,
+    "Pi",
+    mltt_term_display(store, actual_type)
+  );
+  store.alloc_error()
+}
+
+def mltt_non_sigma_projection(
+  store: &mut MlttTermStore,
+  context: &MlttContext,
+  term: MlttTermId,
+  actual_type: MlttTermId,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): MlttTermId = {
+  mltt_push_diagnostic(
+    diagnostics,
+    mltt_type_mismatch_code(),
+    "projection target does not have a Sigma type",
+    make_span(0, 0),
+    context,
+    "Sigma",
+    mltt_term_display(store, actual_type)
+  );
+  store.alloc_error()
+}
+
+def mltt_report_unsolved_metas(
+  store: &MlttTermStore,
+  context: &MlttContext,
+  metas: MlttMetaStore,
+  diagnostics: &mut Vec[MlttDiagnostic]
+): Unit = {
+  if (metas.has_unsolved_public_meta()) {
+    mltt_push_diagnostic(
+      diagnostics,
+      mltt_unsolved_constraint_code(),
+      "checking completed with an unsolved metavariable",
+      make_span(0, 0),
+      context,
+      "solved constraints",
+      "unsolved metavariable"
+    )
+  }
+}
+
+def mltt_reject_higher_order_unification(context: &MlttContext): MlttDiagnostic = {
+  mltt_diagnostic(
+    mltt_higher_order_unification_code(),
+    "arbitrary higher-order unification is outside mltt.core",
+    make_span(0, 0),
+    context,
+    "first-order pattern constraint",
+    "higher-order constraint"
+  )
+}
+
+def mltt_check_status(diagnostics: &Vec[MlttDiagnostic]): String = {
+  if (diagnostics.is_empty()) {
+    return "accepted"
+  }
+  "rejected"
+}

--- a/packages/cosmoc/src/types/mltt/check_test.cos
+++ b/packages/cosmoc/src/types/mltt/check_test.cos
@@ -1,0 +1,345 @@
+import source.span
+import types.mltt.check
+import types.mltt.core
+import types.profile
+
+def mltt_profile_metadata_declares_core_checker(): Bool = {
+  val profile = checker_profile_mltt_core();
+  profile.id == "mltt.core" and
+    profile.artifact_kind == checker_artifact_mltt_core_term() and
+    profile.supports_feature("mltt-core-terms") and
+    profile.supports_feature("conversion") and
+    profile.supports_feature("sigma-types") and
+    profile.supports_feature("equality-types") and
+    profile.rejects_feature(checker_feature_effects()) and
+    profile.rejects_feature(checker_feature_async()) and
+    profile.rejects_feature(checker_feature_traits()) and
+    profile.rejects_feature(checker_feature_object_dispatch()) and
+    profile.rejects_feature(checker_feature_cpp_imports()) and
+    profile.rejects_feature(checker_feature_staging())
+}
+
+def mltt_core_display_covers_pi_sigma_eq_nat_vec(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val a = store.alloc_var("A");
+  val n = store.alloc_var("n");
+  val vec = store.alloc_inductive("Vec", mltt_single_term(a), mltt_single_term(n));
+  val pi = store.alloc_pi("x", a, a);
+  val sigma = store.alloc_sigma("x", a, a);
+  val eq = store.alloc_eq(a, n, n);
+
+  mltt_term_display(store, type0) == "Type0" and
+    mltt_term_display(store, pi) == "(x: A) -> A" and
+    mltt_term_display(store, sigma) == "Sigma(x: A). A" and
+    mltt_term_display(store, eq) == "Eq(A, n, n)" and
+    mltt_term_display(store, vec) == "Vec(A, n)"
+}
+
+def mltt_infers_universes_and_variables(): Bool = {
+  var store = mltt_term_store();
+  val context = mltt_context();
+  val type0 = store.alloc_universe(0);
+  val type_result = mltt_infer(store, context, type0);
+  val context_with_a = mltt_context_extend_local(context, "A", type0);
+  val a = store.alloc_var("A");
+  val var_result = mltt_infer(store, context_with_a, a);
+
+  type_result.is_ok() and
+    mltt_term_display(store, type_result.typ) == "Type1" and
+    var_result.is_ok() and
+    mltt_term_display(store, var_result.typ) == "Type0"
+}
+
+def mltt_lambda_checks_against_pi(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val a = store.alloc_var("A");
+  val context = mltt_context_extend_local(mltt_context(), "A", type0);
+  val body = store.alloc_var("x");
+  val lambda = store.alloc_lambda("x", a, body);
+  val expected = store.alloc_pi("x", a, a);
+
+  val checked = mltt_check(store, context, lambda, expected);
+  checked.is_ok() and
+    checked.profile_id == "mltt.core" and
+    checked.artifact_kind == "mltt-core-term" and
+    checked.artifact_summary() == "mltt.core|mltt-core-term|accepted|mltt.whnf-conversion"
+}
+
+def mltt_application_infers_through_pi(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val a = store.alloc_var("A");
+  var context = mltt_context_extend_local(mltt_context(), "A", type0);
+  context = mltt_context_extend_local(context, "y", a);
+
+  val body = store.alloc_var("x");
+  val lambda = store.alloc_lambda("x", a, body);
+  val y = store.alloc_var("y");
+  val apply = store.alloc_apply(lambda, y);
+  val inferred = mltt_infer(store, context, apply);
+
+  inferred.is_ok() and mltt_term_display(store, inferred.typ) == "A"
+}
+
+def mltt_unknown_variable_reports_profile_diagnostic(): Bool = {
+  var store = mltt_term_store();
+  val context = mltt_context();
+  val missing = store.alloc_var("missing");
+  val inferred = mltt_infer(store, context, missing);
+
+  !inferred.is_ok() and
+    inferred.first_code() == mltt_unknown_variable_code() and
+    inferred.diagnostics.get(0).profile_id == "mltt.core" and
+    inferred.diagnostics.get(0).context_summary == "<empty>"
+}
+
+def mltt_non_function_application_reports_diagnostic(): Bool = {
+  var store = mltt_term_store();
+  val context = mltt_context();
+  val type0 = store.alloc_universe(0);
+  val arg = store.alloc_universe(0);
+  val apply = store.alloc_apply(type0, arg);
+  val inferred = mltt_infer(store, context, apply);
+
+  !inferred.is_ok() and inferred.first_code() == mltt_non_function_application_code()
+}
+
+def mltt_conversion_accepts_beta_and_let(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val a = store.alloc_var("A");
+  var context = mltt_context_extend_local(mltt_context(), "A", type0);
+  context = mltt_context_extend_local(context, "y", a);
+
+  val x = store.alloc_var("x");
+  val lambda = store.alloc_lambda("x", a, x);
+  val y = store.alloc_var("y");
+  val apply = store.alloc_apply(lambda, y);
+  val beta = mltt_convert(store, context, apply, y);
+  val let_term = store.alloc_let("z", y, store.alloc_var("z"));
+  val let_conversion = mltt_convert(store, context, let_term, y);
+
+  beta.is_ok() and
+    beta.strategy == mltt_whnf_conversion_strategy() and
+    let_conversion.is_ok()
+}
+
+def mltt_conversion_reduces_transparent_nat_definition(): Bool = {
+  var store = mltt_term_store();
+  val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+  val n = store.alloc_var("n");
+  var context = mltt_context_extend_local(mltt_context(), "n", nat);
+  context = mltt_context_extend_definition(context, "add_Z_n", nat, n, true, true);
+  val add_z_n = store.alloc_var("add_Z_n");
+  val converted = mltt_convert(store, context, add_z_n, n);
+
+  converted.is_ok()
+}
+
+def mltt_conversion_rejects_effectful_definition(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val a = store.alloc_var("A");
+  val y = store.alloc_var("y");
+  var context = mltt_context_extend_local(mltt_context(), "A", type0);
+  context = mltt_context_extend_local(context, "y", a);
+  context = mltt_context_extend_definition(context, "effectful", a, y, false, false);
+  val effectful = store.alloc_var("effectful");
+  val converted = mltt_convert(store, context, effectful, y);
+
+  !converted.is_ok() and converted.first_code() == mltt_effectful_conversion_code()
+}
+
+def mltt_conversion_rejects_unknown_normalization_profile(): Bool = {
+  var store = mltt_term_store();
+  val context = mltt_context();
+  val type0 = store.alloc_universe(0);
+  val converted = mltt_convert_with_strategy(store, context, type0, type0, "mltt.full-normalization");
+
+  !converted.is_ok() and converted.first_code() == mltt_unsupported_normalization_profile_code()
+}
+
+def mltt_sigma_pair_and_refl_check(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val a = store.alloc_var("A");
+  val x = store.alloc_var("x");
+  var context = mltt_context_extend_local(mltt_context(), "A", type0);
+  context = mltt_context_extend_local(context, "x", a);
+
+  val sigma = store.alloc_sigma("left", a, a);
+  val pair = store.alloc_pair(x, x);
+  val pair_checked = mltt_check(store, context, pair, sigma);
+  val eq = store.alloc_eq(a, x, x);
+  val refl = store.alloc_refl(x);
+  val refl_checked = mltt_check(store, context, refl, eq);
+
+  pair_checked.is_ok() and refl_checked.is_ok()
+}
+
+def mltt_nat_and_vec_declaration_metadata_is_deterministic(): Bool = {
+  var store = mltt_term_store();
+  var env = mltt_declaration_env();
+  mltt_add_nat_fixture(store, env);
+  mltt_add_vec_fixture(store, env);
+
+  val maybe_nat = env.find_inductive("Nat");
+  val maybe_vec = env.find_inductive("Vec");
+  maybe_nat match {
+    case Option[MlttInductiveDecl]::Some(nat) => {
+      maybe_vec match {
+        case Option[MlttInductiveDecl]::Some(vec) => {
+          val nil = vec.constructors.get(0);
+          val cons = vec.constructors.get(1);
+          nat.constructors.get(0).name == "Z" and
+            nat.constructors.get(1).name == "S" and
+            vec.parameters.get(0).name == "A" and
+            vec.indices.get(0).name == "n" and
+            mltt_term_display(store, nil.result) == "Vec(A, Z)" and
+            mltt_term_display(store, cons.result) == "Vec(A, S(k))" and
+            cons.telescope.get(2).name == "tail"
+        }
+        case Option[MlttInductiveDecl]::None => {
+          false
+        }
+      }
+    }
+    case Option[MlttInductiveDecl]::None => {
+      false
+    }
+  }
+}
+
+def mltt_nat_constructor_checks_without_pattern_matching(): Bool = {
+  var store = mltt_term_store();
+  val context = mltt_context();
+  val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+  val z = store.alloc_constructor("Z", Vec[MlttTermId]());
+  val s_args = Vec[MlttTermId]();
+  s_args.push(z);
+  val s_z = store.alloc_constructor("S", s_args);
+  val checked = mltt_check(store, context, s_z, nat);
+
+  checked.is_ok()
+}
+
+def mltt_vec_constructor_signatures_check_without_pattern_matching(): Bool = {
+  var store = mltt_term_store();
+  val type0 = store.alloc_universe(0);
+  val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+  val a = store.alloc_var("A");
+  val k = store.alloc_var("k");
+  val head = store.alloc_var("head");
+  val tail = store.alloc_var("tail");
+  var context = mltt_context_extend_local(mltt_context(), "A", type0);
+  context = mltt_context_extend_local(context, "k", nat);
+  context = mltt_context_extend_local(context, "head", a);
+  val tail_indices = Vec[MlttTermId]();
+  tail_indices.push(k);
+  val tail_type = store.alloc_inductive("Vec", mltt_single_term(a), tail_indices);
+  context = mltt_context_extend_local(context, "tail", tail_type);
+
+  val z = store.alloc_constructor("Z", Vec[MlttTermId]());
+  val nil_indices = Vec[MlttTermId]();
+  nil_indices.push(z);
+  val vec_a_z = store.alloc_inductive("Vec", mltt_single_term(a), nil_indices);
+  val nil = store.alloc_constructor("Nil", Vec[MlttTermId]());
+
+  val s_args = Vec[MlttTermId]();
+  s_args.push(k);
+  val s_k = store.alloc_constructor("S", s_args);
+  val cons_indices = Vec[MlttTermId]();
+  cons_indices.push(s_k);
+  val vec_a_s_k = store.alloc_inductive("Vec", mltt_single_term(a), cons_indices);
+  val cons_args = Vec[MlttTermId]();
+  cons_args.push(k);
+  cons_args.push(head);
+  cons_args.push(tail);
+  val cons = store.alloc_constructor("Cons", cons_args);
+
+  val nil_checked = mltt_check(store, context, nil, vec_a_z);
+  val cons_checked = mltt_check(store, context, cons, vec_a_s_k);
+
+  nil_checked.is_ok() and cons_checked.is_ok()
+}
+
+def mltt_metavariables_are_local_and_reportable(): Bool = {
+  var store = mltt_term_store();
+  var metas = mltt_meta_store();
+  val context = mltt_context();
+  val type0 = store.alloc_universe(0);
+  val id = metas.new_meta(context, type0);
+  val meta_term = store.alloc_meta(id);
+  val has_unsolved = metas.has_unsolved_public_meta();
+  val solved = metas.solve_exact(id, type0);
+
+  id == 0 and
+    mltt_term_display(store, meta_term) == "?m0" and
+    has_unsolved and
+    solved and
+    !metas.has_unsolved_public_meta()
+}
+
+def mltt_higher_order_unification_is_rejected_deterministically(): Bool = {
+  val diagnostic = mltt_reject_higher_order_unification(mltt_context());
+  diagnostic.code == mltt_higher_order_unification_code() and
+    diagnostic.profile_id == "mltt.core" and
+    diagnostic.expected == "first-order pattern constraint"
+}
+
+def main(): i32 = {
+  if (!mltt_profile_metadata_declares_core_checker()) {
+    return 1
+  }
+  if (!mltt_core_display_covers_pi_sigma_eq_nat_vec()) {
+    return 1
+  }
+  if (!mltt_infers_universes_and_variables()) {
+    return 1
+  }
+  if (!mltt_lambda_checks_against_pi()) {
+    return 1
+  }
+  if (!mltt_application_infers_through_pi()) {
+    return 1
+  }
+  if (!mltt_unknown_variable_reports_profile_diagnostic()) {
+    return 1
+  }
+  if (!mltt_non_function_application_reports_diagnostic()) {
+    return 1
+  }
+  if (!mltt_conversion_accepts_beta_and_let()) {
+    return 1
+  }
+  if (!mltt_conversion_reduces_transparent_nat_definition()) {
+    return 1
+  }
+  if (!mltt_conversion_rejects_effectful_definition()) {
+    return 1
+  }
+  if (!mltt_conversion_rejects_unknown_normalization_profile()) {
+    return 1
+  }
+  if (!mltt_sigma_pair_and_refl_check()) {
+    return 1
+  }
+  if (!mltt_nat_and_vec_declaration_metadata_is_deterministic()) {
+    return 1
+  }
+  if (!mltt_nat_constructor_checks_without_pattern_matching()) {
+    return 1
+  }
+  if (!mltt_vec_constructor_signatures_check_without_pattern_matching()) {
+    return 1
+  }
+  if (!mltt_metavariables_are_local_and_reportable()) {
+    return 1
+  }
+  if (!mltt_higher_order_unification_is_rejected_deterministically()) {
+    return 1
+  }
+  0
+}

--- a/packages/cosmoc/src/types/mltt/core.cos
+++ b/packages/cosmoc/src/types/mltt/core.cos
@@ -1,0 +1,760 @@
+type MlttTermId = Id[MlttTerm]
+
+class MlttTerm {
+  case Var(String)
+  case Universe(usize)
+  case Pi(String, MlttTermId, MlttTermId)
+  case Sigma(String, MlttTermId, MlttTermId)
+  case Lambda(String, MlttTermId, MlttTermId)
+  case Apply(MlttTermId, MlttTermId)
+  case Pair(MlttTermId, MlttTermId)
+  case Fst(MlttTermId)
+  case Snd(MlttTermId)
+  case Let(String, MlttTermId, MlttTermId)
+  case Inductive(String, Vec[MlttTermId], Vec[MlttTermId])
+  case Constructor(String, Vec[MlttTermId])
+  case Eq(MlttTermId, MlttTermId, MlttTermId)
+  case Refl(MlttTermId)
+  case Neutral(String, Vec[MlttTermId])
+  case Meta(usize)
+  case Error
+}
+
+class MlttTermStore {
+  var terms: Arena[MlttTerm]
+
+  def alloc(&mut self, value: MlttTerm): MlttTermId = {
+    var terms = self.terms;
+    val id = terms.alloc(value);
+    self.terms = terms;
+    id
+  }
+
+  def term_value(&self, id: MlttTermId): MlttTerm = {
+    *self.terms.get(id)
+  }
+
+  def alloc_var(&mut self, name: String): MlttTermId = {
+    self.alloc(MlttTerm.Var(name))
+  }
+
+  def alloc_universe(&mut self, level: usize): MlttTermId = {
+    self.alloc(MlttTerm.Universe(level))
+  }
+
+  def alloc_pi(&mut self, name: String, domain: MlttTermId, body: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Pi(name, domain, body))
+  }
+
+  def alloc_sigma(&mut self, name: String, first: MlttTermId, second: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Sigma(name, first, second))
+  }
+
+  def alloc_lambda(&mut self, name: String, annotation: MlttTermId, body: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Lambda(name, annotation, body))
+  }
+
+  def alloc_apply(&mut self, function: MlttTermId, argument: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Apply(function, argument))
+  }
+
+  def alloc_pair(&mut self, first: MlttTermId, second: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Pair(first, second))
+  }
+
+  def alloc_fst(&mut self, pair: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Fst(pair))
+  }
+
+  def alloc_snd(&mut self, pair: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Snd(pair))
+  }
+
+  def alloc_let(&mut self, name: String, value: MlttTermId, body: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Let(name, value, body))
+  }
+
+  def alloc_inductive(&mut self, name: String, params: Vec[MlttTermId], indices: Vec[MlttTermId]): MlttTermId = {
+    self.alloc(MlttTerm.Inductive(name, params, indices))
+  }
+
+  def alloc_constructor(&mut self, name: String, args: Vec[MlttTermId]): MlttTermId = {
+    self.alloc(MlttTerm.Constructor(name, args))
+  }
+
+  def alloc_eq(&mut self, typ: MlttTermId, left: MlttTermId, right: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Eq(typ, left, right))
+  }
+
+  def alloc_refl(&mut self, value: MlttTermId): MlttTermId = {
+    self.alloc(MlttTerm.Refl(value))
+  }
+
+  def alloc_neutral(&mut self, head: String, spine: Vec[MlttTermId]): MlttTermId = {
+    self.alloc(MlttTerm.Neutral(head, spine))
+  }
+
+  def alloc_meta(&mut self, index: usize): MlttTermId = {
+    self.alloc(MlttTerm.Meta(index))
+  }
+
+  def alloc_error(&mut self): MlttTermId = {
+    self.alloc(MlttTerm.Error)
+  }
+
+  def len(&self): usize = {
+    self.terms.len()
+  }
+}
+
+class MlttContextEntry {
+  val name: String
+  val typ: MlttTermId
+  val value: Option[MlttTermId]
+  val transparent: Bool
+  val pure: Bool
+  val universe_level: usize
+}
+
+class MlttContext {
+  val entries: Vec[MlttContextEntry]
+
+  def lookup(&self, name: String): Option[MlttContextEntry] = {
+    var remaining = self.entries.len();
+    while (remaining > 0) {
+      remaining = remaining - 1;
+      val entry = self.entries.get(remaining);
+      if (entry.name == name) {
+        return Option[MlttContextEntry]::Some(entry)
+      }
+    }
+    Option[MlttContextEntry]::None
+  }
+
+  def summary(&self): String = {
+    if (self.entries.is_empty()) {
+      return "<empty>"
+    }
+    var text = "";
+    var index: usize = 0;
+    while (index < self.entries.len()) {
+      if (index > 0) {
+        text = text.concat(", ")
+      }
+      text = text.concat(self.entries.get(index).name);
+      index = index + 1
+    }
+    text
+  }
+}
+
+class MlttBinder {
+  val name: String
+  val typ: MlttTermId
+}
+
+class MlttDefinitionDecl {
+  val name: String
+  val typ: MlttTermId
+  val value: MlttTermId
+  val transparent: Bool
+  val pure: Bool
+}
+
+class MlttConstructorDecl {
+  val name: String
+  val telescope: Vec[MlttBinder]
+  val result: MlttTermId
+}
+
+class MlttInductiveDecl {
+  val name: String
+  val parameters: Vec[MlttBinder]
+  val indices: Vec[MlttBinder]
+  val constructors: Vec[MlttConstructorDecl]
+}
+
+class MlttDeclarationEnv {
+  var definitions: Vec[MlttDefinitionDecl]
+  var inductives: Vec[MlttInductiveDecl]
+
+  def add_definition(&mut self, decl: MlttDefinitionDecl): Unit = {
+    self.definitions.push(decl)
+  }
+
+  def add_inductive(&mut self, decl: MlttInductiveDecl): Unit = {
+    self.inductives.push(decl)
+  }
+
+  def find_definition(&self, name: String): Option[MlttDefinitionDecl] = {
+    var index: usize = 0;
+    while (index < self.definitions.len()) {
+      val decl = self.definitions.get(index);
+      if (decl.name == name) {
+        return Option[MlttDefinitionDecl]::Some(decl)
+      }
+      index = index + 1
+    }
+    Option[MlttDefinitionDecl]::None
+  }
+
+  def find_inductive(&self, name: String): Option[MlttInductiveDecl] = {
+    var index: usize = 0;
+    while (index < self.inductives.len()) {
+      val decl = self.inductives.get(index);
+      if (decl.name == name) {
+        return Option[MlttInductiveDecl]::Some(decl)
+      }
+      index = index + 1
+    }
+    Option[MlttInductiveDecl]::None
+  }
+
+  def find_constructor(&self, name: String): Option[MlttConstructorDecl] = {
+    var family_index: usize = 0;
+    while (family_index < self.inductives.len()) {
+      val family = self.inductives.get(family_index);
+      var ctor_index: usize = 0;
+      while (ctor_index < family.constructors.len()) {
+        val ctor = family.constructors.get(ctor_index);
+        if (ctor.name == name) {
+          return Option[MlttConstructorDecl]::Some(ctor)
+        }
+        ctor_index = ctor_index + 1
+      }
+      family_index = family_index + 1
+    }
+    Option[MlttConstructorDecl]::None
+  }
+}
+
+class MlttMetaVar {
+  val id: usize
+  val context_summary: String
+  val expected_type: MlttTermId
+  val solution: Option[MlttTermId]
+}
+
+class MlttMetaStore {
+  var metas: Vec[MlttMetaVar]
+
+  def new_meta(&mut self, context: &MlttContext, expected_type: MlttTermId): usize = {
+    val id = self.metas.len();
+    self.metas.push(MlttMetaVar(id, context.summary(), expected_type, Option[MlttTermId]::None));
+    id
+  }
+
+  def solve_exact(&mut self, id: usize, value: MlttTermId): Bool = {
+    if (id >= self.metas.len()) {
+      return false
+    }
+    val current = self.metas.get(id);
+    val solved = MlttMetaVar(
+      current.id,
+      current.context_summary,
+      current.expected_type,
+      Option[MlttTermId]::Some(value)
+    );
+    val next = Vec[MlttMetaVar]();
+    var index: usize = 0;
+    while (index < self.metas.len()) {
+      if (index == id) {
+        next.push(solved)
+      } else {
+        next.push(self.metas.get(index))
+      }
+      index = index + 1
+    }
+    self.metas = next;
+    true
+  }
+
+  def has_unsolved_public_meta(&self): Bool = {
+    var index: usize = 0;
+    while (index < self.metas.len()) {
+      val meta = self.metas.get(index);
+      meta.solution match {
+        case Option[MlttTermId]::Some(value) => {
+        }
+        case Option[MlttTermId]::None => {
+          return true
+        }
+      }
+      index = index + 1
+    }
+    false
+  }
+}
+
+def mltt_term_store(): MlttTermStore = {
+  MlttTermStore(Arena[MlttTerm]())
+}
+
+def mltt_context(): MlttContext = {
+  MlttContext(Vec[MlttContextEntry]())
+}
+
+def mltt_declaration_env(): MlttDeclarationEnv = {
+  MlttDeclarationEnv(Vec[MlttDefinitionDecl](), Vec[MlttInductiveDecl]())
+}
+
+def mltt_meta_store(): MlttMetaStore = {
+  MlttMetaStore(Vec[MlttMetaVar]())
+}
+
+def mltt_context_extend_local(ctx: &MlttContext, name: String, typ: MlttTermId): MlttContext = {
+  val entries = mltt_copy_context_entries(ctx.entries);
+  entries.push(MlttContextEntry(name, typ, Option[MlttTermId]::None, false, true, 0));
+  MlttContext(entries)
+}
+
+def mltt_context_extend_definition(
+  ctx: &MlttContext,
+  name: String,
+  typ: MlttTermId,
+  value: MlttTermId,
+  transparent: Bool,
+  pure: Bool
+): MlttContext = {
+  val entries = mltt_copy_context_entries(ctx.entries);
+  entries.push(MlttContextEntry(name, typ, Option[MlttTermId]::Some(value), transparent, pure, 0));
+  MlttContext(entries)
+}
+
+def mltt_copy_context_entries(entries: &Vec[MlttContextEntry]): Vec[MlttContextEntry] = {
+  val copied = Vec[MlttContextEntry]();
+  var index: usize = 0;
+  while (index < entries.len()) {
+    copied.push(entries.get(index));
+    index = index + 1
+  }
+  copied
+}
+
+def mltt_empty_terms(): Vec[MlttTermId] = {
+  Vec[MlttTermId]()
+}
+
+def mltt_copy_terms(items: &Vec[MlttTermId]): Vec[MlttTermId] = {
+  val copied = Vec[MlttTermId]();
+  var index: usize = 0;
+  while (index < items.len()) {
+    copied.push(items.get(index));
+    index = index + 1
+  }
+  copied
+}
+
+def mltt_term_display(store: &MlttTermStore, id: MlttTermId): String = {
+  val value = store.term_value(id);
+  value match {
+    case MlttTerm.Var(name) => {
+      name
+    }
+    case MlttTerm.Universe(level) => {
+      "Type".concat(mltt_ordinal_text(level))
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      "(".concat(name)
+        .concat(": ")
+        .concat(mltt_term_display(store, domain))
+        .concat(") -> ")
+        .concat(mltt_term_display(store, body))
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      "Sigma(".concat(name)
+        .concat(": ")
+        .concat(mltt_term_display(store, first))
+        .concat("). ")
+        .concat(mltt_term_display(store, second))
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      "fun ".concat(name)
+        .concat(": ")
+        .concat(mltt_term_display(store, annotation))
+        .concat(" => ")
+        .concat(mltt_term_display(store, body))
+    }
+    case MlttTerm.Apply(function, argument) => {
+      mltt_term_display(store, function)
+        .concat("(")
+        .concat(mltt_term_display(store, argument))
+        .concat(")")
+    }
+    case MlttTerm.Pair(first, second) => {
+      "(".concat(mltt_term_display(store, first))
+        .concat(", ")
+        .concat(mltt_term_display(store, second))
+        .concat(")")
+    }
+    case MlttTerm.Fst(pair) => {
+      "fst(".concat(mltt_term_display(store, pair)).concat(")")
+    }
+    case MlttTerm.Snd(pair) => {
+      "snd(".concat(mltt_term_display(store, pair)).concat(")")
+    }
+    case MlttTerm.Let(name, value, body) => {
+      "let ".concat(name)
+        .concat(" = ")
+        .concat(mltt_term_display(store, value))
+        .concat("; ")
+        .concat(mltt_term_display(store, body))
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      mltt_head_display(store, name, params, indices)
+    }
+    case MlttTerm.Constructor(name, args) => {
+      mltt_args_display(store, name, args)
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      "Eq(".concat(mltt_term_display(store, typ))
+        .concat(", ")
+        .concat(mltt_term_display(store, left))
+        .concat(", ")
+        .concat(mltt_term_display(store, right))
+        .concat(")")
+    }
+    case MlttTerm.Refl(value) => {
+      "Refl(".concat(mltt_term_display(store, value)).concat(")")
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      mltt_args_display(store, head, spine)
+    }
+    case MlttTerm.Meta(index) => {
+      "?m".concat(mltt_ordinal_text(index))
+    }
+    case MlttTerm.Error => {
+      "<error>"
+    }
+  }
+}
+
+def mltt_head_display(
+  store: &MlttTermStore,
+  name: String,
+  params: &Vec[MlttTermId],
+  indices: &Vec[MlttTermId]
+): String = {
+  val args = Vec[MlttTermId]();
+  var param_index: usize = 0;
+  while (param_index < params.len()) {
+    args.push(params.get(param_index));
+    param_index = param_index + 1
+  }
+  var index_index: usize = 0;
+  while (index_index < indices.len()) {
+    args.push(indices.get(index_index));
+    index_index = index_index + 1
+  }
+  mltt_args_display(store, name, args)
+}
+
+def mltt_args_display(store: &MlttTermStore, name: String, args: &Vec[MlttTermId]): String = {
+  if (args.is_empty()) {
+    return name
+  }
+  name.concat("(").concat(mltt_term_list_display(store, args)).concat(")")
+}
+
+def mltt_term_list_display(store: &MlttTermStore, args: &Vec[MlttTermId]): String = {
+  var text = "";
+  var index: usize = 0;
+  while (index < args.len()) {
+    if (index > 0) {
+      text = text.concat(", ")
+    }
+    text = text.concat(mltt_term_display(store, args.get(index)));
+    index = index + 1
+  }
+  text
+}
+
+def mltt_substitute(
+  store: &mut MlttTermStore,
+  term: MlttTermId,
+  name: String,
+  replacement: MlttTermId
+): MlttTermId = {
+  val value = store.term_value(term);
+  value match {
+    case MlttTerm.Var(var_name) => {
+      if (var_name == name) {
+        return replacement
+      }
+      store.alloc_var(var_name)
+    }
+    case MlttTerm.Universe(level) => {
+      store.alloc_universe(level)
+    }
+    case MlttTerm.Pi(param, domain, body) => {
+      val next_domain = mltt_substitute(store, domain, name, replacement);
+      var next_body = body;
+      if (param != name) {
+        next_body = mltt_substitute(store, body, name, replacement)
+      }
+      store.alloc_pi(param, next_domain, next_body)
+    }
+    case MlttTerm.Sigma(param, first, second) => {
+      val next_first = mltt_substitute(store, first, name, replacement);
+      var next_second = second;
+      if (param != name) {
+        next_second = mltt_substitute(store, second, name, replacement)
+      }
+      store.alloc_sigma(param, next_first, next_second)
+    }
+    case MlttTerm.Lambda(param, annotation, body) => {
+      val next_annotation = mltt_substitute(store, annotation, name, replacement);
+      var next_body = body;
+      if (param != name) {
+        next_body = mltt_substitute(store, body, name, replacement)
+      }
+      store.alloc_lambda(param, next_annotation, next_body)
+    }
+    case MlttTerm.Apply(function, argument) => {
+      val next_function = mltt_substitute(store, function, name, replacement);
+      val next_argument = mltt_substitute(store, argument, name, replacement);
+      store.alloc_apply(next_function, next_argument)
+    }
+    case MlttTerm.Pair(first, second) => {
+      val next_first = mltt_substitute(store, first, name, replacement);
+      val next_second = mltt_substitute(store, second, name, replacement);
+      store.alloc_pair(next_first, next_second)
+    }
+    case MlttTerm.Fst(pair) => {
+      store.alloc_fst(mltt_substitute(store, pair, name, replacement))
+    }
+    case MlttTerm.Snd(pair) => {
+      store.alloc_snd(mltt_substitute(store, pair, name, replacement))
+    }
+    case MlttTerm.Let(local_name, local_value, body) => {
+      val next_value = mltt_substitute(store, local_value, name, replacement);
+      var next_body = body;
+      if (local_name != name) {
+        next_body = mltt_substitute(store, body, name, replacement)
+      }
+      store.alloc_let(local_name, next_value, next_body)
+    }
+    case MlttTerm.Inductive(inductive_name, params, indices) => {
+      store.alloc_inductive(
+        inductive_name,
+        mltt_substitute_terms(store, params, name, replacement),
+        mltt_substitute_terms(store, indices, name, replacement)
+      )
+    }
+    case MlttTerm.Constructor(ctor_name, args) => {
+      store.alloc_constructor(ctor_name, mltt_substitute_terms(store, args, name, replacement))
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      store.alloc_eq(
+        mltt_substitute(store, typ, name, replacement),
+        mltt_substitute(store, left, name, replacement),
+        mltt_substitute(store, right, name, replacement)
+      )
+    }
+    case MlttTerm.Refl(refl_value) => {
+      store.alloc_refl(mltt_substitute(store, refl_value, name, replacement))
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      store.alloc_neutral(head, mltt_substitute_terms(store, spine, name, replacement))
+    }
+    case MlttTerm.Meta(index) => {
+      store.alloc_meta(index)
+    }
+    case MlttTerm.Error => {
+      store.alloc_error()
+    }
+  }
+}
+
+def mltt_substitute_terms(
+  store: &mut MlttTermStore,
+  items: &Vec[MlttTermId],
+  name: String,
+  replacement: MlttTermId
+): Vec[MlttTermId] = {
+  val copied = Vec[MlttTermId]();
+  var index: usize = 0;
+  while (index < items.len()) {
+    copied.push(mltt_substitute(store, items.get(index), name, replacement));
+    index = index + 1
+  }
+  copied
+}
+
+def mltt_terms_equal(store: &MlttTermStore, left: MlttTermId, right: MlttTermId): Bool = {
+  mltt_term_display(store, left) == mltt_term_display(store, right)
+}
+
+def mltt_universe_level_of_term(store: &MlttTermStore, id: MlttTermId): Option[usize] = {
+  val value = store.term_value(id);
+  value match {
+    case MlttTerm.Universe(level) => {
+      Option[usize]::Some(level)
+    }
+    case MlttTerm.Var(name) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Pi(name, domain, body) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Sigma(name, first, second) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Lambda(name, annotation, body) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Apply(function, argument) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Pair(first, second) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Fst(pair) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Snd(pair) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Let(name, value, body) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Inductive(name, params, indices) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Constructor(name, args) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Eq(typ, left, right) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Refl(value) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Neutral(head, spine) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Meta(index) => {
+      Option[usize]::None
+    }
+    case MlttTerm.Error => {
+      Option[usize]::None
+    }
+  }
+}
+
+def mltt_type_universe_level(store: &MlttTermStore, inferred_type: MlttTermId): Option[usize] = {
+  val maybe_level = mltt_universe_level_of_term(store, inferred_type);
+  maybe_level match {
+    case Option[usize]::Some(level) => {
+      if (level == 0) {
+        return Option[usize]::Some(0)
+      }
+      Option[usize]::Some(level - 1)
+    }
+    case Option[usize]::None => {
+      Option[usize]::None
+    }
+  }
+}
+
+def mltt_max_usize(left: usize, right: usize): usize = {
+  if (left > right) {
+    return left
+  }
+  right
+}
+
+def mltt_add_nat_fixture(store: &mut MlttTermStore, env: &mut MlttDeclarationEnv): Unit = {
+  val type0 = store.alloc_universe(0);
+  val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+  val z = MlttConstructorDecl("Z", Vec[MlttBinder](), nat);
+  val s_telescope = Vec[MlttBinder]();
+  s_telescope.push(MlttBinder("pred", nat));
+  val s = MlttConstructorDecl("S", s_telescope, nat);
+  val ctors = Vec[MlttConstructorDecl]();
+  ctors.push(z);
+  ctors.push(s);
+  env.add_inductive(MlttInductiveDecl("Nat", Vec[MlttBinder](), Vec[MlttBinder](), ctors));
+  env.add_definition(MlttDefinitionDecl("Nat", type0, nat, true, true))
+}
+
+def mltt_add_vec_fixture(store: &mut MlttTermStore, env: &mut MlttDeclarationEnv): Unit = {
+  val type0 = store.alloc_universe(0);
+  val nat = store.alloc_inductive("Nat", Vec[MlttTermId](), Vec[MlttTermId]());
+  val a = store.alloc_var("A");
+  val n = store.alloc_var("n");
+  val k = store.alloc_var("k");
+  val z = store.alloc_constructor("Z", Vec[MlttTermId]());
+  val s_args = Vec[MlttTermId]();
+  s_args.push(k);
+  val s_k = store.alloc_constructor("S", s_args);
+  val nil_indices = Vec[MlttTermId]();
+  nil_indices.push(z);
+  val nil_result = store.alloc_inductive("Vec", mltt_single_term(a), nil_indices);
+  val tail_indices = Vec[MlttTermId]();
+  tail_indices.push(k);
+  val tail_type = store.alloc_inductive("Vec", mltt_single_term(a), tail_indices);
+  val cons_indices = Vec[MlttTermId]();
+  cons_indices.push(s_k);
+  val cons_result = store.alloc_inductive("Vec", mltt_single_term(a), cons_indices);
+
+  val params = Vec[MlttBinder]();
+  params.push(MlttBinder("A", type0));
+  val indices = Vec[MlttBinder]();
+  indices.push(MlttBinder("n", nat));
+  val nil = MlttConstructorDecl("Nil", Vec[MlttBinder](), nil_result);
+  val cons_telescope = Vec[MlttBinder]();
+  cons_telescope.push(MlttBinder("k", nat));
+  cons_telescope.push(MlttBinder("head", a));
+  cons_telescope.push(MlttBinder("tail", tail_type));
+  val cons = MlttConstructorDecl("Cons", cons_telescope, cons_result);
+  val ctors = Vec[MlttConstructorDecl]();
+  ctors.push(nil);
+  ctors.push(cons);
+  env.add_inductive(MlttInductiveDecl("Vec", params, indices, ctors));
+  env.add_definition(MlttDefinitionDecl("Vec", type0, store.alloc_inductive("Vec", mltt_single_term(a), mltt_single_term(n)), true, true))
+}
+
+def mltt_single_term(term: MlttTermId): Vec[MlttTermId] = {
+  val items = Vec[MlttTermId]();
+  items.push(term);
+  items
+}
+
+def mltt_ordinal_text(value: usize): String = {
+  if (value < 10) {
+    return mltt_digit_text(value)
+  }
+  mltt_ordinal_text(value / 10).concat(mltt_digit_text(value % 10))
+}
+
+def mltt_digit_text(value: usize): String = {
+  if (value == 0) {
+    return "0"
+  }
+  if (value == 1) {
+    return "1"
+  }
+  if (value == 2) {
+    return "2"
+  }
+  if (value == 3) {
+    return "3"
+  }
+  if (value == 4) {
+    return "4"
+  }
+  if (value == 5) {
+    return "5"
+  }
+  if (value == 6) {
+    return "6"
+  }
+  if (value == 7) {
+    return "7"
+  }
+  if (value == 8) {
+    return "8"
+  }
+  "9"
+}

--- a/packages/cosmoc/src/types/profile.cos
+++ b/packages/cosmoc/src/types/profile.cos
@@ -107,6 +107,10 @@ def checker_feature_effects(): String = {
   "effects"
 }
 
+def checker_feature_async(): String = {
+  "async"
+}
+
 def checker_feature_traits(): String = {
   "traits"
 }
@@ -125,6 +129,18 @@ def checker_feature_dependent_pattern_elaboration(): String = {
 
 def checker_feature_cpp_imports(): String = {
   "cpp-imports"
+}
+
+def checker_feature_macros(): String = {
+  "macros"
+}
+
+def checker_feature_reflection(): String = {
+  "reflection"
+}
+
+def checker_feature_staging(): String = {
+  "staging"
 }
 
 def checker_profile_cosmoc_basic_expr(): CheckerProfile = {
@@ -218,7 +234,14 @@ def checker_mltt_core_supported_features(): Vec[String] = {
   features.push("mltt-core-terms");
   features.push("universes");
   features.push("pi-types");
+  features.push("sigma-types");
+  features.push("equality-types");
+  features.push("let-reduction");
+  features.push("nat-metadata");
+  features.push("vec-metadata");
+  features.push("metavariables");
   features.push("conversion");
+  features.push("whnf-conversion");
   features
 }
 
@@ -235,19 +258,27 @@ def checker_mltt_dependent_pattern_supported_features(): Vec[String] = {
 def checker_mltt_core_rejected_features(): Vec[CheckerFeatureRejection] = {
   val features = Vec[CheckerFeatureRejection]();
   features.push(CheckerFeatureRejection(checker_feature_effects(), checker_unsupported_effect_row_code()));
+  features.push(CheckerFeatureRejection(checker_feature_async(), checker_unsupported_effect_row_code()));
   features.push(CheckerFeatureRejection(checker_feature_traits(), checker_unsupported_trait_constraint_code()));
   features.push(CheckerFeatureRejection(checker_feature_object_dispatch(), checker_unsupported_object_dispatch_code()));
   features.push(CheckerFeatureRejection(checker_feature_dependent_patterns(), checker_unsupported_dependent_pattern_code()));
   features.push(CheckerFeatureRejection(checker_feature_cpp_imports(), checker_unsupported_cpp_import_code()));
+  features.push(CheckerFeatureRejection(checker_feature_macros(), checker_unsupported_feature_code()));
+  features.push(CheckerFeatureRejection(checker_feature_reflection(), checker_unsupported_feature_code()));
+  features.push(CheckerFeatureRejection(checker_feature_staging(), checker_unsupported_feature_code()));
   features
 }
 
 def checker_mltt_dependent_pattern_rejected_features(): Vec[CheckerFeatureRejection] = {
   val features = Vec[CheckerFeatureRejection]();
   features.push(CheckerFeatureRejection(checker_feature_effects(), checker_unsupported_effect_row_code()));
+  features.push(CheckerFeatureRejection(checker_feature_async(), checker_unsupported_effect_row_code()));
   features.push(CheckerFeatureRejection(checker_feature_traits(), checker_unsupported_trait_constraint_code()));
   features.push(CheckerFeatureRejection(checker_feature_object_dispatch(), checker_unsupported_object_dispatch_code()));
   features.push(CheckerFeatureRejection(checker_feature_cpp_imports(), checker_unsupported_cpp_import_code()));
+  features.push(CheckerFeatureRejection(checker_feature_macros(), checker_unsupported_feature_code()));
+  features.push(CheckerFeatureRejection(checker_feature_reflection(), checker_unsupported_feature_code()));
+  features.push(CheckerFeatureRejection(checker_feature_staging(), checker_unsupported_feature_code()));
   features
 }
 


### PR DESCRIPTION
## Summary
- add MLTT core term/context/declaration data and bidirectional checker under packages/cosmoc
- add Scala-side cosmo0 MLTT checker mirror with profile-aware diagnostics and WHNF conversion
- add profile metadata, package fixture, docs, and focused tests for mltt.core

## Tests
- sbt "cosmo0/test"
- sbt "cosmo/testOnly cosmo.Cosmo1MlttTypeCheckerTests"
- node scripts/validateCosmo0Docs.js
- openspec status --change introduce-mltt-type-checker