### PR TITLE
feat: route and document MLTT checker profiles

### DIFF
--- a/fixtures/cosmo0/package/mltt-core-profile/src/main.cos
+++ b/fixtures/cosmo0/package/mltt-core-profile/src/main.cos
@@ -1,1 +1,6 @@
-val answer = 42
+mltt: lambda-checks-pi
+mltt: application-infers-through-pi
+mltt: sigma-pair-checks
+mltt: equality-refl-checks
+mltt: conversion-beta-let
+mltt: vec-constructors-check

--- a/fixtures/cosmo0/package/mltt-dependent-pattern-profile/cosmo.json
+++ b/fixtures/cosmo0/package/mltt-dependent-pattern-profile/cosmo.json
@@ -1,0 +1,6 @@
+{
+  "name": "@cosmo0/package-mltt-dependent-pattern-profile",
+  "version": "0.0.0",
+  "target": "cosmo0",
+  "checkerProfile": "mltt.dependent-patterns"
+}

--- a/fixtures/cosmo0/package/mltt-dependent-pattern-profile/src/main.cos
+++ b/fixtures/cosmo0/package/mltt-dependent-pattern-profile/src/main.cos
@@ -1,0 +1,2 @@
+dependent-pattern: vec-head-elaborates
+dependent-pattern: impossible-nil-diagnostic

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -72,6 +72,11 @@ final class Cosmo0:
     CheckerProfiles.byId(profileId) match
       case Some(profile) if profile.id == CheckerProfiles.Cosmo0Subset.id =>
         checkWithProfile(source, profile)
+      case Some(profile) if profile.id == CheckerProfiles.MlttCore.id =>
+        checkedModuleResult(MlttProfileChecker.checkSource(source))
+      case Some(profile)
+          if profile.id == CheckerProfiles.MlttDependentPatterns.id =>
+        checkedModuleResult(DependentPatternProfileChecker.checkSource(source))
       case Some(profile) =>
         Result.unsupported(
           Phase.Check,
@@ -88,6 +93,22 @@ final class Cosmo0:
           Phase.Check,
           List(CheckerProfiles.unknownProfileDiagnostic(profileId)),
         )
+
+  private def checkedModuleResult(
+      result: Result[TypedModule],
+  ): Result[CheckedModule] =
+    result match
+      case checked if checked.isSuccess =>
+        Result.success(Phase.Check, CheckedModule(checked.value.get))
+      case checked if checked.isUnsupported =>
+        Result(
+          Phase.Check,
+          PhaseStatus.Unsupported,
+          None,
+          checked.diagnostics,
+        )
+      case failed =>
+        Result.failure(Phase.Check, failed.diagnostics)
 
   private def checkWithProfile(
       source: SourceFile,

--- a/packages/cosmo0/src/main/scala/cosmo0/source/Pipeline.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/source/Pipeline.scala
@@ -186,6 +186,38 @@ private[cosmo0] final class PackagePipeline(compiler: Cosmo0):
     module.modulePath == List("main")
 
   def check(pkg: Cosmo0Package): Result[CheckedPackage] =
+    selectedCheckerProfile(pkg.metadata) match
+      case Left(diagnostics) =>
+        return Result.failure(Phase.Check, diagnostics)
+      case Right(profile) =>
+        if profile.id == CheckerProfiles.MlttCore.id then
+          val diagnostics = stageProfileDiagnostics(pkg)
+          if diagnostics.nonEmpty then
+            return Result.failure(Phase.Check, diagnostics)
+          return checkProfilePackage(
+            pkg,
+            pkg.modules,
+            pkg.modules.map(module => moduleKey(module.modulePath)),
+            MlttProfileChecker.checkSources(
+              pkg.modules.map(_.source),
+              pkg.metadata.outputModuleName,
+            ),
+          )
+
+        if profile.id == CheckerProfiles.MlttDependentPatterns.id then
+          val diagnostics = stageProfileDiagnostics(pkg)
+          if diagnostics.nonEmpty then
+            return Result.failure(Phase.Check, diagnostics)
+          return checkProfilePackage(
+            pkg,
+            pkg.modules,
+            pkg.modules.map(module => moduleKey(module.modulePath)),
+            DependentPatternProfileChecker.checkSources(
+              pkg.modules.map(_.source),
+              pkg.metadata.outputModuleName,
+            ),
+          )
+
     val elaborated =
       pkg.modules.map(module => module -> compiler.elaborate(module.source))
     val diagnostics = elaborated.flatMap(_._2.diagnostics)
@@ -224,25 +256,16 @@ private[cosmo0] final class PackagePipeline(compiler: Cosmo0):
       pkg: Cosmo0Package,
       ordered: List[AnalyzedModule],
   ): Result[CheckedPackage] =
-    val stageDiagnostics =
-      pkg.metadata.stageProfile.toList.flatMap(profileName =>
-        StageCapabilityRegistry.validate(profileName),
-      )
+    val stageDiagnostics = stageProfileDiagnostics(pkg)
     if stageDiagnostics.nonEmpty then
       return Result.failure(Phase.Check, stageDiagnostics)
 
     val checkerProfile =
-      pkg.metadata.checkerProfile match
-        case Some(profileId) =>
-          CheckerProfiles.byId(profileId) match
-            case Some(profile) => profile
-            case None =>
-              return Result.failure(
-                Phase.Check,
-                List(CheckerProfiles.unknownProfileDiagnostic(profileId)),
-              )
-        case None =>
-          CheckerProfiles.Cosmo0Subset
+      selectedCheckerProfile(pkg.metadata) match
+        case Left(diagnostics) =>
+          return Result.failure(Phase.Check, diagnostics)
+        case Right(profile) =>
+          profile
 
     if checkerProfile.id != CheckerProfiles.Cosmo0Subset.id then
       return Result.unsupported(
@@ -272,22 +295,74 @@ private[cosmo0] final class PackagePipeline(compiler: Cosmo0):
       case typed if typed.isFailure =>
         Result.failure(Phase.Check, typed.diagnostics)
       case typed =>
-        val checkedModule = CheckedModule(typed.value.get)
-        LirLowerer(checkedModule.typed).lower() match
-          case lowered if lowered.isFailure =>
-            Result.failure(Phase.Check, lowered.diagnostics)
-          case lowered =>
-            val loweredModule = LoweredModule(checkedModule, lowered.value.get)
-            Result.success(
-              Phase.Check,
-              CheckedPackage(
-                pkg.metadata,
-                ordered.map(_.pkgModule),
-                ordered.map(_.key),
-                checkedModule,
-                loweredModule,
-              ),
-            )
+        checkedPackageFromTyped(
+          pkg,
+          ordered.map(_.pkgModule),
+          ordered.map(_.key),
+          typed.value.get,
+        )
+
+  private def checkProfilePackage(
+      pkg: Cosmo0Package,
+      modules: List[Cosmo0PackageModule],
+      moduleOrder: List[String],
+      typed: Result[TypedModule],
+  ): Result[CheckedPackage] =
+    typed match
+      case checked if checked.isFailure =>
+        Result.failure(Phase.Check, checked.diagnostics)
+      case checked if checked.isUnsupported =>
+        Result(
+          Phase.Check,
+          PhaseStatus.Unsupported,
+          None,
+          checked.diagnostics,
+        )
+      case checked =>
+        checkedPackageFromTyped(pkg, modules, moduleOrder, checked.value.get)
+
+  private def checkedPackageFromTyped(
+      pkg: Cosmo0Package,
+      modules: List[Cosmo0PackageModule],
+      moduleOrder: List[String],
+      typed: TypedModule,
+  ): Result[CheckedPackage] =
+    val checkedModule = CheckedModule(typed)
+    LirLowerer(checkedModule.typed).lower() match
+      case lowered if lowered.isFailure =>
+        Result.failure(Phase.Check, lowered.diagnostics)
+      case lowered =>
+        val loweredModule = LoweredModule(checkedModule, lowered.value.get)
+        Result.success(
+          Phase.Check,
+          CheckedPackage(
+            pkg.metadata,
+            modules,
+            moduleOrder,
+            checkedModule,
+            loweredModule,
+          ),
+        )
+
+  private def selectedCheckerProfile(
+      metadata: Cosmo0PackageMetadata,
+  ): Either[List[Diagnostic], CheckerProfile] =
+    metadata.checkerProfile match
+      case Some(profileId) =>
+        CheckerProfiles.byId(profileId) match
+          case Some(profile) =>
+            Right(profile)
+          case None =>
+            Left(List(CheckerProfiles.unknownProfileDiagnostic(profileId)))
+      case None =>
+        Right(CheckerProfiles.Cosmo0Subset)
+
+  private def stageProfileDiagnostics(
+      pkg: Cosmo0Package,
+  ): List[Diagnostic] =
+    pkg.metadata.stageProfile.toList.flatMap(profileName =>
+      StageCapabilityRegistry.validate(profileName),
+    )
 
   private def readMetadata(
       metadataPath: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/ProfileCheckers.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/ProfileCheckers.scala
@@ -54,6 +54,31 @@ private[cosmo0] object ProfileDirectiveParser:
 
 /** Source adapter for `checkerProfile: "mltt.core"`.
   *
+  * Profile source examples:
+  *
+  * {{{
+  * mltt: lambda-checks-pi
+  * mltt: application-infers-through-pi
+  * mltt: sigma-pair-checks
+  * mltt: equality-refl-checks
+  * mltt: conversion-beta-let
+  * mltt: vec-constructors-check
+  * }}}
+  *
+  * Rules:
+  *
+  * {{{
+  * lambda-checks-pi              runs Gamma |- fun x: A => x <= (x: A) -> A
+  * application-infers-through-pi runs Gamma |- (fun x: A => x)(y) => A
+  * sigma-pair-checks             runs Gamma |- (x, y) <= Sigma(first: A). A
+  * equality-refl-checks          runs Gamma |- Refl(x) <= Eq(A, x, x)
+  * conversion-beta-let           runs Gamma |- beta == y and let == y
+  * vec-constructors-check        runs Gamma |- Nil <= Vec(A, Z)
+  *                               and Gamma |- Cons(k,h,t) <= Vec(A, S(k))
+  * }}}
+  *
+  * Explanation:
+  *
   * The profile source names MLTT capabilities to assert. Each assertion builds
   * a concrete core term and calls `MlttTypeChecker`, so package-level fixtures
   * fail when the checker stops accepting the advertised MLTT fragment.
@@ -69,7 +94,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Runs all MLTT assertion directives in a profile source module.
     *
-    * Program example:
+    * Profile source examples:
     *
     * {{{
     * mltt: lambda-checks-pi
@@ -106,9 +131,9 @@ private[cosmo0] object MlttProfileChecker:
       syntheticModule(moduleName, directives, "mltt_core"),
     )
 
-  /** Dispatches a source directive to the corresponding MLTT rule example.
+  /** Dispatches a source directive to the corresponding MLTT rule.
     *
-    * Program example:
+    * Profile source examples:
     *
     * {{{
     * mltt: conversion-beta-let
@@ -144,7 +169,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Checks the Pi introduction rule for annotated lambdas.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * A : Type0
@@ -177,7 +202,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Checks the Pi elimination rule used by application inference.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * A : Type0
@@ -210,7 +235,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Checks the Sigma introduction rule for pairs.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * x : A
@@ -242,7 +267,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Checks equality introduction for reflexivity.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * x : A
@@ -274,7 +299,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Checks WHNF conversion for beta and let reduction.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (fun x: A => x)(y) == y
@@ -309,7 +334,7 @@ private[cosmo0] object MlttProfileChecker:
 
   /** Checks indexed constructor introduction for the `Vec` fixture.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Nil <= Vec(A, Z)
@@ -421,6 +446,27 @@ private[cosmo0] object MlttProfileChecker:
 
 /** Source adapter for `checkerProfile: "mltt.dependent-patterns"`.
   *
+  * Profile source examples:
+  *
+  * {{{
+  * dependent-pattern: vec-head-elaborates
+  * dependent-pattern: impossible-nil-diagnostic
+  * }}}
+  *
+  * Rules:
+  *
+  * {{{
+  * vec-head-elaborates:
+  *   case xs : Vec(A, S(n)) of Cons(head, tail) -> head
+  *   elaborates with refinement n=k
+  *
+  * impossible-nil-diagnostic:
+  *   case xs : Vec(A, S(n)) of Nil -> absurd
+  *   reports impossible because Vec(A, Z) cannot refine Vec(A, S(n))
+  * }}}
+  *
+  * Explanation:
+  *
   * Assertions construct dependent-pattern fixtures and call `DependentPatterns`
   * so the profile verifies case-tree elaboration and impossible-index
   * diagnostics through the package checker path.
@@ -439,7 +485,7 @@ private[cosmo0] object DependentPatternProfileChecker:
 
   /** Runs all dependent-pattern assertion directives in profile source.
     *
-    * Program example:
+    * Profile source examples:
     *
     * {{{
     * dependent-pattern: vec-head-elaborates
@@ -475,9 +521,9 @@ private[cosmo0] object DependentPatternProfileChecker:
       syntheticModule(moduleName, directives, "dependent_pattern"),
     )
 
-  /** Dispatches a dependent-pattern directive to its rule example.
+  /** Dispatches a dependent-pattern directive to its rule.
     *
-    * Program example:
+    * Profile source examples:
     *
     * {{{
     * dependent-pattern: vec-head-elaborates
@@ -505,7 +551,7 @@ private[cosmo0] object DependentPatternProfileChecker:
 
   /** Checks constructor-pattern elaboration for a non-empty vector.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * case xs : Vec(A, S(n)) of
@@ -538,7 +584,7 @@ private[cosmo0] object DependentPatternProfileChecker:
 
   /** Checks that impossible constructor indices are diagnosed.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * case xs : Vec(A, S(n)) of
@@ -585,7 +631,7 @@ private[cosmo0] object DependentPatternProfileChecker:
 
   /** Builds the reusable `Vec(A, S(n))` head-elaboration program.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * xs : Vec(A, S(n))

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/ProfileCheckers.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/ProfileCheckers.scala
@@ -67,6 +67,20 @@ private[cosmo0] object MlttProfileChecker:
   def checkSource(source: SourceFile): Result[TypedModule] =
     checkSources(List(source), source.name)
 
+  /** Runs all MLTT assertion directives in a profile source module.
+    *
+    * Program example:
+    *
+    * {{{
+    * mltt: lambda-checks-pi
+    * mltt: application-infers-through-pi
+    * mltt: sigma-pair-checks
+    * }}}
+    *
+    * Each directive maps to a concrete MLTT core term, not a placeholder
+    * marker, so this entry point validates the package-level profile path
+    * against the same infer/check rules used by direct MLTT tests.
+    */
   def checkSources(
       sources: List[SourceFile],
       moduleName: String,
@@ -92,6 +106,17 @@ private[cosmo0] object MlttProfileChecker:
       syntheticModule(moduleName, directives, "mltt_core"),
     )
 
+  /** Dispatches a source directive to the corresponding MLTT rule example.
+    *
+    * Program example:
+    *
+    * {{{
+    * mltt: conversion-beta-let
+    * }}}
+    *
+    * The directive above checks definitional equality for beta and let
+    * reductions through `MlttTypeChecker.convert`.
+    */
   private def runAssertion(
       directive: ProfileDirective,
   ): List[Diagnostic] =
@@ -117,6 +142,18 @@ private[cosmo0] object MlttProfileChecker:
           ),
         )
 
+  /** Checks the Pi introduction rule for annotated lambdas.
+    *
+    * Program example:
+    *
+    * {{{
+    * A : Type0
+    * fun x: A => x <= (x: A) -> A
+    * }}}
+    *
+    * This assertion fails if `MlttTypeChecker.check` no longer accepts lambda
+    * introduction against a Pi type.
+    */
   private def lambdaChecksPi(span: SourceSpan): List[Diagnostic] =
     val store = MlttTypeChecker.termStore()
     val type0 = store.allocUniverse(0)
@@ -138,6 +175,16 @@ private[cosmo0] object MlttProfileChecker:
         span,
       )
 
+  /** Checks the Pi elimination rule used by application inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * A : Type0
+    * y : A
+    * (fun x: A => x)(y)  // infers A
+    * }}}
+    */
   private def applicationInfersThroughPi(span: SourceSpan): List[Diagnostic] =
     val store = MlttTypeChecker.termStore()
     val type0 = store.allocUniverse(0)
@@ -161,6 +208,16 @@ private[cosmo0] object MlttProfileChecker:
         span,
       )
 
+  /** Checks the Sigma introduction rule for pairs.
+    *
+    * Program example:
+    *
+    * {{{
+    * x : A
+    * y : A
+    * (x, y) <= Sigma(first: A). A
+    * }}}
+    */
   private def sigmaPairChecks(span: SourceSpan): List[Diagnostic] =
     val store = MlttTypeChecker.termStore()
     val type0 = store.allocUniverse(0)
@@ -183,6 +240,15 @@ private[cosmo0] object MlttProfileChecker:
         span,
       )
 
+  /** Checks equality introduction for reflexivity.
+    *
+    * Program example:
+    *
+    * {{{
+    * x : A
+    * Refl(x) <= Eq(A, x, x)
+    * }}}
+    */
   private def equalityReflChecks(span: SourceSpan): List[Diagnostic] =
     val store = MlttTypeChecker.termStore()
     val type0 = store.allocUniverse(0)
@@ -206,6 +272,15 @@ private[cosmo0] object MlttProfileChecker:
         span,
       )
 
+  /** Checks WHNF conversion for beta and let reduction.
+    *
+    * Program example:
+    *
+    * {{{
+    * (fun x: A => x)(y) == y
+    * let z = y; z == y
+    * }}}
+    */
   private def conversionBetaLet(span: SourceSpan): List[Diagnostic] =
     val store = MlttTypeChecker.termStore()
     val type0 = store.allocUniverse(0)
@@ -232,6 +307,18 @@ private[cosmo0] object MlttProfileChecker:
         span,
       )
 
+  /** Checks indexed constructor introduction for the `Vec` fixture.
+    *
+    * Program example:
+    *
+    * {{{
+    * Nil <= Vec(A, Z)
+    * Cons(k, head, tail) <= Vec(A, S(k))
+    * }}}
+    *
+    * This exercises constructor checking with family indices rather than just
+    * unindexed algebraic constructors.
+    */
   private def vecConstructorsCheck(span: SourceSpan): List[Diagnostic] =
     val store = MlttTypeChecker.termStore()
     val type0 = store.allocUniverse(0)
@@ -350,6 +437,19 @@ private[cosmo0] object DependentPatternProfileChecker:
   def checkSource(source: SourceFile): Result[TypedModule] =
     checkSources(List(source), source.name)
 
+  /** Runs all dependent-pattern assertion directives in profile source.
+    *
+    * Program example:
+    *
+    * {{{
+    * dependent-pattern: vec-head-elaborates
+    * dependent-pattern: impossible-nil-diagnostic
+    * }}}
+    *
+    * The assertions build concrete `Vec` clauses and call
+    * `DependentPatterns.elaborateClauses`, so package fixtures validate the
+    * same refinement and coverage rules as the direct dependent-pattern tests.
+    */
   def checkSources(
       sources: List[SourceFile],
       moduleName: String,
@@ -375,6 +475,17 @@ private[cosmo0] object DependentPatternProfileChecker:
       syntheticModule(moduleName, directives, "dependent_pattern"),
     )
 
+  /** Dispatches a dependent-pattern directive to its rule example.
+    *
+    * Program example:
+    *
+    * {{{
+    * dependent-pattern: vec-head-elaborates
+    * }}}
+    *
+    * The directive above proves that a `Cons` branch for `Vec(A, S(n))`
+    * elaborates to a refined case tree with the substitution `n=k`.
+    */
   private def runAssertion(
       directive: ProfileDirective,
   ): List[Diagnostic] =
@@ -392,6 +503,22 @@ private[cosmo0] object DependentPatternProfileChecker:
           ),
         )
 
+  /** Checks constructor-pattern elaboration for a non-empty vector.
+    *
+    * Program example:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Cons(head, tail) -> head
+    * }}}
+    *
+    * Expected case tree:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Cons(head, tail) -> head [n=k]
+    * }}}
+    */
   private def vecHeadElaborates(span: SourceSpan): List[Diagnostic] =
     val tree = vecHeadTree(CheckerProfiles.MlttDependentPatterns, span)
     val rendered = DependentPatterns.renderCaseTree(tree)
@@ -409,6 +536,18 @@ private[cosmo0] object DependentPatternProfileChecker:
         span,
       )
 
+  /** Checks that impossible constructor indices are diagnosed.
+    *
+    * Program example:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Nil -> absurd
+    * }}}
+    *
+    * `Nil` has result index `Vec(A, Z)`, so this branch cannot refine a
+    * scrutinee whose length index is `S(n)`.
+    */
   private def impossibleNilDiagnostic(span: SourceSpan): List[Diagnostic] =
     val store = DependentPatterns.termStore()
     val env = DependentPatterns.env()
@@ -444,6 +583,19 @@ private[cosmo0] object DependentPatternProfileChecker:
       span,
     )
 
+  /** Builds the reusable `Vec(A, S(n))` head-elaboration program.
+    *
+    * Program example:
+    *
+    * {{{
+    * xs : Vec(A, S(n))
+    * Cons(head, tail) -> head
+    * }}}
+    *
+    * The helper sets up the Nat/Vec fixtures, allocates the source pattern, and
+    * invokes `DependentPatterns.elaborateClauses` under the selected checker
+    * profile.
+    */
   private def vecHeadTree(
       profile: CheckerProfile,
       span: SourceSpan,

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/ProfileCheckers.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/ProfileCheckers.scala
@@ -1,0 +1,540 @@
+package cosmo0
+
+import scala.collection.mutable.ListBuffer
+
+private[cosmo0] final case class ProfileDirective(
+    name: String,
+    span: SourceSpan,
+)
+
+/** Extracts profile assertion directives from profile-specific source.
+  *
+  * Accepted forms:
+  *
+  * {{{
+  * mltt: lambda-checks-pi
+  * // mltt: lambda-checks-pi
+  * dependent-pattern: vec-head-elaborates
+  * }}}
+  */
+private[cosmo0] object ProfileDirectiveParser:
+  def extract(
+      sources: List[SourceFile],
+      prefix: String,
+  ): List[ProfileDirective] =
+    sources.flatMap(extract(_, prefix))
+
+  private def extract(
+      source: SourceFile,
+      prefix: String,
+  ): List[ProfileDirective] =
+    val directives = ListBuffer.empty[ProfileDirective]
+    var offset = 0
+
+    source.text.linesIterator.foreach { line =>
+      val lineStart = offset
+      val lineEnd = lineStart + line.length
+      directiveName(line, prefix).foreach { name =>
+        directives += ProfileDirective(name, source.span(lineStart, lineEnd))
+      }
+      offset = lineEnd + 1
+    }
+
+    directives.toList
+
+  private def directiveName(line: String, prefix: String): Option[String] =
+    val trimmed = line.trim
+    val body =
+      if trimmed.startsWith("//") then trimmed.dropWhile(_ == '/').trim
+      else trimmed
+    if !body.startsWith(prefix) then return None
+
+    val name = body.drop(prefix.length).trim
+    if name.nonEmpty then Some(name) else None
+
+/** Source adapter for `checkerProfile: "mltt.core"`.
+  *
+  * The profile source names MLTT capabilities to assert. Each assertion builds
+  * a concrete core term and calls `MlttTypeChecker`, so package-level fixtures
+  * fail when the checker stops accepting the advertised MLTT fragment.
+  */
+private[cosmo0] object MlttProfileChecker:
+  private val DirectivePrefix = "mltt:"
+  private val NoAssertionsCode = "cosmo.type.mltt.no-profile-assertions"
+  private val UnknownAssertionCode = "cosmo.type.mltt.unknown-profile-assertion"
+  private val AssertionFailedCode = "cosmo.type.mltt.profile-assertion-failed"
+
+  def checkSource(source: SourceFile): Result[TypedModule] =
+    checkSources(List(source), source.name)
+
+  def checkSources(
+      sources: List[SourceFile],
+      moduleName: String,
+  ): Result[TypedModule] =
+    val directives = ProfileDirectiveParser.extract(sources, DirectivePrefix)
+    if directives.isEmpty then
+      return Result.failure(
+        Phase.Check,
+        List(
+          diagnostic(
+            NoAssertionsCode,
+            "mltt.core profile source did not declare any MLTT assertions",
+            wholeSourceSpan(sources),
+          ),
+        ),
+      )
+
+    val diagnostics = directives.flatMap(runAssertion)
+    if diagnostics.nonEmpty then return Result.failure(Phase.Check, diagnostics)
+
+    Result.success(
+      Phase.Check,
+      syntheticModule(moduleName, directives, "mltt_core"),
+    )
+
+  private def runAssertion(
+      directive: ProfileDirective,
+  ): List[Diagnostic] =
+    directive.name match
+      case "lambda-checks-pi" =>
+        lambdaChecksPi(directive.span)
+      case "application-infers-through-pi" =>
+        applicationInfersThroughPi(directive.span)
+      case "sigma-pair-checks" =>
+        sigmaPairChecks(directive.span)
+      case "equality-refl-checks" =>
+        equalityReflChecks(directive.span)
+      case "conversion-beta-let" =>
+        conversionBetaLet(directive.span)
+      case "vec-constructors-check" =>
+        vecConstructorsCheck(directive.span)
+      case other =>
+        List(
+          diagnostic(
+            UnknownAssertionCode,
+            s"unknown mltt.core assertion $other",
+            directive.span,
+          ),
+        )
+
+  private def lambdaChecksPi(span: SourceSpan): List[Diagnostic] =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val body = store.allocVar("x")
+    val lambda = store.allocLambda("x", a, body)
+    val expected = store.allocPi("x", a, a)
+    val context = MlttTypeChecker.context().extendLocal("A", type0)
+    val checked = MlttTypeChecker.check(store, context, lambda, expected)
+    val expectedSummary =
+      "mltt.core|mltt-core-term|accepted|mltt.whnf-conversion"
+
+    mlttDiagnostics(checked.diagnostics, span) :::
+      assertCondition(
+        checked.isOk && checked.artifactSummary == expectedSummary,
+        "lambda did not check against the expected Pi type",
+        expectedSummary,
+        checked.artifactSummary,
+        span,
+      )
+
+  private def applicationInfersThroughPi(span: SourceSpan): List[Diagnostic] =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    var context = MlttTypeChecker.context().extendLocal("A", type0)
+    context = context.extendLocal("y", a)
+
+    val body = store.allocVar("x")
+    val lambda = store.allocLambda("x", a, body)
+    val y = store.allocVar("y")
+    val apply = store.allocApply(lambda, y)
+    val inferred = MlttTypeChecker.infer(store, context, apply)
+    val actual = MlttTypeChecker.display(store, inferred.valueType)
+
+    mlttDiagnostics(inferred.diagnostics, span) :::
+      assertCondition(
+        inferred.isOk && actual == "A",
+        "application did not infer through Pi elimination",
+        "A",
+        actual,
+        span,
+      )
+
+  private def sigmaPairChecks(span: SourceSpan): List[Diagnostic] =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val x = store.allocVar("x")
+    val y = store.allocVar("y")
+    var context = MlttTypeChecker.context().extendLocal("A", type0)
+    context = context.extendLocal("x", a).extendLocal("y", a)
+
+    val pair = store.allocPair(x, y)
+    val sigma = store.allocSigma("first", a, a)
+    val checked = MlttTypeChecker.check(store, context, pair, sigma)
+
+    mlttDiagnostics(checked.diagnostics, span) :::
+      assertCondition(
+        checked.isOk,
+        "pair did not check against the expected Sigma type",
+        "accepted",
+        checked.status,
+        span,
+      )
+
+  private def equalityReflChecks(span: SourceSpan): List[Diagnostic] =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val x = store.allocVar("x")
+    val context = MlttTypeChecker
+      .context()
+      .extendLocal("A", type0)
+      .extendLocal("x", a)
+
+    val eq = store.allocEq(a, x, x)
+    val refl = store.allocRefl(x)
+    val checked = MlttTypeChecker.check(store, context, refl, eq)
+
+    mlttDiagnostics(checked.diagnostics, span) :::
+      assertCondition(
+        checked.isOk,
+        "Refl did not check against the expected equality type",
+        "accepted",
+        checked.status,
+        span,
+      )
+
+  private def conversionBetaLet(span: SourceSpan): List[Diagnostic] =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val a = store.allocVar("A")
+    val y = store.allocVar("y")
+    val context = MlttTypeChecker
+      .context()
+      .extendLocal("A", type0)
+      .extendLocal("y", a)
+
+    val lambda = store.allocLambda("x", a, store.allocVar("x"))
+    val beta = store.allocApply(lambda, y)
+    val letTerm = store.allocLet("z", y, store.allocVar("z"))
+    val betaResult = MlttTypeChecker.convert(store, context, beta, y)
+    val letResult = MlttTypeChecker.convert(store, context, letTerm, y)
+
+    mlttDiagnostics(betaResult.diagnostics, span) :::
+      mlttDiagnostics(letResult.diagnostics, span) :::
+      assertCondition(
+        betaResult.isOk && letResult.isOk,
+        "WHNF conversion did not accept beta and let reductions",
+        "both conversions accepted",
+        s"beta=${betaResult.isOk}, let=${letResult.isOk}",
+        span,
+      )
+
+  private def vecConstructorsCheck(span: SourceSpan): List[Diagnostic] =
+    val store = MlttTypeChecker.termStore()
+    val type0 = store.allocUniverse(0)
+    val nat = store.allocInductive("Nat")
+    val a = store.allocVar("A")
+    val k = store.allocVar("k")
+    val z = store.allocConstructor("Z")
+    val sK = store.allocConstructor("S", List(k))
+    val vecAK = store.allocInductive("Vec", List(a), List(k))
+    val vecAZ = store.allocInductive("Vec", List(a), List(z))
+    val vecASK = store.allocInductive("Vec", List(a), List(sK))
+    val head = store.allocVar("head")
+    val tail = store.allocVar("tail")
+    val nil = store.allocConstructor("Nil")
+    val cons = store.allocConstructor("Cons", List(k, head, tail))
+    var context = MlttTypeChecker.context().extendLocal("A", type0)
+    context = context
+      .extendLocal("k", nat)
+      .extendLocal("head", a)
+      .extendLocal("tail", vecAK)
+
+    val nilChecked = MlttTypeChecker.check(store, context, nil, vecAZ)
+    val consChecked = MlttTypeChecker.check(store, context, cons, vecASK)
+
+    mlttDiagnostics(nilChecked.diagnostics, span) :::
+      mlttDiagnostics(consChecked.diagnostics, span) :::
+      assertCondition(
+        nilChecked.isOk && consChecked.isOk,
+        "Vec constructors did not check against indexed Vec families",
+        "Nil and Cons accepted",
+        s"Nil=${nilChecked.isOk}, Cons=${consChecked.isOk}",
+        span,
+      )
+
+  private def mlttDiagnostics(
+      diagnostics: List[MlttDiagnostic],
+      span: SourceSpan,
+  ): List[Diagnostic] =
+    diagnostics.map { diagnosticValue =>
+      diagnostic(
+        diagnosticValue.code,
+        s"${diagnosticValue.message}; expected ${diagnosticValue.expected}, got ${diagnosticValue.actual}",
+        diagnosticValue.span.getOrElse(span),
+      )
+    }
+
+  private def assertCondition(
+      condition: Boolean,
+      message: String,
+      expected: String,
+      actual: String,
+      span: SourceSpan,
+  ): List[Diagnostic] =
+    if condition then Nil
+    else
+      List(
+        diagnostic(
+          AssertionFailedCode,
+          s"$message; expected $expected, got $actual",
+          span,
+        ),
+      )
+
+  private def syntheticModule(
+      moduleName: String,
+      directives: List[ProfileDirective],
+      prefix: String,
+  ): TypedModule =
+    val source = SourceFile(moduleName, "")
+    val span = source.span(0, 0)
+    val declarations = directives.map { directive =>
+      val name = s"${prefix}_${sanitizeName(directive.name)}"
+      TypedValueDecl(
+        UntypedValueKind.Val,
+        name,
+        SourceType.Bool,
+        Some(TypedBoolLiteral(true, SourceType.Bool, directive.span)),
+        directive.span,
+      )
+    }
+    TypedModule(source, declarations, span)
+
+  private def sanitizeName(value: String): String =
+    value.map {
+      case char if char.isLetterOrDigit => char
+      case _                            => '_'
+    }
+
+  private def wholeSourceSpan(sources: List[SourceFile]): SourceSpan =
+    sources.headOption match
+      case Some(source) => source.span(0, source.text.length)
+      case None         => SourceFile("<mltt-profile>", "").span(0, 0)
+
+  private def diagnostic(
+      code: String,
+      message: String,
+      span: SourceSpan,
+  ): Diagnostic =
+    Diagnostic(Phase.Check, DiagnosticSeverity.Error, code, message, Some(span))
+
+/** Source adapter for `checkerProfile: "mltt.dependent-patterns"`.
+  *
+  * Assertions construct dependent-pattern fixtures and call `DependentPatterns`
+  * so the profile verifies case-tree elaboration and impossible-index
+  * diagnostics through the package checker path.
+  */
+private[cosmo0] object DependentPatternProfileChecker:
+  private val DirectivePrefix = "dependent-pattern:"
+  private val NoAssertionsCode =
+    "cosmo.type.dependent-pattern.no-profile-assertions"
+  private val UnknownAssertionCode =
+    "cosmo.type.dependent-pattern.unknown-profile-assertion"
+  private val AssertionFailedCode =
+    "cosmo.type.dependent-pattern.profile-assertion-failed"
+
+  def checkSource(source: SourceFile): Result[TypedModule] =
+    checkSources(List(source), source.name)
+
+  def checkSources(
+      sources: List[SourceFile],
+      moduleName: String,
+  ): Result[TypedModule] =
+    val directives = ProfileDirectiveParser.extract(sources, DirectivePrefix)
+    if directives.isEmpty then
+      return Result.failure(
+        Phase.Check,
+        List(
+          diagnostic(
+            NoAssertionsCode,
+            "mltt.dependent-patterns profile source did not declare any dependent-pattern assertions",
+            wholeSourceSpan(sources),
+          ),
+        ),
+      )
+
+    val diagnostics = directives.flatMap(runAssertion)
+    if diagnostics.nonEmpty then return Result.failure(Phase.Check, diagnostics)
+
+    Result.success(
+      Phase.Check,
+      syntheticModule(moduleName, directives, "dependent_pattern"),
+    )
+
+  private def runAssertion(
+      directive: ProfileDirective,
+  ): List[Diagnostic] =
+    directive.name match
+      case "vec-head-elaborates" =>
+        vecHeadElaborates(directive.span)
+      case "impossible-nil-diagnostic" =>
+        impossibleNilDiagnostic(directive.span)
+      case other =>
+        List(
+          diagnostic(
+            UnknownAssertionCode,
+            s"unknown dependent-pattern assertion $other",
+            directive.span,
+          ),
+        )
+
+  private def vecHeadElaborates(span: SourceSpan): List[Diagnostic] =
+    val tree = vecHeadTree(CheckerProfiles.MlttDependentPatterns, span)
+    val rendered = DependentPatterns.renderCaseTree(tree)
+    val expected = "case xs : Vec(A, S(n)) of\n  Cons(head, tail) -> head [n=k]"
+
+    dependentDiagnostics(tree.diagnostics, span) :::
+      assertCondition(
+        tree.isOk &&
+          tree.branches.length == 1 &&
+          tree.branches.head.constructor == "Cons" &&
+          rendered == expected,
+        "Vec head pattern did not elaborate to the expected case tree",
+        expected,
+        rendered,
+        span,
+      )
+
+  private def impossibleNilDiagnostic(span: SourceSpan): List[Diagnostic] =
+    val store = DependentPatterns.termStore()
+    val env = DependentPatterns.env()
+    val patterns = DependentPatterns.sourcePatternStore()
+    DependentPatterns.addNatFixture(store, env)
+    DependentPatterns.addVecFixture(store, env)
+
+    val n = store.allocVar("n")
+    val sN = DependentPatterns.natSuccessor(store, n)
+    val scrutineeIndices = DependentPatterns.vecIndices(store, sN)
+    val nil = patterns.allocConstructor("Nil", Nil, span)
+    val clauses = List(DependentPatternClause(nil, "absurd", span))
+    val tree =
+      DependentPatterns.elaborateClauses(
+        CheckerProfiles.MlttDependentPatterns,
+        env,
+        store,
+        patterns,
+        "Vec",
+        "xs",
+        scrutineeIndices,
+        "A",
+        clauses,
+      )
+
+    assertCondition(
+      !tree.isOk &&
+        tree.firstCode == "cosmo.type.dependent-pattern.impossible-branch" &&
+        tree.branches.headOption.exists(_.impossible),
+      "Nil branch did not report impossible indices for Vec(A, S(n))",
+      "cosmo.type.dependent-pattern.impossible-branch",
+      tree.firstCode,
+      span,
+    )
+
+  private def vecHeadTree(
+      profile: CheckerProfile,
+      span: SourceSpan,
+  ): DependentCaseTree =
+    val store = DependentPatterns.termStore()
+    val env = DependentPatterns.env()
+    val patterns = DependentPatterns.sourcePatternStore()
+    DependentPatterns.addNatFixture(store, env)
+    DependentPatterns.addVecFixture(store, env)
+
+    val n = store.allocVar("n")
+    val sN = DependentPatterns.natSuccessor(store, n)
+    val scrutineeIndices = DependentPatterns.vecIndices(store, sN)
+    val headPat = patterns.allocVariable("head", span)
+    val tailPat = patterns.allocVariable("tail", span)
+    val cons = patterns.allocConstructor("Cons", List(headPat, tailPat), span)
+    val clauses = List(DependentPatternClause(cons, "head", span))
+    DependentPatterns.elaborateClauses(
+      profile,
+      env,
+      store,
+      patterns,
+      "Vec",
+      "xs",
+      scrutineeIndices,
+      "A",
+      clauses,
+    )
+
+  private def dependentDiagnostics(
+      diagnostics: List[DependentPatternDiagnostic],
+      span: SourceSpan,
+  ): List[Diagnostic] =
+    diagnostics.map { diagnosticValue =>
+      diagnostic(
+        diagnosticValue.code,
+        s"${diagnosticValue.message}; ${diagnosticValue.summary}",
+        diagnosticValue.span,
+      )
+    }
+
+  private def assertCondition(
+      condition: Boolean,
+      message: String,
+      expected: String,
+      actual: String,
+      span: SourceSpan,
+  ): List[Diagnostic] =
+    if condition then Nil
+    else
+      List(
+        diagnostic(
+          AssertionFailedCode,
+          s"$message; expected $expected, got $actual",
+          span,
+        ),
+      )
+
+  private def syntheticModule(
+      moduleName: String,
+      directives: List[ProfileDirective],
+      prefix: String,
+  ): TypedModule =
+    val source = SourceFile(moduleName, "")
+    val span = source.span(0, 0)
+    val declarations = directives.map { directive =>
+      val name = s"${prefix}_${sanitizeName(directive.name)}"
+      TypedValueDecl(
+        UntypedValueKind.Val,
+        name,
+        SourceType.Bool,
+        Some(TypedBoolLiteral(true, SourceType.Bool, directive.span)),
+        directive.span,
+      )
+    }
+    TypedModule(source, declarations, span)
+
+  private def sanitizeName(value: String): String =
+    value.map {
+      case char if char.isLetterOrDigit => char
+      case _                            => '_'
+    }
+
+  private def wholeSourceSpan(sources: List[SourceFile]): SourceSpan =
+    sources.headOption match
+      case Some(source) => source.span(0, source.text.length)
+      case None => SourceFile("<dependent-pattern-profile>", "").span(0, 0)
+
+  private def diagnostic(
+      code: String,
+      message: String,
+      span: SourceSpan,
+  ): Diagnostic =
+    Diagnostic(Phase.Check, DiagnosticSeverity.Error, code, message, Some(span))

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/Profiles.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/Profiles.scala
@@ -1,5 +1,37 @@
 package cosmo0
 
+/** Static description of a checker implementation or experiment.
+  *
+  * A profile is deliberately metadata, not a dynamic dispatcher. It records the
+  * artifact a checker expects as input, the artifact it returns, and the
+  * feature set that callers may advertise or reject in diagnostics.
+  *
+  * Profile selection examples:
+  *
+  * {{{
+  * // No package metadata:
+  * //   checkerProfile = None
+  * //   selected profile = cosmo0.subset
+  * //   implementation = SourceTyper over UntypedModule
+  *
+  * // Experimental package metadata:
+  * //   "checkerProfile": "mltt.core"
+  * //   selected profile = mltt.core
+  * //   implementation = no source-pipeline route yet; report unsupported
+  *
+  * // Direct test harness:
+  * //   MlttTypeChecker.infer(store, context, term)
+  * //   implementation = Scala MLTT core mirror in tyck/mltt/TypeChecker.scala
+  * }}}
+  *
+  * Routing rule:
+  *
+  *   - `Cosmo0.check` and `source/Pipeline.check` execute only `cosmo0.subset`.
+  *   - Other profiles are still useful as stable contracts for diagnostics,
+  *     fixtures, and future checker artifacts, but selecting them from ordinary
+  *     source currently yields an unsupported result instead of invoking the
+  *     experimental MLTT or dependent-pattern code.
+  */
 final case class CheckerProfile(
     id: String,
     owner: String,
@@ -21,6 +53,29 @@ final case class CheckerProfile(
   def summary: String =
     s"$id|$inputArtifact|$artifactKind|$diagnosticNamespace"
 
+/** Registry of type-checker profiles known to cosmo0.
+  *
+  * Language profile examples:
+  *
+  * {{{
+  * cosmo0.subset:
+  *   source declarations, expressions, classes, traits, impls, variants,
+  *   standard generics, source match patterns, and C++ namespace imports.
+  *
+  * mltt.core:
+  *   core terms such as Type0, Pi, Sigma, lambda, application, Eq, Refl,
+  *   Nat, Vec, metavariables, and WHNF conversion.
+  *
+  * mltt.dependent-patterns:
+  *   MLTT core terms plus constructor metadata and source pattern clauses
+  *   elaborated to case-tree artifacts.
+  * }}}
+  *
+  * Feature inference is intentionally simple: callers ask whether a profile
+  * supports or rejects a named feature. The profile does not infer source
+  * syntax by itself; concrete inference rules live in `SourceTyper`,
+  * `MlttTypeChecker`, and `DependentPatterns`.
+  */
 object CheckerProfiles:
   val CosmocBasicExprId = "cosmoc.basic-expr"
   val Cosmo0SubsetId = "cosmo0.subset"

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/Profiles.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/Profiles.scala
@@ -17,7 +17,7 @@ package cosmo0
   * // Experimental package metadata:
   * //   "checkerProfile": "mltt.core"
   * //   selected profile = mltt.core
-  * //   implementation = no source-pipeline route yet; report unsupported
+  * //   implementation = MlttProfileChecker over profile assertion directives
   *
   * // Direct test harness:
   * //   MlttTypeChecker.infer(store, context, term)
@@ -26,11 +26,11 @@ package cosmo0
   *
   * Routing rule:
   *
-  *   - `Cosmo0.check` and `source/Pipeline.check` execute only `cosmo0.subset`.
-  *   - Other profiles are still useful as stable contracts for diagnostics,
-  *     fixtures, and future checker artifacts, but selecting them from ordinary
-  *     source currently yields an unsupported result instead of invoking the
-  *     experimental MLTT or dependent-pattern code.
+  *   - `cosmo0.subset` source executes through `SourceTyper`.
+  *   - `mltt.core` and `mltt.dependent-patterns` execute through profile
+  *     checkers that read source assertion directives and call the experimental
+  *     MLTT or dependent-pattern implementation.
+  *   - Profiles without a concrete adapter remain unsupported checker results.
   */
 final case class CheckerProfile(
     id: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/README.md
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/README.md
@@ -8,6 +8,8 @@ patterns, mutability, and expression result types.
 
 `Profiles.scala` describes checker profiles and feature gates. `StageCapabilities.scala`
 validates package-level stage capability profiles before package checking.
+`ProfileCheckers.scala` adapts profile-specific source directives such as
+`mltt: lambda-checks-pi` into executable MLTT and dependent-pattern assertions.
 
 Subdirectories:
 
@@ -16,4 +18,6 @@ Subdirectories:
 
 Upstream input comes from `syntax/Elaborator.scala`. Downstream output goes to
 `lir/Lowerer.scala`. Profile metadata is also read by `source/Pipeline.scala`
-when package metadata selects a checker profile.
+when package metadata selects a checker profile. `mltt.core` and
+`mltt.dependent-patterns` are routed through profile assertion checkers before
+`SourceTyper`; `cosmo0.subset` remains the ordinary source checker.

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/StageCapabilities.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/StageCapabilities.scala
@@ -1,5 +1,27 @@
 package cosmo0
 
+/** Runtime and standard-library capabilities required by a package stage.
+  *
+  * `stageProfile` is separate from `checkerProfile`: stage validation answers
+  * "does the current package target have enough runtime/std support?", while
+  * checker profiles answer "which type-checker artifact contract is selected?".
+  *
+  * Package metadata example:
+  *
+  * {{{
+  * {
+  *   "name": "@cosmo/compiler",
+  *   "target": "cosmo0",
+  *   "stageProfile": "cosmo1.stage1"
+  * }
+  * }}}
+  *
+  * Validation rule:
+  *
+  *   - every required primitive descriptor must be available,
+  *   - every required std capability must be available, and
+  *   - every required backend symbol/include must be available.
+  */
 final case class StageCapabilityProfile(
     name: String,
     requiredPrimitiveDescriptors: Set[String],
@@ -7,12 +29,19 @@ final case class StageCapabilityProfile(
     requiredBackendRequirements: Set[BackendRequirement] = Set.empty,
 )
 
+/** Concrete capabilities supplied by the active compiler/runtime boundary. */
 final case class StageCapabilityAvailability(
     primitiveDescriptors: Set[String],
     stdCapabilities: Set[String],
     backendRequirements: Set[BackendRequirement],
 )
 
+/** Registry for package stage profiles.
+  *
+  * The registry does no expression or type inference. It produces check-phase
+  * diagnostics before source type checking when a package asks for capabilities
+  * that the current cosmo0 target cannot provide.
+  */
 object StageCapabilityRegistry:
   val Cosmo1Stage1 = "cosmo1.stage1"
 

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
@@ -3,6 +3,13 @@ package cosmo0
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
+/** Factory for the source-level checker.
+  *
+  * The no-profile entry point intentionally selects `cosmo0.subset`. MLTT and
+  * dependent-pattern profiles are registered in `CheckerProfiles`, but the
+  * public cosmo0 source pipeline does not elaborate ordinary source into those
+  * artifacts yet.
+  */
 object SourceTyper:
   def apply(module: UntypedModule): SourceTyper =
     new SourceTyper(
@@ -14,6 +21,66 @@ object SourceTyper:
   def apply(module: UntypedModule, profile: CheckerProfile): SourceTyper =
     new SourceTyper(module, StandardGenericDescriptors.all, profile)
 
+/** Checks an `UntypedModule` into a `TypedModule` for the default cosmo0 source
+  * language subset.
+  *
+  * Source language examples handled here:
+  *
+  * {{{
+  * val answer = 42
+  * var name: String = "cosmo"
+  *
+  * class Nat {
+  *   case Zero
+  *   case Succ(Nat)
+  * }
+  *
+  * def inc(value: i32): i32 = { value + 1 }
+  *
+  * def pred(value: Nat): i32 = {
+  *   value match {
+  *     case Nat.Zero => 0
+  *     case Nat.Succ(rest) => 1
+  *   }
+  * }
+  * }}}
+  *
+  * The `profile` constructor parameter is metadata for diagnostics and future
+  * routing. It is not a second dispatcher inside this class: today this
+  * implementation checks the cosmo0 source subset, while public callers reject
+  * non-`cosmo0.subset` profiles before reaching `SourceTyper`.
+  *
+  * The checker is bidirectional in a small, source-oriented sense: `expr(node,
+  * expected, context)` infers a type when `expected` is absent, and uses
+  * `expected` to guide literals, calls, branch bodies, assignments, returns,
+  * and block final expressions.
+  *
+  * Inference and checking rules:
+  *
+  *   - Declarations: `val x: T = e` checks `e <= T`; `val x = e` infers `T`
+  *     from `e`. Fields and parameters require explicit source types.
+  *   - Functions: parameter and return annotations form a `CallableSignature`.
+  *     A missing return annotation is `Unit`; the body is checked against the
+  *     declared return type.
+  *   - Names: lexical values are looked up first; otherwise a single-segment
+  *     name may resolve to a function, class constructor, or standard generic
+  *     constructor.
+  *   - Literals: integer and float literals use an expected numeric type when
+  *     one is available, defaulting to `i32` and `f64`; bool, string, unit,
+  *     ASCII, and rune literals have fixed types.
+  *   - Calls: the callee must have a `CallableSignature` or function type; each
+  *     argument is checked against the matching parameter, including mutable
+  *     reference passing rules.
+  *   - Blocks: only the final item receives the outer expected type; the block
+  *     type is the final expression type, or `Unit` for statement-only blocks.
+  *   - `if` and `match`: conditions check as `Bool`; branch bodies must agree
+  *     on one result type unless no branch body is present.
+  *   - Patterns: a match pattern is checked against the scrutinee type. Binding
+  *     patterns introduce locals of the expected type, and variant patterns
+  *     check payloads against the selected constructor signature.
+  *   - Mutation: assignable values require mutable bindings, and mutable
+  *     receiver methods require a mutable receiver capability.
+  */
 final class SourceTyper(
     module: UntypedModule,
     standardGenerics: Map[String, StandardGenericDescriptor] =
@@ -1935,6 +2002,9 @@ final class SourceTyper(
       expected: Option[SourceType],
       context: FunctionContext,
   ): ExprInfo =
+    // Ordinary cosmo0 match checking is SourceType-based: it checks variant
+    // payloads and branch result agreement, but it does not elaborate indexed
+    // families into `DependentPatterns` case trees.
     val scrut = expr(node.scrut, scope, None, context)
     val arms = node.arms.map { arm =>
       val armScope = scope.child

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
@@ -24,7 +24,7 @@ object SourceTyper:
 /** Checks an `UntypedModule` into a `TypedModule` for the default cosmo0 source
   * language subset.
   *
-  * Source language examples handled here:
+  * Program examples:
   *
   * {{{
   * val answer = 42
@@ -55,7 +55,69 @@ object SourceTyper:
   * `expected` to guide literals, calls, branch bodies, assignments, returns,
   * and block final expressions.
   *
-  * Inference and checking rules:
+  * Rules:
+  *
+  * {{{
+  * Gamma |- e => T
+  * Gamma |- e <= T
+  *
+  * Gamma |- init <= T
+  *   --------------------------------------------------- ValueCheck
+  *   Gamma |- val x : T = init checks
+  *
+  * Gamma |- init => T
+  *   --------------------------------------------------- ValueInfer
+  *   Gamma |- val x = init defines x : T
+  *
+  * Gamma, params : ParamTypes |- body <= Return
+  *   --------------------------------------------------- FunctionCheck
+  *   Gamma |- def f(params): Return = body checks
+  *
+  * Gamma(x) = T
+  *   --------------------------------------------------- Name
+  *   Gamma |- x => T
+  *
+  * Gamma |- callee => (P1, ..., Pn) -> R
+  * Gamma |- arg1 <= P1 ... Gamma |- argn <= Pn
+  *   --------------------------------------------------- Call
+  *   Gamma |- callee(arg1, ..., argn) => R
+  *
+  * Gamma |- recv => Owner; method(Owner, name) = (P*) -> R
+  * Gamma |- args <= P*
+  *   --------------------------------------------------- MethodCall
+  *   Gamma |- recv.name(args) => R
+  *
+  * Gamma |- target => T mutable; Gamma |- value <= T
+  *   --------------------------------------------------- Assign
+  *   Gamma |- target = value => Unit
+  *
+  * Gamma |- cond <= Bool; Gamma |- then <= T; Gamma |- else <= T
+  *   --------------------------------------------------- If
+  *   Gamma |- if cond then else => T
+  *
+  * Gamma |- scrutinee => T
+  * Gamma |- pattern_i <= T; Gamma + binds(pattern_i) |- body_i <= R
+  *   --------------------------------------------------- Match
+  *   Gamma |- match scrutinee { pattern_i => body_i } => R
+  *
+  * Gamma |- pattern <= Expected
+  *   --------------------------------------------------- Pattern
+  *   pattern binds locals and checks constructor payloads
+  *
+  * Gamma |- final <= Expected
+  *   --------------------------------------------------- BlockCheck
+  *   Gamma |- { items; final } <= Expected
+  *
+  * Gamma |- left => Numeric; Gamma |- right <= Numeric
+  *   --------------------------------------------------- BinaryNumeric
+  *   Gamma |- left op right => Numeric
+  *
+  * Gamma |- operand <= Bool
+  *   --------------------------------------------------- UnaryNot
+  *   Gamma |- !operand => Bool
+  * }}}
+  *
+  * Explanation:
   *
   *   - Declarations: `val x: T = e` checks `e <= T`; `val x = e` infers `T`
   *     from `e`. Fields and parameters require explicit source types.
@@ -194,7 +256,7 @@ final class SourceTyper(
 
   /** Runs declaration collection before expression inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * class Counter { var value: i32 }
@@ -575,7 +637,7 @@ final class SourceTyper(
 
   /** Converts one top-level declaration into its typed form.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val answer = 42
@@ -626,7 +688,7 @@ final class SourceTyper(
 
   /** Checks class fields, variants, aliases, and methods.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * class Point {
@@ -690,7 +752,7 @@ final class SourceTyper(
 
   /** Checks a function or method body against its declared signature.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * def clamp(value: i32, min: i32 = 0): i32 = {
@@ -757,7 +819,7 @@ final class SourceTyper(
 
   /** Infers or checks a top-level value declaration.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val inferred = 42      // inferred: i32
@@ -803,7 +865,7 @@ final class SourceTyper(
 
   /** Resolves a function signature before body checking.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * class Counter {
@@ -876,7 +938,7 @@ final class SourceTyper(
 
   /** Infers an expression type, optionally under an expected type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val byte: u8 = 65
@@ -995,7 +1057,7 @@ final class SourceTyper(
 
   /** Checks a block left-to-right and infers its result from the final item.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val result = {
@@ -1030,7 +1092,7 @@ final class SourceTyper(
 
   /** Checks one item inside a block and updates block scope.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * {
@@ -1090,7 +1152,7 @@ final class SourceTyper(
 
   /** Infers the type of a name.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val value = 1
@@ -1179,7 +1241,7 @@ final class SourceTyper(
 
   /** Infers a direct type-constructor expression.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val make_vec = Vec[i32]
@@ -1207,7 +1269,7 @@ final class SourceTyper(
 
   /** Infers a field, method, foreign method, or variant constructor selection.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * class Nat { case Zero; case Succ(Nat) }
@@ -1328,7 +1390,7 @@ final class SourceTyper(
 
   /** Builds the typed error expression for failed field or method inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * value.missing
@@ -1362,7 +1424,7 @@ final class SourceTyper(
 
   /** Infers a fully qualified variant constructor expression.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val ok = Result[i32, String]::Ok
@@ -1419,7 +1481,7 @@ final class SourceTyper(
 
   /** Resolves an imported foreign qualified name during expression inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * import cpp namespace std as std
@@ -1455,7 +1517,7 @@ final class SourceTyper(
 
   /** Builds the canonical C++ spelling for a foreign symbol.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * std + vector + push_back => ::std::vector::push_back
@@ -1471,7 +1533,7 @@ final class SourceTyper(
 
   /** Infers a call expression from callee shape and expected argument types.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * def add(left: i32, right: i32): i32 = { left + right }
@@ -1661,7 +1723,7 @@ final class SourceTyper(
 
   /** Resolves selected calls before generic function-value call inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val n = Nat.Succ(Nat.Zero)
@@ -1774,7 +1836,7 @@ final class SourceTyper(
 
   /** Checks a call whose callee already inferred as an expression.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val apply: (i32) -> i32 = inc
@@ -1823,7 +1885,7 @@ final class SourceTyper(
   /** Checks arguments against a resolved callable signature and returns result
     * type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * def take(value: u8): Unit = {}
@@ -1868,7 +1930,7 @@ final class SourceTyper(
 
   /** Builds a typed placeholder for a call whose callee rule already failed.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * missing(1)
@@ -1898,7 +1960,7 @@ final class SourceTyper(
 
   /** Checks calls to trusted runtime functions.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * println("hello")
@@ -1960,7 +2022,7 @@ final class SourceTyper(
 
   /** Detects source names handled by the trusted runtime call rule.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * println("hello")
@@ -1971,7 +2033,7 @@ final class SourceTyper(
 
   /** Checks assignment and compound numeric assignment.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * var count: i32 = 0
@@ -2026,7 +2088,7 @@ final class SourceTyper(
 
   /** Infers unary operator expressions.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val no = !flag
@@ -2119,7 +2181,7 @@ final class SourceTyper(
 
   /** Infers binary operator expressions.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val ok = left < right and enabled
@@ -2258,7 +2320,7 @@ final class SourceTyper(
 
   /** Checks conditionals and infers their common branch type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val result: i32 = if flag { 1 } else { 2 }
@@ -2309,7 +2371,7 @@ final class SourceTyper(
 
   /** Checks supported collection iteration and binds the loop item type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * for item in values { println(item.to_string()) }
@@ -2361,7 +2423,7 @@ final class SourceTyper(
 
   /** Checks ordinary cosmo0 match expressions.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * value match {
@@ -2412,7 +2474,7 @@ final class SourceTyper(
 
   /** Checks a return expression against the enclosing function result type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * def answer(): i32 = {
@@ -2457,7 +2519,7 @@ final class SourceTyper(
 
   /** Checks a source match pattern against the expected scrutinee/payload type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * value match {
@@ -2533,7 +2595,7 @@ final class SourceTyper(
 
   /** Checks a variant pattern and its payload patterns.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * result match {
@@ -2602,7 +2664,7 @@ final class SourceTyper(
 
   /** Resolves constructor syntax used in a pattern.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * case Nat.Succ(rest) => rest
@@ -2652,7 +2714,7 @@ final class SourceTyper(
 
   /** Looks up the callable signature of a variant constructor.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * Nat.Succ(Nat.Zero)
@@ -2682,7 +2744,7 @@ final class SourceTyper(
 
   /** Resolves a nullary standard descriptor constructor by source name.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val text = String()
@@ -2705,7 +2767,7 @@ final class SourceTyper(
 
   /** Resolves a method from standard descriptor metadata.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val length = values.len()
@@ -2730,7 +2792,7 @@ final class SourceTyper(
 
   /** Resolves a supported foreign method surface.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * cxx_vector.push_back(1)
@@ -2753,7 +2815,7 @@ final class SourceTyper(
 
   /** Resolves the supported `std::vector` method signatures.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * cxx_vector.push_back(value)
@@ -2793,7 +2855,7 @@ final class SourceTyper(
 
   /** Finds the nullary descriptor owner used by constructor-call inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * String()
@@ -2806,7 +2868,7 @@ final class SourceTyper(
 
   /** Removes references and aliases before descriptor method lookup.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * (&String).len()  // lookup is performed on String
@@ -2819,7 +2881,7 @@ final class SourceTyper(
 
   /** Extracts the descriptor family name from a normalized owner type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * Vec[i32].len()  // descriptor name Vec
@@ -2833,7 +2895,7 @@ final class SourceTyper(
 
   /** Extracts descriptor arity for generic-method inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * Vec[i32] => 1
@@ -2848,7 +2910,7 @@ final class SourceTyper(
 
   /** Resolves a source class constructor signature by class name.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * Point(1, 2)
@@ -2862,7 +2924,7 @@ final class SourceTyper(
 
   /** Finds class metadata for field, method, and constructor inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * point.x
@@ -2877,7 +2939,7 @@ final class SourceTyper(
 
   /** Resolves a type alias target and detects recursive aliases.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * type Count = i32
@@ -2908,7 +2970,7 @@ final class SourceTyper(
 
   /** Resolves source type syntax into `SourceType`.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val bytes: Vec[u8] = Vec[u8]()
@@ -2930,7 +2992,7 @@ final class SourceTyper(
   /** Worker for `resolveType` that tracks alias recursion and in-scope generic
     * type parameters.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * type Pair[T] = Vec[T]
@@ -3045,7 +3107,7 @@ final class SourceTyper(
 
   /** Substitutes generic alias parameters after type-argument checking.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * type Boxed[T] = Option[T]
@@ -3083,7 +3145,7 @@ final class SourceTyper(
 
   /** Applies descriptor-specific constraints after standard type inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * Map[String, i32]
@@ -3107,7 +3169,7 @@ final class SourceTyper(
 
   /** Checks the Map/Set key-type rule.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * Map[String, i32]  // accepted
@@ -3128,7 +3190,7 @@ final class SourceTyper(
 
   /** Decides whether a type is a supported Map or Set key.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * String
@@ -3149,7 +3211,7 @@ final class SourceTyper(
 
   /** Applies argument-passing compatibility after argument inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * def read(value: &String): Unit = {}
@@ -3183,7 +3245,7 @@ final class SourceTyper(
   /** Emits an assignment-style mismatch when an inferred type cannot flow to an
     * expected type.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val value: i32 = true
@@ -3207,7 +3269,7 @@ final class SourceTyper(
 
   /** Checks receiver mutability for method calls.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * class Buffer { def push(&mut self, value: u8): Unit = {} }
@@ -3235,7 +3297,7 @@ final class SourceTyper(
 
   /** Checks a condition-like expression as `Bool`.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * while index < limit { index += 1 }
@@ -3255,7 +3317,7 @@ final class SourceTyper(
 
   /** Reports a literal-pattern type mismatch.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * value: String match {
@@ -3279,7 +3341,7 @@ final class SourceTyper(
 
   /** Creates the scope symbol used by later name-expression inference.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * var count: i32 = 0
@@ -3306,7 +3368,7 @@ final class SourceTyper(
   /** Computes whether a value of a type can be used as a mutable l-value or
     * mutable receiver.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * var value: i32 = 1
@@ -3326,7 +3388,7 @@ final class SourceTyper(
 
   /** Checks an ASCII literal and returns its integer code point.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val open: u8 = a"("
@@ -3350,7 +3412,7 @@ final class SourceTyper(
 
   /** Checks a rune literal and returns its Unicode scalar value.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * val letter: u32 = c"A"
@@ -3364,7 +3426,7 @@ final class SourceTyper(
 
   /** Extracts the single code point required by rune and ASCII literals.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * c"A"  // one code point

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
@@ -192,6 +192,20 @@ final class SourceTyper(
   private val classes = mutable.LinkedHashMap.empty[String, ClassInfo]
   private val functions = mutable.LinkedHashMap.empty[String, FunctionInfo]
 
+  /** Runs declaration collection before expression inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * class Counter { var value: i32 }
+    * def bump(value: i32): i32 = { value + 1 }
+    * val next = bump(41)
+    * }}}
+    *
+    * The checker first collects class/function signatures so later expression
+    * inference can resolve `Counter` constructors and `bump` calls without
+    * depending on declaration order.
+    */
   def check(): Result[TypedModule] =
     collectForeignNamespaceImports()
     collectAliases()
@@ -559,6 +573,20 @@ final class SourceTyper(
       functions.update(info.name, info)
     }
 
+  /** Converts one top-level declaration into its typed form.
+    *
+    * Program example:
+    *
+    * {{{
+    * val answer = 42
+    * def id(value: i32): i32 = { value }
+    * class Box { val value: i32 }
+    * }}}
+    *
+    * Value declarations define globals in the shared scope after their
+    * initializer has been inferred or checked. Functions and classes use the
+    * pre-collected signatures from the collection pass.
+    */
   private def typedDecl(decl: UntypedDecl, scope: Scope): Option[TypedDecl] =
     decl match
       case importDecl: UntypedImport =>
@@ -596,6 +624,22 @@ final class SourceTyper(
       case _: UntypedImpl =>
         None
 
+  /** Checks class fields, variants, aliases, and methods.
+    *
+    * Program example:
+    *
+    * {{{
+    * class Point {
+    *   val x: i32 = 0
+    *   val y: i32
+    *   def sum(&self): i32 = { self.x + self.y }
+    * }
+    * }}}
+    *
+    * Field initializers are checked against explicit field types. Method bodies
+    * are checked with the global scope so method lookup remains owner-based
+    * rather than accidentally capturing sibling methods as locals.
+    */
   private def typedClass(info: ClassInfo, globalScope: Scope): TypedClass =
     val classScope = globalScope.child
     info.methods.values.foreach(method =>
@@ -644,6 +688,20 @@ final class SourceTyper(
       info.span,
     )
 
+  /** Checks a function or method body against its declared signature.
+    *
+    * Program example:
+    *
+    * {{{
+    * def clamp(value: i32, min: i32 = 0): i32 = {
+    *   if value < min { min } else { value }
+    * }
+    * }}}
+    *
+    * Parameter annotations seed the local scope. Defaults and the body receive
+    * expected types from the resolved signature, so literals and branches can
+    * infer in context.
+    */
   private def typedFunction(
       info: FunctionInfo,
       outerScope: Scope,
@@ -697,6 +755,18 @@ final class SourceTyper(
       info.extern,
     )
 
+  /** Infers or checks a top-level value declaration.
+    *
+    * Program example:
+    *
+    * {{{
+    * val inferred = 42      // inferred: i32
+    * val checked: u8 = 42   // literal checked as u8
+    * }}}
+    *
+    * An explicit annotation supplies the expected initializer type. Without an
+    * annotation, the initializer type becomes the declaration type.
+    */
   private def typedValueDecl(
       value: UntypedValueDecl,
       scope: Scope,
@@ -731,6 +801,20 @@ final class SourceTyper(
       ),
     )
 
+  /** Resolves a function signature before body checking.
+    *
+    * Program example:
+    *
+    * {{{
+    * class Counter {
+    *   def add(&mut self, amount: i32): Unit = { self.value += amount }
+    * }
+    * }}}
+    *
+    * Parameters require explicit types. A leading `self` parameter is
+    * normalized into receiver metadata, which later method-call inference uses
+    * for receiver mutability checks.
+    */
   private def functionInfo(
       fn: UntypedFunction,
       owner: Option[String],
@@ -790,6 +874,19 @@ final class SourceTyper(
       fn.extern,
     )
 
+  /** Infers an expression type, optionally under an expected type.
+    *
+    * Program example:
+    *
+    * {{{
+    * val byte: u8 = 65
+    * val total = byte.to_i32() + 1
+    * }}}
+    *
+    * The `expected` type flows into literals, calls, branches, returns, and the
+    * final expression of a block. When no expected type is available, the
+    * expression chooses its default inference rule.
+    */
   private def expr(
       node: UntypedExpr,
       scope: Scope,
@@ -896,6 +993,20 @@ final class SourceTyper(
       case value: UntypedUnitLiteral =>
         ExprInfo(TypedUnitLiteral(SourceType.Unit, value.span), false, false)
 
+  /** Checks a block left-to-right and infers its result from the final item.
+    *
+    * Program example:
+    *
+    * {{{
+    * val result = {
+    *   val base = 40
+    *   base + 2
+    * }
+    * }}}
+    *
+    * Only the final item receives the caller's expected type; earlier items are
+    * checked without it so local inference remains statement-local.
+    */
   private def blockExpr(
       node: UntypedBlock,
       outerScope: Scope,
@@ -917,6 +1028,21 @@ final class SourceTyper(
       mutAllowed = true,
     )
 
+  /** Checks one item inside a block and updates block scope.
+    *
+    * Program example:
+    *
+    * {{{
+    * {
+    *   val x = 1
+    *   var y: i32 = x + 1
+    *   y
+    * }
+    * }}}
+    *
+    * Local declarations follow the same annotation-or-initializer rule as
+    * top-level values, then define a local symbol for later items.
+    */
   private def blockItem(
       item: UntypedBlockItem,
       scope: Scope,
@@ -962,6 +1088,19 @@ final class SourceTyper(
         val typed = expr(expression, scope, expected, context)
         typed.expr
 
+  /** Infers the type of a name.
+    *
+    * Program example:
+    *
+    * {{{
+    * val value = 1
+    * val copied = value
+    * val empty = Vec[i32]()
+    * }}}
+    *
+    * Lexical bindings win first. If no value binding exists, a single-segment
+    * name may infer as a class constructor or standard generic constructor.
+    */
   private def nameExpr(node: UntypedName, scope: Scope): ExprInfo =
     node.path.parts match
       case name :: Nil =>
@@ -1038,6 +1177,18 @@ final class SourceTyper(
           false,
         )
 
+  /** Infers a direct type-constructor expression.
+    *
+    * Program example:
+    *
+    * {{{
+    * val make_vec = Vec[i32]
+    * val values = Vec[i32]()
+    * }}}
+    *
+    * Only constructible standard or foreign applied types produce callable
+    * constructor types here.
+    */
   private def typeConstructorExpr(node: UntypedTypeConstructor): ExprInfo =
     val constructedTy = resolveType(node.ty, None)
     val ty = SourceType.dealias(constructedTy) match
@@ -1054,6 +1205,21 @@ final class SourceTyper(
       false,
     )
 
+  /** Infers a field, method, foreign method, or variant constructor selection.
+    *
+    * Program example:
+    *
+    * {{{
+    * class Nat { case Zero; case Succ(Nat) }
+    * val zero = Nat.Zero
+    * val size = values.len()
+    * val field = point.x
+    * }}}
+    *
+    * The receiver type determines whether selection resolves to variant
+    * metadata, field type, callable method signature, descriptor method, or
+    * foreign method surface.
+    */
   private def selectExpr(
       node: UntypedSelect,
       scope: Scope,
@@ -1160,6 +1326,17 @@ final class SourceTyper(
           case None =>
             invalidField(node.field, recv.expr.ty, node.span)
 
+  /** Builds the typed error expression for failed field or method inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * value.missing
+    * }}}
+    *
+    * The surrounding inference rule can keep producing a typed tree after the
+    * diagnostic, which avoids cascading failures in later expressions.
+    */
   private def invalidField(
       field: String,
       receiverType: SourceType,
@@ -1183,6 +1360,18 @@ final class SourceTyper(
       mutAllowed = false,
     )
 
+  /** Infers a fully qualified variant constructor expression.
+    *
+    * Program example:
+    *
+    * {{{
+    * val ok = Result[i32, String]::Ok
+    * val one = Result[i32, String]::Ok(1)
+    * }}}
+    *
+    * Nullary constructors infer directly as their result type. Constructors
+    * with payloads infer as function types until a call supplies arguments.
+    */
   private def variantConstructorExpr(
       node: UntypedVariantConstructor,
   ): ExprInfo =
@@ -1228,6 +1417,18 @@ final class SourceTyper(
           false,
         )
 
+  /** Resolves an imported foreign qualified name during expression inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * import cpp namespace std as std
+    * val symbol = std::vector
+    * }}}
+    *
+    * If the root segment is a foreign namespace alias, the source path infers
+    * as a foreign symbol rather than a user-defined variant constructor.
+    */
   private def foreignQualifiedName(
       owner: UntypedType,
       finalSegment: String,
@@ -1252,6 +1453,14 @@ final class SourceTyper(
       case _ =>
         None
 
+  /** Builds the canonical C++ spelling for a foreign symbol.
+    *
+    * Program example:
+    *
+    * {{{
+    * std + vector + push_back => ::std::vector::push_back
+    * }}}
+    */
   private def foreignCanonicalName(
       importValue: SourceCppNamespaceImport,
       suffix: List[String],
@@ -1260,6 +1469,21 @@ final class SourceTyper(
     if suffixName.isEmpty then importValue.namespace.cppName
     else s"${importValue.namespace.cppName}::$suffixName"
 
+  /** Infers a call expression from callee shape and expected argument types.
+    *
+    * Program example:
+    *
+    * {{{
+    * def add(left: i32, right: i32): i32 = { left + right }
+    * val total = add(1, 2)
+    * val next = counter.bump(1)
+    * val some = Option[i32]::Some(1)
+    * }}}
+    *
+    * Named functions, constructors, variant constructors, selected methods, and
+    * function-valued expressions all converge on `callWithSig` once a callable
+    * signature is known.
+    */
   private def callExpr(
       node: UntypedCall,
       scope: Scope,
@@ -1435,6 +1659,20 @@ final class SourceTyper(
         val callee = expr(node.callee, scope, None, context)
         callFunctionValue(callee, node.args, node.span, scope, context)
 
+  /** Resolves selected calls before generic function-value call inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * val n = Nat.Succ(Nat.Zero)
+    * values.push(1)
+    * builder.finish()
+    * }}}
+    *
+    * This rule handles `Owner.Variant(...)` specially, then checks descriptor,
+    * foreign, and class methods with receiver mutability before validating
+    * arguments.
+    */
   private def methodOrVariantCall(
       select: UntypedSelect,
       args: List[UntypedExpr],
@@ -1534,6 +1772,18 @@ final class SourceTyper(
             val selected = selectExpr(select, scope, context)
             callFunctionValue(selected, args, span, scope, context)
 
+  /** Checks a call whose callee already inferred as an expression.
+    *
+    * Program example:
+    *
+    * {{{
+    * val apply: (i32) -> i32 = inc
+    * val next = apply(41)
+    * }}}
+    *
+    * Only `SourceType.Function` is callable here; all named and method calls
+    * should already have been resolved to a `CallableSignature`.
+    */
   private def callFunctionValue(
       callee: ExprInfo,
       args: List[UntypedExpr],
@@ -1570,6 +1820,19 @@ final class SourceTyper(
           false,
         )
 
+  /** Checks arguments against a resolved callable signature and returns result
+    * type.
+    *
+    * Program example:
+    *
+    * {{{
+    * def take(value: u8): Unit = {}
+    * take(65) // integer literal is checked with expected u8
+    * }}}
+    *
+    * Each argument is inferred with its parameter type as `expected`, then
+    * `canPass` applies assignment and reference-passing rules.
+    */
   private def callWithSig(
       callee: TypedExpr,
       sig: CallableSignature,
@@ -1603,6 +1866,17 @@ final class SourceTyper(
       mutAllowed = mutationCapability(sig.returnType),
     )
 
+  /** Builds a typed placeholder for a call whose callee rule already failed.
+    *
+    * Program example:
+    *
+    * {{{
+    * missing(1)
+    * }}}
+    *
+    * Arguments are still inferred so their diagnostics are preserved, but the
+    * call itself receives an error signature.
+    */
   private def errorCall(
       node: UntypedCall,
       scope: Scope,
@@ -1622,6 +1896,19 @@ final class SourceTyper(
       false,
     )
 
+  /** Checks calls to trusted runtime functions.
+    *
+    * Program example:
+    *
+    * {{{
+    * println("hello")
+    * print("prefix")
+    * }}}
+    *
+    * Runtime calls use `TrustedExternAbi` signatures instead of ordinary source
+    * declarations, but argument inference still uses the parameter types as
+    * expected types.
+    */
   private def runtimeFunctionCall(
       calleeName: String,
       name: UntypedName,
@@ -1671,9 +1958,31 @@ final class SourceTyper(
       mutAllowed = mutationCapability(sig.returnType),
     )
 
+  /** Detects source names handled by the trusted runtime call rule.
+    *
+    * Program example:
+    *
+    * {{{
+    * println("hello")
+    * }}}
+    */
   private def isRuntimeFunction(name: String): Boolean =
     TrustedExternAbi.isTrustedSourceName(name)
 
+  /** Checks assignment and compound numeric assignment.
+    *
+    * Program example:
+    *
+    * {{{
+    * var count: i32 = 0
+    * count += 1
+    * count = 10
+    * }}}
+    *
+    * The target must be a mutable binding. The right side is checked against
+    * the target type, and compound assignments additionally require a numeric
+    * target.
+    */
   private def assignExpr(
       node: UntypedAssign,
       scope: Scope,
@@ -1715,6 +2024,21 @@ final class SourceTyper(
       true,
     )
 
+  /** Infers unary operator expressions.
+    *
+    * Program example:
+    *
+    * {{{
+    * val no = !flag
+    * val neg = -amount
+    * val ref = &value
+    * val value = *ref
+    * }}}
+    *
+    * Boolean negation checks `Bool`; numeric negation preserves the operand
+    * numeric type; reference and dereference rules construct or inspect
+    * `SourceType.Ref` while carrying mutability.
+    */
   private def unaryExpr(
       node: UntypedUnary,
       scope: Scope,
@@ -1793,6 +2117,20 @@ final class SourceTyper(
           false,
         )
 
+  /** Infers binary operator expressions.
+    *
+    * Program example:
+    *
+    * {{{
+    * val ok = left < right and enabled
+    * val sum: i64 = 1 + 2
+    * val same = name == other
+    * }}}
+    *
+    * Boolean operators check both operands as `Bool`; comparisons return
+    * `Bool`; arithmetic preserves the common numeric operand type and passes an
+    * expected numeric type to the left operand when available.
+    */
   private def binaryExpr(
       node: UntypedBinary,
       scope: Scope,
@@ -1918,6 +2256,19 @@ final class SourceTyper(
           false,
         )
 
+  /** Checks conditionals and infers their common branch type.
+    *
+    * Program example:
+    *
+    * {{{
+    * val result: i32 = if flag { 1 } else { 2 }
+    * if ready { println("ready") }
+    * }}}
+    *
+    * The condition checks as `Bool`. Both branches receive the outer expected
+    * type, then their inferred types must match; an `if` without `else` is
+    * `Unit`.
+    */
   private def ifExpr(
       node: UntypedIf,
       scope: Scope,
@@ -1956,6 +2307,18 @@ final class SourceTyper(
       mutationCapability(ty),
     )
 
+  /** Checks supported collection iteration and binds the loop item type.
+    *
+    * Program example:
+    *
+    * {{{
+    * for item in values { println(item.to_string()) }
+    * for key in table { println(key) }
+    * }}}
+    *
+    * Vec/Set/Arena iterate their element type. Map iteration currently binds
+    * the key type. The loop body is expected to type as `Unit`.
+    */
   private def forExpr(
       node: UntypedFor,
       scope: Scope,
@@ -1996,6 +2359,20 @@ final class SourceTyper(
       true,
     )
 
+  /** Checks ordinary cosmo0 match expressions.
+    *
+    * Program example:
+    *
+    * {{{
+    * value match {
+    *   case Option[i32]::Some(item) => item
+    *   case Option[i32]::None => 0
+    * }
+    * }}}
+    *
+    * The scrutinee type drives pattern checking. Arm bodies receive the outer
+    * expected type and must infer a common result type when present.
+    */
   private def matchExpr(
       node: UntypedMatch,
       scope: Scope,
@@ -2033,6 +2410,19 @@ final class SourceTyper(
       mutationCapability(ty),
     )
 
+  /** Checks a return expression against the enclosing function result type.
+    *
+    * Program example:
+    *
+    * {{{
+    * def answer(): i32 = {
+    *   return 42
+    * }
+    * }}}
+    *
+    * The returned value receives the function return type as its expected type.
+    * The return expression itself has type `Never` after checking.
+    */
   private def returnExpr(
       node: UntypedReturn,
       scope: Scope,
@@ -2065,6 +2455,22 @@ final class SourceTyper(
           false,
         )
 
+  /** Checks a source match pattern against the expected scrutinee/payload type.
+    *
+    * Program example:
+    *
+    * {{{
+    * value match {
+    *   case 0 => "zero"
+    *   case Option[i32]::Some(item) => item.to_string()
+    *   case _ => "other"
+    * }
+    * }}}
+    *
+    * Patterns do not infer independently. Literals check against the expected
+    * type, bindings define locals of that type, and variant patterns delegate
+    * payload checking to the constructor signature.
+    */
   private def pattern(
       node: UntypedPattern,
       expectedTy: SourceType,
@@ -2125,6 +2531,20 @@ final class SourceTyper(
       case value: UntypedVariantPattern =>
         variantPattern(value, expectedTy, scope)
 
+  /** Checks a variant pattern and its payload patterns.
+    *
+    * Program example:
+    *
+    * {{{
+    * result match {
+    *   case Result[i32, String]::Ok(value) => value
+    *   case Result[i32, String]::Err(message) => 0
+    * }
+    * }}}
+    *
+    * The selected constructor must return the expected scrutinee type. Each
+    * nested pattern is checked against the matching constructor payload type.
+    */
   private def variantPattern(
       node: UntypedVariantPattern,
       expectedTy: SourceType,
@@ -2180,6 +2600,19 @@ final class SourceTyper(
           node.span,
         )
 
+  /** Resolves constructor syntax used in a pattern.
+    *
+    * Program example:
+    *
+    * {{{
+    * case Nat.Succ(rest) => rest
+    * case Result[i32, String]::Ok(value) => value
+    * }}}
+    *
+    * Pattern constructors accept the same owner-qualified forms that expression
+    * constructors use, but they are resolved under the scrutinee's expected
+    * type.
+    */
   private def ctorExprForPattern(
       node: UntypedExpr,
       expectedTy: SourceType,
@@ -2217,6 +2650,18 @@ final class SourceTyper(
       case _ =>
         None
 
+  /** Looks up the callable signature of a variant constructor.
+    *
+    * Program example:
+    *
+    * {{{
+    * Nat.Succ(Nat.Zero)
+    * Option[i32]::Some(1)
+    * }}}
+    *
+    * Standard generic constructors come from descriptor metadata. User variants
+    * come from collected class metadata.
+    */
   private def ctorSig(
       ownerType: SourceType,
       variant: String,
@@ -2235,6 +2680,18 @@ final class SourceTyper(
           .map(_.sig(name))
       case _ => None
 
+  /** Resolves a nullary standard descriptor constructor by source name.
+    *
+    * Program example:
+    *
+    * {{{
+    * val text = String()
+    * val values = Vec[i32]()
+    * }}}
+    *
+    * Descriptor constructors let builtin and standard generic families behave
+    * like source constructors during call inference.
+    */
   private def descriptorCtor(
       name: String,
       span: SourceSpan,
@@ -2246,6 +2703,18 @@ final class SourceTyper(
         .map(_.instantiate(owner, span)),
     )
 
+  /** Resolves a method from standard descriptor metadata.
+    *
+    * Program example:
+    *
+    * {{{
+    * val length = values.len()
+    * val text = number.to_string()
+    * }}}
+    *
+    * The receiver type is normalized before descriptor lookup so references use
+    * the same method surface as their targets.
+    */
   private def descriptorMethod(
       ownerType: SourceType,
       methodName: String,
@@ -2259,6 +2728,18 @@ final class SourceTyper(
         .flatMap(_.method(methodName)),
     )
 
+  /** Resolves a supported foreign method surface.
+    *
+    * Program example:
+    *
+    * {{{
+    * cxx_vector.push_back(1)
+    * val size = cxx_vector.size()
+    * }}}
+    *
+    * Foreign methods are intentionally explicit descriptor shims; only known
+    * imported runtime surfaces infer callable signatures here.
+    */
   private def foreignMethod(
       ownerType: SourceType,
       methodName: String,
@@ -2270,6 +2751,18 @@ final class SourceTyper(
       case _ =>
         None
 
+  /** Resolves the supported `std::vector` method signatures.
+    *
+    * Program example:
+    *
+    * {{{
+    * cxx_vector.push_back(value)
+    * val n = cxx_vector.size()
+    * }}}
+    *
+    * These signatures enter the same method-call inference rule as source
+    * methods, including receiver mutability checks.
+    */
   private def foreignVectorMethod(
       owner: SourceType,
       item: SourceType,
@@ -2298,40 +2791,103 @@ final class SourceTyper(
       case _ =>
         None
 
+  /** Finds the nullary descriptor owner used by constructor-call inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * String()
+    * }}}
+    */
   private def descriptorOwner(name: String): Option[SourceType] =
     standardGenerics.get(name).filter(_.arity == 0).flatMap { _ =>
       SourceType.scalar(name)
     }
 
+  /** Removes references and aliases before descriptor method lookup.
+    *
+    * Program example:
+    *
+    * {{{
+    * (&String).len()  // lookup is performed on String
+    * }}}
+    */
   private def normalizeDescriptorOwner(ownerType: SourceType): SourceType =
     SourceType.dealias(ownerType) match
       case SourceType.Ref(target, _) => SourceType.dealias(target)
       case other                     => other
 
+  /** Extracts the descriptor family name from a normalized owner type.
+    *
+    * Program example:
+    *
+    * {{{
+    * Vec[i32].len()  // descriptor name Vec
+    * }}}
+    */
   private def descriptorName(ownerType: SourceType): Option[String] =
     normalizeDescriptorOwner(ownerType) match
       case SourceType.Standard(name, _) => Some(name)
       case SourceType.Builtin(name)     => Some(name)
       case _                            => None
 
+  /** Extracts descriptor arity for generic-method inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * Vec[i32] => 1
+    * String   => 0
+    * }}}
+    */
   private def descriptorArity(ownerType: SourceType): Int =
     normalizeDescriptorOwner(ownerType) match
       case SourceType.Standard(_, args) => args.length
       case SourceType.Builtin(_)        => 0
       case _                            => -1
 
+  /** Resolves a source class constructor signature by class name.
+    *
+    * Program example:
+    *
+    * {{{
+    * Point(1, 2)
+    * }}}
+    */
   private def classCtor(
       name: String,
       span: SourceSpan,
   ): Option[CallableSignature] =
     classes.get(name).map(_.ctorSig)
 
+  /** Finds class metadata for field, method, and constructor inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * point.x
+    * point.translate(1, 2)
+    * }}}
+    */
   private def classInfoFor(ty: SourceType): Option[ClassInfo] =
     SourceType.dealias(ty) match
       case SourceType.User(name)                    => classes.get(name)
       case SourceType.Ref(SourceType.User(name), _) => classes.get(name)
       case _                                        => None
 
+  /** Resolves a type alias target and detects recursive aliases.
+    *
+    * Program example:
+    *
+    * {{{
+    * type Count = i32
+    * val total: Count = 0
+    * }}}
+    *
+    * Alias resolution preserves the alias wrapper for diagnostics elsewhere,
+    * while this helper computes the target used by equality and assignment
+    * checks.
+    */
   private def resolveAlias(name: String): SourceType =
     resolveAlias(name, Set.empty)
 
@@ -2350,12 +2906,40 @@ final class SourceTyper(
         SourceType.Error
     aliasTypes.getOrElseUpdate(name, resolved)
 
+  /** Resolves source type syntax into `SourceType`.
+    *
+    * Program example:
+    *
+    * {{{
+    * val bytes: Vec[u8] = Vec[u8]()
+    * def update(value: &mut String): Unit = {}
+    * type Names = Map[String, i32]
+    * }}}
+    *
+    * This is the type-level counterpart of expression inference: it resolves
+    * builtins, `Self`, user classes, aliases, standard generics, references,
+    * and imported foreign symbols, then validates arity and descriptor
+    * constraints.
+    */
   private def resolveType(
       node: UntypedType,
       owner: Option[String],
   ): SourceType =
     resolveType(node, owner, Set.empty)
 
+  /** Worker for `resolveType` that tracks alias recursion and in-scope generic
+    * type parameters.
+    *
+    * Program example:
+    *
+    * {{{
+    * type Pair[T] = Vec[T]
+    * class Box { type Item = i32 }
+    * }}}
+    *
+    * `seenAliases` prevents infinite expansion, while `tyParams` lets alias
+    * bodies resolve generic parameters before falling back to named types.
+    */
   private def resolveType(
       node: UntypedType,
       owner: Option[String],
@@ -2459,6 +3043,18 @@ final class SourceTyper(
           mut,
         )
 
+  /** Substitutes generic alias parameters after type-argument checking.
+    *
+    * Program example:
+    *
+    * {{{
+    * type Boxed[T] = Option[T]
+    * val value: Boxed[i32] = Option[i32]::Some(1)
+    * }}}
+    *
+    * The alias body may contain references, functions, standard generics, and
+    * foreign applied types; substitution preserves that structure.
+    */
   private def substituteTypeParams(
       ty: SourceType,
       values: Map[String, SourceType],
@@ -2485,6 +3081,18 @@ final class SourceTyper(
       case other =>
         other
 
+  /** Applies descriptor-specific constraints after standard type inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * Map[String, i32]
+    * Set[Id[User]]
+    * }}}
+    *
+    * The core checker accepts the type constructor shape first, then verifies
+    * the extra key-type premise required by Map and Set.
+    */
   private def validateStandardTypeApplication(
       name: String,
       args: List[SourceType],
@@ -2497,6 +3105,15 @@ final class SourceTyper(
         validateMapSetKey(args.head, "Set", span)
       case _ =>
 
+  /** Checks the Map/Set key-type rule.
+    *
+    * Program example:
+    *
+    * {{{
+    * Map[String, i32]  // accepted
+    * Map[Vec[i32], i32] // rejected
+    * }}}
+    */
   private def validateMapSetKey(
       keyType: SourceType,
       owner: String,
@@ -2509,6 +3126,16 @@ final class SourceTyper(
         span,
       )
 
+  /** Decides whether a type is a supported Map or Set key.
+    *
+    * Program example:
+    *
+    * {{{
+    * String
+    * u64
+    * Id[User]
+    * }}}
+    */
   private def isSupportedMapSetKey(ty: SourceType): Boolean =
     SourceType.dealias(ty) match
       case SourceType.String => true
@@ -2520,6 +3147,22 @@ final class SourceTyper(
       case SourceType.Standard("Id", _ :: Nil) => true
       case _                                   => false
 
+  /** Applies argument-passing compatibility after argument inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * def read(value: &String): Unit = {}
+    * def write(value: &mut String): Unit = {}
+    * var text = "hello"
+    * read(text)   // allowed
+    * write(text)  // allowed because `text` is mutation-capable
+    * }}}
+    *
+    * Non-reference parameters use assignment compatibility. Reference
+    * parameters additionally check that mutable references are supplied only by
+    * mutable references or mutation-capable l-values.
+    */
   private def canPass(actual: ExprInfo, expected: SourceType): Boolean =
     SourceType.dealias(expected) match
       case SourceType.Ref(target, mutable) =>
@@ -2537,6 +3180,18 @@ final class SourceTyper(
       case other =>
         SourceType.assignable(actual.expr.ty, other)
 
+  /** Emits an assignment-style mismatch when an inferred type cannot flow to an
+    * expected type.
+    *
+    * Program example:
+    *
+    * {{{
+    * val value: i32 = true
+    * }}}
+    *
+    * This helper centralizes declaration initialization, assignment, and return
+    * checks so all use `SourceType.assignable`.
+    */
   private def checkAssignable(
       actual: ExprInfo,
       expected: SourceType,
@@ -2550,6 +3205,20 @@ final class SourceTyper(
         span,
       )
 
+  /** Checks receiver mutability for method calls.
+    *
+    * Program example:
+    *
+    * {{{
+    * class Buffer { def push(&mut self, value: u8): Unit = {} }
+    * val frozen = Buffer()
+    * frozen.push(1) // rejected
+    * }}}
+    *
+    * Method lookup infers the receiver expression first; this check verifies
+    * that a mutable receiver signature only accepts a mutation-capable
+    * receiver.
+    */
   private def checkRecvMutation(
       recv: ExprInfo,
       sig: CallableSignature,
@@ -2564,6 +3233,18 @@ final class SourceTyper(
         )
     }
 
+  /** Checks a condition-like expression as `Bool`.
+    *
+    * Program example:
+    *
+    * {{{
+    * while index < limit { index += 1 }
+    * if ready { println("ready") }
+    * }}}
+    *
+    * The expression is already inferred; this helper reports the standard
+    * expected-bool diagnostic when the inferred type is not `Bool`.
+    */
   private def requireBool(value: ExprInfo, span: SourceSpan): Unit =
     if !SourceType.same(value.expr.ty, SourceType.Bool) then
       error(
@@ -2572,6 +3253,19 @@ final class SourceTyper(
         span,
       )
 
+  /** Reports a literal-pattern type mismatch.
+    *
+    * Program example:
+    *
+    * {{{
+    * value: String match {
+    *   case 1 => "bad"
+    * }
+    * }}}
+    *
+    * Literal patterns have fixed or expected numeric types, so this diagnostic
+    * keeps pattern checking tied to the scrutinee type.
+    */
   private def invalidPatternType(
       span: SourceSpan,
       expected: SourceType,
@@ -2583,6 +3277,18 @@ final class SourceTyper(
       span,
     )
 
+  /** Creates the scope symbol used by later name-expression inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * var count: i32 = 0
+    * count
+    * }}}
+    *
+    * The `var`/`val` kind determines whether assignment inference can later use
+    * the name as a mutable binding.
+    */
   private def valueSymbol(
       name: String,
       ty: SourceType,
@@ -2597,6 +3303,19 @@ final class SourceTyper(
       span,
     )
 
+  /** Computes whether a value of a type can be used as a mutable l-value or
+    * mutable receiver.
+    *
+    * Program example:
+    *
+    * {{{
+    * var value: i32 = 1
+    * val ref: &mut i32 = &value
+    * }}}
+    *
+    * Mutable references carry their own capability; foreign namespaces/symbols,
+    * `Never`, and `Error` are never mutable values.
+    */
   private def mutationCapability(ty: SourceType): Boolean =
     SourceType.dealias(ty) match
       case SourceType.Ref(_, mutable) => mutable
@@ -2605,6 +3324,16 @@ final class SourceTyper(
       case SourceType.Never | SourceType.Error => false
       case _                                   => true
 
+  /** Checks an ASCII literal and returns its integer code point.
+    *
+    * Program example:
+    *
+    * {{{
+    * val open: u8 = a"("
+    * }}}
+    *
+    * ASCII literals type as `u8` and must contain exactly one ASCII code point.
+    */
   private def asciiLiteralValue(value: String, span: SourceSpan): BigInt =
     singleCodePoint(value, "ascii", span) match
       case Some(codePoint) if codePoint <= 0x7f =>
@@ -2619,9 +3348,29 @@ final class SourceTyper(
       case None =>
         BigInt(0)
 
+  /** Checks a rune literal and returns its Unicode scalar value.
+    *
+    * Program example:
+    *
+    * {{{
+    * val letter: u32 = c"A"
+    * }}}
+    *
+    * Rune literals type as `u32` and must contain exactly one valid Unicode
+    * scalar value.
+    */
   private def runeLiteralValue(value: String, span: SourceSpan): BigInt =
     singleCodePoint(value, "rune", span).fold(BigInt(0))(BigInt(_))
 
+  /** Extracts the single code point required by rune and ASCII literals.
+    *
+    * Program example:
+    *
+    * {{{
+    * c"A"  // one code point
+    * a"A"  // one ASCII code point
+    * }}}
+    */
   private def singleCodePoint(
       value: String,
       name: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/Typer.scala
@@ -7,8 +7,8 @@ import scala.collection.mutable.ListBuffer
   *
   * The no-profile entry point intentionally selects `cosmo0.subset`. MLTT and
   * dependent-pattern profiles are registered in `CheckerProfiles`, but the
-  * public cosmo0 source pipeline does not elaborate ordinary source into those
-  * artifacts yet.
+  * public cosmo0 source pipeline routes them to profile checkers before this
+  * factory is used.
   */
 object SourceTyper:
   def apply(module: UntypedModule): SourceTyper =
@@ -47,8 +47,8 @@ object SourceTyper:
   *
   * The `profile` constructor parameter is metadata for diagnostics and future
   * routing. It is not a second dispatcher inside this class: today this
-  * implementation checks the cosmo0 source subset, while public callers reject
-  * non-`cosmo0.subset` profiles before reaching `SourceTyper`.
+  * implementation checks only the cosmo0 source subset, while public callers
+  * route non-`cosmo0.subset` profiles before reaching `SourceTyper`.
   *
   * The checker is bidirectional in a small, source-oriented sense: `expr(node,
   * expected, context)` infers a type when `expected` is absent, and uses

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/Patterns.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/Patterns.scala
@@ -191,6 +191,16 @@ final case class DependentCaseTree(
 
 /** Elaborates dependent source pattern clauses into a small case tree.
   *
+  * Program examples:
+  *
+  * {{{
+  * case xs : Vec(A, S(n)) of
+  *   Cons(head, tail) -> head
+  *
+  * case xs : Vec(A, S(n)) of
+  *   Nil -> absurd
+  * }}}
+  *
   * Direct harness example:
   *
   * {{{
@@ -223,25 +233,52 @@ final case class DependentCaseTree(
   * )
   * }}}
   *
-  * Elaboration and refinement rules:
+  * Rules:
   *
-  *   - Profile gate: the selected `CheckerProfile` must support
-  *     `dependent-pattern-elaboration`; otherwise elaboration returns an
-  *     unsupported diagnostic and no branches.
-  *   - Constructor branch: find constructor metadata, unify the scrutinee
-  *     family indices with the constructor result indices, add constructor
-  *     telescope binders to the branch, and record the resulting substitution
-  *     summary as the branch refinement.
-  *   - Variable or wildcard branch: accept as a catch-all and mark all later
-  *     constructor branches redundant.
-  *   - Impossible branch: preserve a branch marked impossible by source.
-  *   - Equality branch: keep the representation, but reject it because equality
-  *     pattern matching is outside the current accepted fragment.
-  *   - Coverage: every constructor whose result indices are not impossible for
-  *     the scrutinee must be covered by a constructor branch or catch-all.
-  *   - Unification: variables and metas receive first-order substitutions,
-  *     same-headed constructors/families unify recursively, different heads
-  *     mark a branch impossible, and recursive solutions fail the occurs check.
+  * {{{
+  * profile supports dependent-pattern-elaboration
+  *   --------------------------------------------------- ProfileGate
+  *   elaborate clauses under profile
+  *
+  * ctor : (tel) -> F(actualIndices)
+  * unify(expectedIndices, actualIndices) = subst
+  *   --------------------------------------------------- ConstructorBranch
+  *   case x : F(expectedIndices) of ctor(patterns) -> body
+  *     elaborates with tel binders and branch refinement subst
+  *
+  * unify(expectedIndices, actualIndices) = impossible
+  *   --------------------------------------------------- ImpossibleBranch
+  *   ctor branch is preserved but marked impossible
+  *
+  * case x : F(indices) of y -> body
+  * case x : F(indices) of _ -> body
+  *   --------------------------------------------------- CatchAll
+  *   branch covers every remaining possible constructor
+  *
+  * case x : F(indices) of left = right -> body
+  *   --------------------------------------------------- EqualityPattern
+  *   rejected as outside the accepted dependent-pattern fragment
+  *
+  * forall ctor in F.constructors.
+  *   unify(scrutineeIndices, ctor.resultIndices) is impossible
+  *   or ctor is covered
+  *   or a catch-all branch exists
+  *   --------------------------------------------------- Coverage
+  *   case tree is exhaustive
+  *
+  * unify(v, term) = { v := term } when v notin FV(term)
+  * unify(H(xs), H(ys)) = zipWith unify xs ys
+  * unify(H(xs), K(ys)) = impossible when H != K
+  * unify(v, term) = occurs-check failure when v in FV(term)
+  * }}}
+  *
+  * Explanation:
+  *
+  * Elaboration is driven by constructor result indices. A `Cons` branch for
+  * `Vec(A, S(n))` compares the scrutinee indices `[A, S(n)]` with the
+  * constructor result indices `[A, S(k)]`, yielding the refinement `n=k`. A
+  * `Nil` branch compares `[A, S(n)]` with `[A, Z]`, so the branch is diagnosed
+  * as impossible instead of being treated as a valid head case.
   *
   * Pipeline note: this object is an experiment and test harness. The ordinary
   * cosmo0 package pipeline still type-checks source through `SourceTyper`.
@@ -263,7 +300,7 @@ object DependentPatterns:
 
   /** Reports whether the selected checker profile admits the elaboration rule.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * checkerProfile: "mltt.dependent-patterns"
@@ -292,7 +329,7 @@ object DependentPatterns:
 
   /** Unifies expected scrutinee indices with constructor result indices.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * xs : Vec(A, S(n))
@@ -301,12 +338,18 @@ object DependentPatterns:
     * // Cons result index is Vec(A, S(k)); unification records n = k.
     * }}}
     *
-    * Rule shape:
+    * Rules:
     *
     * {{{
     * unifyIndices([A, S(n)], [A, S(k)]) = { n := k }
     * unifyIndices([A, S(n)], [A, Z])    = impossible
     * }}}
+    *
+    * Explanation:
+    *
+    * The expected index list comes from the scrutinee type, and the actual
+    * index list comes from the constructor result family. Each pair is sent to
+    * the first-order index unifier; arity mismatch is a hard diagnostic.
     */
   def unifyIndices(
       store: DependentPatternTermStore,
@@ -330,7 +373,7 @@ object DependentPatterns:
 
   /** Elaborates source clauses into a dependent case tree.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * case xs : Vec(A, S(n)) of
@@ -341,6 +384,12 @@ object DependentPatterns:
     * imports the constructor telescope as branch binders, specializes the
     * expected branch type using the unifier result, and then records coverage
     * obligations for any remaining possible constructors.
+    *
+    * Explanation:
+    *
+    * This is the orchestration point for profile gating, constructor
+    * elaboration, wildcard handling, impossible branches, unsupported equality
+    * patterns, and final coverage checking.
     */
   def elaborateClauses(
       profile: CheckerProfile,
@@ -562,7 +611,7 @@ object DependentPatterns:
 
   /** Elaborates one constructor branch and its index refinement.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * case xs : Vec(A, S(n)) of
@@ -576,9 +625,21 @@ object DependentPatterns:
     * tail : Vec(A, k)
     * }}}
     *
-    * and unifies `Vec(A, S(n))` with `Vec(A, S(k))`, so the branch summary is
-    * `n=k`. If the same rule is tried with `Nil`, the heads `S` and `Z` differ
-    * and the branch is marked impossible.
+    * Rules:
+    *
+    * {{{
+    * ctor : telescope -> Vec(A, S(k))
+    * unify([A, S(n)], [A, S(k)]) = { n := k }
+    *   --------------------------------------------------- ConstructorBranch
+    *   Cons(head, tail) elaborates with binders and refinement n=k
+    * }}}
+    *
+    * Explanation:
+    *
+    * The constructor telescope becomes branch binders. The constructor result
+    * indices are unified with the scrutinee indices; if the same rule is tried
+    * with `Nil`, the heads `S` and `Z` differ and the branch is marked
+    * impossible.
     */
   private def elaborateConstructorClause(
       env: DependentPatternEnv,
@@ -626,12 +687,23 @@ object DependentPatterns:
 
   /** Checks that all possible constructors are covered after refinement.
     *
-    * Program example:
+    * Program examples:
     *
     * {{{
     * case xs : Vec(A, S(n)) of
     *   Cons(head, tail) -> head
     * }}}
+    *
+    * Rules:
+    *
+    * {{{
+    * forall ctor in Vec.constructors.
+    *   unify(scrutineeIndices, ctor.resultIndices) is impossible
+    *   or ctor has a branch
+    *   or a wildcard branch exists
+    * }}}
+    *
+    * Explanation:
     *
     * Coverage does not require `Nil` here, because `Vec(A, S(n))` cannot unify
     * with `Nil`'s result index `Vec(A, Z)`. For `xs : Vec(A, n)`, both `Nil`
@@ -683,7 +755,7 @@ object DependentPatterns:
 
   /** Renders the branch refinement inferred by constructor-index unification.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Cons(head, tail) -> head  // summary: n=k
@@ -704,7 +776,7 @@ object DependentPatterns:
 
   /** Extracts a named substitution for human-readable branch summaries.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * unify S(n) with S(k)
@@ -722,7 +794,7 @@ object DependentPatterns:
 
   /** Specializes the displayed expected branch type with the refinement.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * xs : Vec(A, S(n))
@@ -768,7 +840,7 @@ private final class DependentPatternUnifier(
 
   /** Dispatches the first-order index unification rule by the left term head.
     *
-    * Program examples:
+    * Rules:
     *
     * {{{
     * unify(n, k)       // records n := k
@@ -813,7 +885,7 @@ private final class DependentPatternUnifier(
 
   /** Solves an index variable or reuses the existing solution.
     *
-    * Program examples:
+    * Rules:
     *
     * {{{
     * n = k     // stores n := k
@@ -837,7 +909,7 @@ private final class DependentPatternUnifier(
 
   /** Unifies a constructor or family head against the right-hand term.
     *
-    * Program examples:
+    * Rules:
     *
     * {{{
     * S(n) ~ S(k)             // same constructor head, recurse on args
@@ -884,7 +956,7 @@ private final class DependentPatternUnifier(
 
   /** Applies the same-head unification rule for constructors and families.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Vec(A, S(n)) ~ Vec(A, S(k))
@@ -917,7 +989,7 @@ private final class DependentPatternUnifier(
 
   /** Recognizes the reflexive variable unification case.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * unify(n, n)    // no substitution is needed
@@ -939,7 +1011,7 @@ private final class DependentPatternUnifier(
 
   /** Detects whether a candidate variable solution would be recursive.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * ?m = Vec(A, ?m)  // rejected: ?m occurs in its own solution
@@ -960,7 +1032,7 @@ private final class DependentPatternUnifier(
 
   /** Records that the current constructor branch cannot refine the scrutinee.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * case xs : Vec(A, S(n)) of

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/Patterns.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/Patterns.scala
@@ -3,6 +3,23 @@ package cosmo0
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
+/** Index and family term fragment used by dependent-pattern elaboration.
+  *
+  * Term examples:
+  *
+  * {{{
+  * n               // Var("n")
+  * ?m0             // Meta(0)
+  * Z               // Constructor("Z", Nil)
+  * S(n)            // Constructor("S", List(n))
+  * Vec(A, S(n))    // Family("Vec", List(A, S(n)))
+  * }}}
+  *
+  * These terms model constructor result indices, not ordinary cosmo0
+  * expressions. They are stored by integer ids in `DependentPatternTermStore`
+  * so case-tree refinements can share the same compact representation as the
+  * Scala MLTT mirror.
+  */
 enum DependentPatternTerm:
   case Var(name: String)
   case Meta(index: Int)
@@ -91,6 +108,17 @@ final case class DependentPatternUnifyResult(
   def firstCode: String =
     diagnostics.headOption.map(_.code).getOrElse("")
 
+/** Source-level pattern fragment accepted by the dependent-pattern experiment.
+  *
+  * Pattern examples for `xs : Vec(A, S(n))`:
+  *
+  * {{{
+  * Cons(head, tail)  // refines the length index by unifying S(n) with S(k)
+  * _                 // catch-all branch
+  * impossible        // source marks an unreachable branch
+  * left = right      // represented but currently rejected by elaboration
+  * }}}
+  */
 enum DependentSourcePattern:
   case Constructor(name: String, args: List[Int], span: SourceSpan)
   case Variable(name: String, span: SourceSpan)
@@ -161,6 +189,63 @@ final case class DependentCaseTree(
   def firstCode: String =
     diagnostics.headOption.map(_.code).getOrElse("")
 
+/** Elaborates dependent source pattern clauses into a small case tree.
+  *
+  * Direct harness example:
+  *
+  * {{{
+  * val store = DependentPatterns.termStore()
+  * val env = DependentPatterns.env()
+  * val patterns = DependentPatterns.sourcePatternStore()
+  * DependentPatterns.addNatFixture(store, env)
+  * DependentPatterns.addVecFixture(store, env)
+  *
+  * val n = store.allocVar("n")
+  * val xsType = DependentPatterns.vecIndices(
+  *   store,
+  *   DependentPatterns.natSuccessor(store, n),
+  * )
+  * val cons = patterns.allocConstructor(
+  *   "Cons",
+  *   List(patterns.allocVariable("head", span), patterns.allocVariable("tail", span)),
+  *   span,
+  * )
+  * DependentPatterns.elaborateClauses(
+  *   CheckerProfiles.MlttDependentPatterns,
+  *   env,
+  *   store,
+  *   patterns,
+  *   "Vec",
+  *   "xs",
+  *   xsType,
+  *   "A",
+  *   List(DependentPatternClause(cons, "head", span)),
+  * )
+  * }}}
+  *
+  * Elaboration and refinement rules:
+  *
+  *   - Profile gate: the selected `CheckerProfile` must support
+  *     `dependent-pattern-elaboration`; otherwise elaboration returns an
+  *     unsupported diagnostic and no branches.
+  *   - Constructor branch: find constructor metadata, unify the scrutinee
+  *     family indices with the constructor result indices, add constructor
+  *     telescope binders to the branch, and record the resulting substitution
+  *     summary as the branch refinement.
+  *   - Variable or wildcard branch: accept as a catch-all and mark all later
+  *     constructor branches redundant.
+  *   - Impossible branch: preserve a branch marked impossible by source.
+  *   - Equality branch: keep the representation, but reject it because equality
+  *     pattern matching is outside the current accepted fragment.
+  *   - Coverage: every constructor whose result indices are not impossible for
+  *     the scrutinee must be covered by a constructor branch or catch-all.
+  *   - Unification: variables and metas receive first-order substitutions,
+  *     same-headed constructors/families unify recursively, different heads
+  *     mark a branch impossible, and recursive solutions fail the occurs check.
+  *
+  * Pipeline note: this object is an experiment and test harness. The ordinary
+  * cosmo0 package pipeline still type-checks source through `SourceTyper`.
+  */
 object DependentPatterns:
   private val UnsupportedUnificationCode =
     "cosmo.type.dependent-pattern.unsupported-unification"

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/Patterns.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/Patterns.scala
@@ -261,6 +261,21 @@ object DependentPatterns:
   def env(): DependentPatternEnv =
     DependentPatternEnv()
 
+  /** Reports whether the selected checker profile admits the elaboration rule.
+    *
+    * Program example:
+    *
+    * {{{
+    * checkerProfile: "mltt.dependent-patterns"
+    *
+    * case xs : Vec(A, S(n)) of
+    *   Cons(head, tail) -> head
+    * }}}
+    *
+    * This gate is the profile-side premise for every dependent-pattern rule
+    * below. Profiles without `dependent-pattern-elaboration` cannot elaborate
+    * constructor refinements or coverage obligations.
+    */
   def profileSupportsElaboration(profile: CheckerProfile): Boolean =
     profile.supports(CheckerProfiles.DependentPatternElaborationFeature)
 
@@ -275,6 +290,24 @@ object DependentPatterns:
       profile.id,
     )
 
+  /** Unifies expected scrutinee indices with constructor result indices.
+    *
+    * Program example:
+    *
+    * {{{
+    * xs : Vec(A, S(n))
+    *
+    * Cons(head, tail) -> head
+    * // Cons result index is Vec(A, S(k)); unification records n = k.
+    * }}}
+    *
+    * Rule shape:
+    *
+    * {{{
+    * unifyIndices([A, S(n)], [A, S(k)]) = { n := k }
+    * unifyIndices([A, S(n)], [A, Z])    = impossible
+    * }}}
+    */
   def unifyIndices(
       store: DependentPatternTermStore,
       expected: List[Int],
@@ -295,6 +328,20 @@ object DependentPatterns:
     }
     unifier.finish()
 
+  /** Elaborates source clauses into a dependent case tree.
+    *
+    * Program example:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Cons(head, tail) -> head
+    * }}}
+    *
+    * The constructor rule checks that `Cons` can refine the scrutinee family,
+    * imports the constructor telescope as branch binders, specializes the
+    * expected branch type using the unifier result, and then records coverage
+    * obligations for any remaining possible constructors.
+    */
   def elaborateClauses(
       profile: CheckerProfile,
       env: DependentPatternEnv,
@@ -513,6 +560,26 @@ object DependentPatterns:
       tree.branches.map(branch => s"  ${renderCaseBranch(branch)}")
     (head :: branchText).mkString("\n")
 
+  /** Elaborates one constructor branch and its index refinement.
+    *
+    * Program example:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Cons(head, tail) -> head
+    * }}}
+    *
+    * `Cons` contributes binders from its telescope:
+    *
+    * {{{
+    * head : A
+    * tail : Vec(A, k)
+    * }}}
+    *
+    * and unifies `Vec(A, S(n))` with `Vec(A, S(k))`, so the branch summary is
+    * `n=k`. If the same rule is tried with `Nil`, the heads `S` and `Z` differ
+    * and the branch is marked impossible.
+    */
   private def elaborateConstructorClause(
       env: DependentPatternEnv,
       store: DependentPatternTermStore,
@@ -557,6 +624,19 @@ object DependentPatterns:
           name,
         )
 
+  /** Checks that all possible constructors are covered after refinement.
+    *
+    * Program example:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Cons(head, tail) -> head
+    * }}}
+    *
+    * Coverage does not require `Nil` here, because `Vec(A, S(n))` cannot unify
+    * with `Nil`'s result index `Vec(A, Z)`. For `xs : Vec(A, n)`, both `Nil`
+    * and `Cons` remain possible unless a wildcard branch appears.
+    */
   private def checkCoverage(
       env: DependentPatternEnv,
       store: DependentPatternTermStore,
@@ -601,6 +681,16 @@ object DependentPatterns:
     if args.isEmpty then name
     else s"$name(${indicesDisplay(store, args)})"
 
+  /** Renders the branch refinement inferred by constructor-index unification.
+    *
+    * Program example:
+    *
+    * {{{
+    * Cons(head, tail) -> head  // summary: n=k
+    * Nil -> absurd             // summary: impossible for Vec(A, S(n))
+    * _ -> fallback             // summary: identity
+    * }}}
+    */
   private def refinementSummary(
       store: DependentPatternTermStore,
       result: DependentPatternUnifyResult,
@@ -612,6 +702,15 @@ object DependentPatterns:
       .orElse(solutionSummary(store, result, "A"))
       .getOrElse("identity")
 
+  /** Extracts a named substitution for human-readable branch summaries.
+    *
+    * Program example:
+    *
+    * {{{
+    * unify S(n) with S(k)
+    * solutionSummary(result, "n") == Some("n=k")
+    * }}}
+    */
   private def solutionSummary(
       store: DependentPatternTermStore,
       result: DependentPatternUnifyResult,
@@ -621,6 +720,18 @@ object DependentPatterns:
       .get(name)
       .map(value => s"$name=${termDisplay(store, value)}")
 
+  /** Specializes the displayed expected branch type with the refinement.
+    *
+    * Program example:
+    *
+    * {{{
+    * xs : Vec(A, S(n))
+    * Cons(head, tail) -> head
+    *
+    * expected branch type: A
+    * specialized display: A under n=k
+    * }}}
+    */
   private def specializedExpectedType(
       expectedType: String,
       refinementSummary: String,
@@ -655,6 +766,16 @@ private final class DependentPatternUnifier(
   private var impossible = false
   private var failed = false
 
+  /** Dispatches the first-order index unification rule by the left term head.
+    *
+    * Program examples:
+    *
+    * {{{
+    * unify(n, k)       // records n := k
+    * unify(S(n), S(k)) // recurses and records n := k
+    * unify(S(n), Z)    // marks the branch impossible
+    * }}}
+    */
   def unify(left: Int, right: Int): Unit =
     if failed || impossible then return
 
@@ -690,6 +811,16 @@ private final class DependentPatternUnifier(
       diagnostics = diagnostics.toList,
     )
 
+  /** Solves an index variable or reuses the existing solution.
+    *
+    * Program examples:
+    *
+    * {{{
+    * n = k     // stores n := k
+    * n = S(n)  // rejected by occurs check
+    * n = n     // accepted without adding a substitution
+    * }}}
+    */
   private def unifyVariable(name: String, value: Int): Unit =
     substitutions.get(name) match
       case Some(solution) =>
@@ -704,6 +835,16 @@ private final class DependentPatternUnifier(
           )
         else substitutions.update(name, value)
 
+  /** Unifies a constructor or family head against the right-hand term.
+    *
+    * Program examples:
+    *
+    * {{{
+    * S(n) ~ S(k)             // same constructor head, recurse on args
+    * Vec(A, S(n)) ~ Vec(A,k) // same family head, recurse on indices
+    * S(n) ~ Z                // different constructor head, impossible
+    * }}}
+    */
   private def unifyConstructorLike(
       left: Int,
       name: String,
@@ -741,6 +882,15 @@ private final class DependentPatternUnifier(
           "<error>",
         )
 
+  /** Applies the same-head unification rule for constructors and families.
+    *
+    * Program example:
+    *
+    * {{{
+    * Vec(A, S(n)) ~ Vec(A, S(k))
+    * // heads and arities match, then A ~ A and S(n) ~ S(k)
+    * }}}
+    */
   private def unifySameHead(
       leftName: String,
       leftArgs: List[Int],
@@ -765,6 +915,15 @@ private final class DependentPatternUnifier(
       unify(left, right)
     }
 
+  /** Recognizes the reflexive variable unification case.
+    *
+    * Program example:
+    *
+    * {{{
+    * unify(n, n)    // no substitution is needed
+    * unify(?m0, ?m0) // no substitution is needed
+    * }}}
+    */
   private def termIsSameVariable(name: String, value: Int): Boolean =
     store.termValue(value) match
       case DependentPatternTerm.Var(valueName) =>
@@ -778,6 +937,14 @@ private final class DependentPatternUnifier(
       case DependentPatternTerm.Error =>
         false
 
+  /** Detects whether a candidate variable solution would be recursive.
+    *
+    * Program example:
+    *
+    * {{{
+    * ?m = Vec(A, ?m)  // rejected: ?m occurs in its own solution
+    * }}}
+    */
   private def occurs(name: String, value: Int): Boolean =
     store.termValue(value) match
       case DependentPatternTerm.Var(valueName) =>
@@ -791,6 +958,17 @@ private final class DependentPatternUnifier(
       case DependentPatternTerm.Error =>
         false
 
+  /** Records that the current constructor branch cannot refine the scrutinee.
+    *
+    * Program example:
+    *
+    * {{{
+    * case xs : Vec(A, S(n)) of
+    *   Nil -> absurd
+    *
+    * // Nil has index Vec(A, Z), and S(n) cannot refine Z.
+    * }}}
+    */
   private def markImpossible(summary: String): Unit =
     impossible = true
     addDiagnostic(

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/README.md
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/dependent/README.md
@@ -6,6 +6,8 @@ profiles and tests.
 `Patterns.scala` models dependent pattern terms, constructors, source patterns,
 case trees, branch refinements, unification results, and diagnostics.
 
-It is intentionally isolated from the ordinary cosmo0 subset path. The default
-source pipeline reaches this code only through explicit checker profile support
-and tests; ordinary package checking still flows through `tyck/Typer.scala`.
+It is intentionally isolated from the ordinary cosmo0 subset path.
+`DependentPatternProfileChecker` lets `checkerProfile: "mltt.dependent-patterns"`
+source fixtures execute named dependent-pattern assertions by constructing
+source clauses and calling this elaborator. Ordinary `cosmo0.subset` package
+checking still flows through `tyck/Typer.scala`.

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/README.md
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/README.md
@@ -6,6 +6,8 @@ This directory contains the Scala mirror for the experimental MLTT core checker.
 metavariables, conversion, bidirectional infer/check entry points, and
 diagnostics.
 
-It is profile-gated and separate from the default cosmo0 source checker. The
-ordinary compiler pipeline does not elaborate user source into MLTT core yet;
-tests and profile fixtures exercise this component directly.
+It is profile-gated and separate from the default cosmo0 source checker.
+`MlttProfileChecker` lets `checkerProfile: "mltt.core"` source fixtures execute
+named MLTT assertions by constructing core terms and calling this checker. The
+ordinary `cosmo0.subset` source path still does not elaborate general user
+source into MLTT core.

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
@@ -274,6 +274,18 @@ final case class MlttCheckResult(
 
 /** Bidirectional checker for the experimental `mltt.core` profile.
   *
+  * Program examples:
+  *
+  * {{{
+  * A : Type0
+  * y : A
+  * (fun x: A => x)(y)
+  * (x, y)
+  * fst((x, y))
+  * Refl(x)
+  * Cons(k, head, tail)
+  * }}}
+  *
   * Direct harness example:
   *
   * {{{
@@ -287,27 +299,59 @@ final case class MlttCheckResult(
   * MlttTypeChecker.check(store, context, id, idType)
   * }}}
   *
-  * Core infer/check rules:
+  * Rules:
   *
-  *   - Universe: `Type n` infers `Type (n + 1)`.
-  *   - Variable: `x` infers the type stored for `x` in the context.
-  *   - Pi/Sigma: domains and bodies must infer universe-classified types; the
-  *     resulting universe is the maximum level of both sides.
-  *   - Lambda: a lambda can infer a Pi type only when its annotation is a type;
-  *     when checking, it is accepted only against an expected Pi type.
-  *   - Application: infer the callee, reduce it to WHNF, require a Pi type,
-  *     check the argument against the domain, then substitute in the codomain.
-  *   - Pair: pair inference is intentionally unsupported; pairs check only
-  *     against an expected Sigma type.
-  *   - Projection: infer the pair, require a Sigma type, then return the first
-  *     component type or the second component type after substituting `fst(p)`.
-  *   - Equality/Refl: `Eq(A, l, r)` checks `A` as a type and both sides as `A`;
-  *     `Refl(v)` checks against `Eq(A, l, r)` when `v`, `l`, and `r` convert.
-  *   - Constructors: Nat and Vec constructors check against expected inductive
-  *     families. Constructor inference is only accepted for simple Nat terms.
-  *   - Conversion: definitional equality uses WHNF normalization with beta,
-  *     let, transparent pure definitions, and Sigma projections. Opaque or
-  *     effectful definitions are not reduced during conversion.
+  * {{{
+  * Gamma |- Type n => Type (n + 1)
+  * Gamma, x : A |- x => A
+  * Gamma |- A => Type i; Gamma, x : A |- B => Type j
+  *   --------------------------------------------------- Pi
+  *   Gamma |- (x: A) -> B => Type(max(i, j))
+  * Gamma |- A => Type i; Gamma, x : A |- B => Type j
+  *   --------------------------------------------------- Sigma
+  *   Gamma |- Sigma(x: A). B => Type(max(i, j))
+  * Gamma |- A => Type i; Gamma, x : A |- body => B
+  *   --------------------------------------------------- LambdaInfer
+  *   Gamma |- fun x: A => body => (x: A) -> B
+  * Gamma, x : A |- body <= B
+  *   --------------------------------------------------- LambdaCheck
+  *   Gamma |- fun x: A => body <= (x: A) -> B
+  * Gamma |- f => (x: A) -> B; Gamma |- arg <= A
+  *   --------------------------------------------------- Apply
+  *   Gamma |- f(arg) => B[arg / x]
+  * Gamma |- fst(p) => A
+  *   when Gamma |- p => Sigma(x: A). B
+  * Gamma |- snd(p) => B[fst(p) / x]
+  *   when Gamma |- p => Sigma(x: A). B
+  * Gamma |- first <= A; Gamma |- second <= B[first / x]
+  *   --------------------------------------------------- PairCheck
+  *   Gamma |- (first, second) <= Sigma(x: A). B
+  * Gamma |- A => Type i; Gamma |- left <= A; Gamma |- right <= A
+  *   --------------------------------------------------- Eq
+  *   Gamma |- Eq(A, left, right) => Type i
+  * Gamma |- value == left; Gamma |- value == right
+  *   --------------------------------------------------- ReflCheck
+  *   Gamma |- Refl(value) <= Eq(A, left, right)
+  * Gamma |- Z <= Nat
+  * Gamma |- n <= Nat
+  *   --------------------------------------------------- Succ
+  *   Gamma |- S(n) <= Nat
+  * Gamma |- Nil <= Vec(A, Z)
+  * Gamma |- k <= Nat; Gamma |- head <= A; Gamma |- tail <= Vec(A, k)
+  *   --------------------------------------------------- Cons
+  *   Gamma |- Cons(k, head, tail) <= Vec(A, S(k))
+  * Gamma |- left --> lwhnf; Gamma |- right --> rwhnf; lwhnf ~= rwhnf
+  *   --------------------------------------------------- Conversion
+  *   Gamma |- left == right
+  * }}}
+  *
+  * Explanation:
+  *
+  * The checker implements these rules over an already elaborated MLTT core term
+  * store. `infer` covers synthesis rules, `check` covers introduction forms
+  * that need an expected type, and `convert` supplies definitional equality
+  * through WHNF beta, let, transparent pure definitions, and Sigma projections.
+  * Opaque or effectful definitions are intentionally not reduced.
   *
   * Pipeline note: direct tests can call this object, and `mltt.core` profile
   * source fixtures reach it through `MlttProfileChecker` assertion directives.
@@ -339,13 +383,19 @@ object MlttTypeChecker:
 
   /** Infers the type of an MLTT core term.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
-    * A : Type0
-    * y : A
-    * (fun x: A => x)(y)  // infers A
+    * Gamma |- term => T
     * }}}
+    *
+    * Program examples:
+    *
+    * {{{
+    * (fun x: A => x)(y)
+    * }}}
+    *
+    * Explanation:
     *
     * This entry point is synthesis-only: terms such as pairs and `Refl` that
     * need an expected type report unsupported inference diagnostics.
@@ -368,13 +418,21 @@ object MlttTypeChecker:
 
   /** Checks an MLTT core term against an expected type.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
-    * fun x: A => x <= (x: A) -> A
-    * (x, y) <= Sigma(first: A). A
-    * Refl(x) <= Eq(A, x, x)
+    * Gamma |- term <= Expected
     * }}}
+    *
+    * Program examples:
+    *
+    * {{{
+    * fun x: A => x
+    * (x, y)
+    * Refl(x)
+    * }}}
+    *
+    * Explanation:
     *
     * Checking handles introduction forms directly, then falls back to inference
     * plus conversion when the term is not an introduction form for the expected
@@ -403,13 +461,25 @@ object MlttTypeChecker:
 
   /** Checks definitional equality under the selected normalization strategy.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
-    * (fun x: A => x)(y) == y
-    * let z = y; z == y
-    * fst((x, y)) == x
+    * Gamma |- left --> lwhnf
+    * Gamma |- right --> rwhnf
+    * lwhnf ~= rwhnf
+    *   --------------------------------------------------- Convert
+    * Gamma |- left == right
     * }}}
+    *
+    * Program examples:
+    *
+    * {{{
+    * (fun x: A => x)(y)
+    * let z = y; z
+    * fst((x, y))
+    * }}}
+    *
+    * Explanation:
     *
     * The current strategy is WHNF conversion. It reduces beta, let, transparent
     * pure definitions, and Sigma projections, then compares normalized heads
@@ -446,7 +516,7 @@ object MlttTypeChecker:
 
   /** Produces the diagnostic for constraints outside the MLTT profile.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * ?f(x) = y
@@ -467,7 +537,7 @@ object MlttTypeChecker:
 
   /** Installs the Nat fixture used by MLTT inference and conversion examples.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Nat : Type0
@@ -487,7 +557,7 @@ object MlttTypeChecker:
 
   /** Installs the indexed Vec fixture used by constructor checking examples.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Vec(A: Type0, n: Nat) : Type0
@@ -537,7 +607,7 @@ object MlttTypeChecker:
 
   /** Renders core MLTT terms in the same notation used by diagnostics.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (x: A) -> A
@@ -611,7 +681,7 @@ object MlttTypeChecker:
 
   /** Implements MLTT synthesis rules for every core term constructor.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Type0          => Type1
@@ -706,7 +776,7 @@ object MlttTypeChecker:
 
   /** Infers a variable from the local context.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * A : Type0, x : A |- x => A
@@ -732,7 +802,7 @@ object MlttTypeChecker:
 
   /** Infers the universe level of Pi and Sigma type formers.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * A : Type0
@@ -769,7 +839,7 @@ object MlttTypeChecker:
 
   /** Infers a Pi type for an annotated lambda.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * fun x: A => x  =>  (x: A) -> A
@@ -795,7 +865,7 @@ object MlttTypeChecker:
 
   /** Infers application by eliminating a Pi type.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * f : (x: A) -> B
@@ -834,7 +904,7 @@ object MlttTypeChecker:
 
   /** Infers Sigma projections.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * p : Sigma(first: A). B(first)
@@ -877,7 +947,7 @@ object MlttTypeChecker:
   /** Synthesizes constructor types where the profile supports unambiguous
     * inference.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Z => Nat
@@ -911,7 +981,7 @@ object MlttTypeChecker:
 
   /** Infers the universe of an equality type.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * A : Type0
@@ -939,7 +1009,7 @@ object MlttTypeChecker:
 
   /** Implements MLTT checking rules for introduction forms.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * fun x: A => body <= (x: A) -> B
@@ -1012,7 +1082,7 @@ object MlttTypeChecker:
 
   /** Checks lambda introduction against an expected Pi type.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * fun y: A => y <= (x: A) -> A
@@ -1046,7 +1116,7 @@ object MlttTypeChecker:
 
   /** Checks pair introduction against an expected Sigma type.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (x, y) <= Sigma(first: A). B(first)
@@ -1079,7 +1149,7 @@ object MlttTypeChecker:
 
   /** Checks reflexivity introduction against an equality type.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Refl(x) <= Eq(A, x, x)
@@ -1108,7 +1178,7 @@ object MlttTypeChecker:
 
   /** Checks constructors against an expected inductive family.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Z <= Nat
@@ -1145,7 +1215,7 @@ object MlttTypeChecker:
 
   /** Checks Nat constructors.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Z <= Nat
@@ -1170,7 +1240,7 @@ object MlttTypeChecker:
 
   /** Checks Vec constructors against the expected element and length indices.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Nil <= Vec(A, Z)
@@ -1205,7 +1275,7 @@ object MlttTypeChecker:
 
   /** Checks the indexed payload of `Cons`.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * k : Nat
@@ -1240,7 +1310,7 @@ object MlttTypeChecker:
 
   /** Recognizes a constructor literal with the expected arity.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * S(k) // constructor "S" with arity 1
@@ -1263,7 +1333,7 @@ object MlttTypeChecker:
 
   /** Recursively checks definitional equality after WHNF reduction.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (fun x: A => x)(y) == y
@@ -1347,7 +1417,7 @@ object MlttTypeChecker:
 
   /** Converts corresponding elements in parameter, index, or spine lists.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Vec(A, S(k)) == Vec(A, S(k))
@@ -1369,7 +1439,7 @@ object MlttTypeChecker:
 
   /** Reduces a term to weak-head normal form for conversion.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (fun x: A => x)(y) --> y
@@ -1409,7 +1479,7 @@ object MlttTypeChecker:
 
   /** Reduces transparent pure definitions during conversion.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * add_z_n = n
@@ -1445,7 +1515,7 @@ object MlttTypeChecker:
 
   /** Performs beta reduction when a WHNF callee is a lambda.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (fun x: A => x)(y) --> y
@@ -1473,7 +1543,7 @@ object MlttTypeChecker:
 
   /** Reduces first projection from a concrete pair.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * fst((x, y)) --> x
@@ -1494,7 +1564,7 @@ object MlttTypeChecker:
 
   /** Reduces second projection from a concrete pair.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * snd((x, y)) --> y
@@ -1515,7 +1585,7 @@ object MlttTypeChecker:
 
   /** Performs capture-oblivious substitution over the stored core term tree.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * substitute(x, x := y) = y
@@ -1605,7 +1675,7 @@ object MlttTypeChecker:
 
   /** Compares stored terms by stable syntax before recursive conversion.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Vec(A, S(k)) == Vec(A, S(k))
@@ -1619,7 +1689,7 @@ object MlttTypeChecker:
 
   /** Reads a universe level from a term.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * Type0 => Some(0)
@@ -1634,7 +1704,7 @@ object MlttTypeChecker:
   /** Converts an inferred classifier `Type(n + 1)` into the classified type's
     * universe level `n`.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * infer(Type0) = Type1
@@ -1649,7 +1719,7 @@ object MlttTypeChecker:
 
   /** Reports that a type former operand did not infer to a universe.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * (x: not_a_type) -> x
@@ -1671,7 +1741,7 @@ object MlttTypeChecker:
 
   /** Reports public metavariables that remain unsolved after checking.
     *
-    * Program example:
+    * Rules:
     *
     * {{{
     * ?m0 <= A

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
@@ -2,6 +2,27 @@ package cosmo0
 
 import scala.collection.mutable.ListBuffer
 
+/** Core Martin-Lof type theory term language used by the experimental MLTT
+  * checker mirror.
+  *
+  * Term examples:
+  *
+  * {{{
+  * Type0                         // Universe(0)
+  * (x: A) -> A                   // Pi("x", A, A)
+  * fun x: A => x                 // Lambda("x", A, Var("x"))
+  * f(a)                          // Apply(f, a)
+  * Sigma(x: A). B                // Sigma("x", A, B)
+  * (a, b), fst(p), snd(p)        // Pair and projections
+  * Eq(A, x, y), Refl(x)          // identity type and reflexivity witness
+  * Nat, Z, S(n)                  // builtin Nat fixture
+  * Vec(A, n), Nil, Cons(k,h,t)   // builtin Vec fixture
+  * }}}
+  *
+  * Terms are stored by integer ids in `MlttTermStore`. The checker expects an
+  * already elaborated core term; ordinary cosmo0 source is not translated into
+  * this representation by the default compiler pipeline.
+  */
 enum MlttTerm:
   case Var(name: String)
   case Universe(level: Int)
@@ -251,6 +272,47 @@ final case class MlttCheckResult(
   def artifactSummary: String =
     s"$profileId|$artifactKind|$status|$normalizationStrategy"
 
+/** Bidirectional checker for the experimental `mltt.core` profile.
+  *
+  * Direct harness example:
+  *
+  * {{{
+  * val store = MlttTypeChecker.termStore()
+  * val type0 = store.allocUniverse(0)
+  * val a = store.allocVar("A")
+  * val id = store.allocLambda("x", a, store.allocVar("x"))
+  * val idType = store.allocPi("x", a, a)
+  * val context = MlttTypeChecker.context().extendLocal("A", type0)
+  *
+  * MlttTypeChecker.check(store, context, id, idType)
+  * }}}
+  *
+  * Core infer/check rules:
+  *
+  *   - Universe: `Type n` infers `Type (n + 1)`.
+  *   - Variable: `x` infers the type stored for `x` in the context.
+  *   - Pi/Sigma: domains and bodies must infer universe-classified types; the
+  *     resulting universe is the maximum level of both sides.
+  *   - Lambda: a lambda can infer a Pi type only when its annotation is a type;
+  *     when checking, it is accepted only against an expected Pi type.
+  *   - Application: infer the callee, reduce it to WHNF, require a Pi type,
+  *     check the argument against the domain, then substitute in the codomain.
+  *   - Pair: pair inference is intentionally unsupported; pairs check only
+  *     against an expected Sigma type.
+  *   - Projection: infer the pair, require a Sigma type, then return the first
+  *     component type or the second component type after substituting `fst(p)`.
+  *   - Equality/Refl: `Eq(A, l, r)` checks `A` as a type and both sides as `A`;
+  *     `Refl(v)` checks against `Eq(A, l, r)` when `v`, `l`, and `r` convert.
+  *   - Constructors: Nat and Vec constructors check against expected inductive
+  *     families. Constructor inference is only accepted for simple Nat terms.
+  *   - Conversion: definitional equality uses WHNF normalization with beta,
+  *     let, transparent pure definitions, and Sigma projections. Opaque or
+  *     effectful definitions are not reduced during conversion.
+  *
+  * Pipeline note: this object is exercised by tests and fixtures directly.
+  * `Cosmo0.check` and package checking currently return unsupported for
+  * non-`cosmo0.subset` profiles instead of routing source here.
+  */
 object MlttTypeChecker:
   val WhnfConversionStrategy = "mltt.whnf-conversion"
   val UnknownVariableCode = "cosmo.type.mltt.unknown-variable"

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
@@ -337,6 +337,19 @@ object MlttTypeChecker:
   def metaStore(): MlttMetaStore =
     MlttMetaStore()
 
+  /** Infers the type of an MLTT core term.
+    *
+    * Program example:
+    *
+    * {{{
+    * A : Type0
+    * y : A
+    * (fun x: A => x)(y)  // infers A
+    * }}}
+    *
+    * This entry point is synthesis-only: terms such as pairs and `Refl` that
+    * need an expected type report unsupported inference diagnostics.
+    */
   def infer(
       store: MlttTermStore,
       context: MlttContext,
@@ -353,6 +366,20 @@ object MlttTypeChecker:
       WhnfConversionStrategy,
     )
 
+  /** Checks an MLTT core term against an expected type.
+    *
+    * Program example:
+    *
+    * {{{
+    * fun x: A => x <= (x: A) -> A
+    * (x, y) <= Sigma(first: A). A
+    * Refl(x) <= Eq(A, x, x)
+    * }}}
+    *
+    * Checking handles introduction forms directly, then falls back to inference
+    * plus conversion when the term is not an introduction form for the expected
+    * type.
+    */
   def check(
       store: MlttTermStore,
       context: MlttContext,
@@ -374,6 +401,20 @@ object MlttTypeChecker:
       WhnfConversionStrategy,
     )
 
+  /** Checks definitional equality under the selected normalization strategy.
+    *
+    * Program example:
+    *
+    * {{{
+    * (fun x: A => x)(y) == y
+    * let z = y; z == y
+    * fst((x, y)) == x
+    * }}}
+    *
+    * The current strategy is WHNF conversion. It reduces beta, let, transparent
+    * pure definitions, and Sigma projections, then compares normalized heads
+    * structurally.
+    */
   def convert(
       store: MlttTermStore,
       context: MlttContext,
@@ -403,6 +444,18 @@ object MlttTypeChecker:
       )
     MlttConversionResult(ok, strategy, diagnostics.toList)
 
+  /** Produces the diagnostic for constraints outside the MLTT profile.
+    *
+    * Program example:
+    *
+    * {{{
+    * ?f(x) = y
+    * }}}
+    *
+    * The profile only accepts the first-order pattern constraints represented
+    * by explicit metas in this file. Arbitrary higher-order unification is
+    * reported as a rejected rule rather than approximated silently.
+    */
   def higherOrderUnificationDiagnostic(context: MlttContext): MlttDiagnostic =
     diagnostic(
       HigherOrderUnificationCode,
@@ -412,6 +465,16 @@ object MlttTypeChecker:
       "higher-order constraint",
     )
 
+  /** Installs the Nat fixture used by MLTT inference and conversion examples.
+    *
+    * Program example:
+    *
+    * {{{
+    * Nat : Type0
+    * Z : Nat
+    * S(pred: Nat) : Nat
+    * }}}
+    */
   def addNatFixture(store: MlttTermStore, env: MlttDeclarationEnv): Unit =
     val type0 = store.allocUniverse(0)
     val nat = store.allocInductive("Nat")
@@ -422,6 +485,16 @@ object MlttTypeChecker:
       MlttDefinitionDecl("Nat", type0, nat, transparent = true, pure = true),
     )
 
+  /** Installs the indexed Vec fixture used by constructor checking examples.
+    *
+    * Program example:
+    *
+    * {{{
+    * Vec(A: Type0, n: Nat) : Type0
+    * Nil : Vec(A, Z)
+    * Cons(k: Nat, head: A, tail: Vec(A, k)) : Vec(A, S(k))
+    * }}}
+    */
   def addVecFixture(store: MlttTermStore, env: MlttDeclarationEnv): Unit =
     val type0 = store.allocUniverse(0)
     val nat = store.allocInductive("Nat")
@@ -462,6 +535,19 @@ object MlttTypeChecker:
       ),
     )
 
+  /** Renders core MLTT terms in the same notation used by diagnostics.
+    *
+    * Program example:
+    *
+    * {{{
+    * (x: A) -> A
+    * Vec(A, S(k))
+    * Eq(A, x, x)
+    * }}}
+    *
+    * Infer/check rules store terms by id; display converts those ids back into
+    * stable program text for expected/actual diagnostics and profile summaries.
+    */
   def display(store: MlttTermStore, id: Int): String =
     store.termValue(id) match
       case MlttTerm.Var(name)       => name
@@ -523,6 +609,19 @@ object MlttTypeChecker:
       actual,
     )
 
+  /** Implements MLTT synthesis rules for every core term constructor.
+    *
+    * Program example:
+    *
+    * {{{
+    * Type0          => Type1
+    * (x: A) -> B    => Type(max(level(A), level(B)))
+    * f(a)           => B[a/x] when f : (x: A) -> B
+    * }}}
+    *
+    * The function returns a term id for the inferred type and appends
+    * diagnostics instead of throwing when a rule cannot synthesize.
+    */
   private def inferTerm(
       store: MlttTermStore,
       context: MlttContext,
@@ -605,6 +704,14 @@ object MlttTypeChecker:
       case MlttTerm.Error =>
         store.allocError()
 
+  /** Infers a variable from the local context.
+    *
+    * Program example:
+    *
+    * {{{
+    * A : Type0, x : A |- x => A
+    * }}}
+    */
   private def inferVar(
       store: MlttTermStore,
       context: MlttContext,
@@ -623,6 +730,20 @@ object MlttTypeChecker:
         )
         store.allocError()
 
+  /** Infers the universe level of Pi and Sigma type formers.
+    *
+    * Program example:
+    *
+    * {{{
+    * A : Type0
+    * B : Type0
+    * (x: A) -> B : Type0
+    * Sigma(x: A). B : Type0
+    * }}}
+    *
+    * Both the domain and body must themselves be classified by universes. The
+    * resulting universe is the maximum body/domain level.
+    */
   private def inferPiLike(
       store: MlttTermStore,
       context: MlttContext,
@@ -646,6 +767,17 @@ object MlttTypeChecker:
         universeMismatch(store, context, bodyType, diagnostics)
         store.allocError()
 
+  /** Infers a Pi type for an annotated lambda.
+    *
+    * Program example:
+    *
+    * {{{
+    * fun x: A => x  =>  (x: A) -> A
+    * }}}
+    *
+    * The annotation must be universe-classified, then the body is inferred in a
+    * context extended with the lambda parameter.
+    */
   private def inferLambda(
       store: MlttTermStore,
       context: MlttContext,
@@ -661,6 +793,19 @@ object MlttTypeChecker:
       inferTerm(store, context.extendLocal(name, annotation), body, diagnostics)
     store.allocPi(name, annotation, bodyType)
 
+  /** Infers application by eliminating a Pi type.
+    *
+    * Program example:
+    *
+    * {{{
+    * f : (x: A) -> B
+    * a : A
+    * f(a) => B[a/x]
+    * }}}
+    *
+    * The callee type is reduced to WHNF before requiring a Pi. The argument is
+    * checked against the domain, then substituted into the codomain.
+    */
   private def inferApply(
       store: MlttTermStore,
       context: MlttContext,
@@ -687,6 +832,18 @@ object MlttTypeChecker:
         )
         store.allocError()
 
+  /** Infers Sigma projections.
+    *
+    * Program example:
+    *
+    * {{{
+    * p : Sigma(first: A). B(first)
+    * fst(p) => A
+    * snd(p) => B(fst(p))
+    * }}}
+    *
+    * The pair type is reduced to WHNF before requiring a Sigma type.
+    */
   private def inferProjection(
       store: MlttTermStore,
       context: MlttContext,
@@ -717,6 +874,19 @@ object MlttTypeChecker:
         )
         store.allocError()
 
+  /** Synthesizes constructor types where the profile supports unambiguous
+    * inference.
+    *
+    * Program example:
+    *
+    * {{{
+    * Z => Nat
+    * S(Z) => Nat
+    * }}}
+    *
+    * Indexed constructors such as Vec generally require an expected family and
+    * are handled by checking instead of synthesis.
+    */
   private def inferConstructor(
       store: MlttTermStore,
       context: MlttContext,
@@ -739,6 +909,19 @@ object MlttTypeChecker:
     )
     store.allocError()
 
+  /** Infers the universe of an equality type.
+    *
+    * Program example:
+    *
+    * {{{
+    * A : Type0
+    * x : A
+    * Eq(A, x, x) => Type0
+    * }}}
+    *
+    * The value type must be universe-classified, and both sides are checked
+    * against that value type.
+    */
   private def inferEq(
       store: MlttTermStore,
       context: MlttContext,
@@ -754,6 +937,20 @@ object MlttTypeChecker:
     checkTerm(store, context, right, valueType, diagnostics)
     store.allocUniverse(0)
 
+  /** Implements MLTT checking rules for introduction forms.
+    *
+    * Program example:
+    *
+    * {{{
+    * fun x: A => body <= (x: A) -> B
+    * (x, y) <= Sigma(first: A). B
+    * Refl(x) <= Eq(A, x, x)
+    * Cons(k, head, tail) <= Vec(A, S(k))
+    * }}}
+    *
+    * If the term is not a recognized introduction for the expected WHNF type,
+    * the checker infers the term and converts inferred and expected types.
+    */
   private def checkTerm(
       store: MlttTermStore,
       context: MlttContext,
@@ -813,6 +1010,17 @@ object MlttTypeChecker:
       )
     expected
 
+  /** Checks lambda introduction against an expected Pi type.
+    *
+    * Program example:
+    *
+    * {{{
+    * fun y: A => y <= (x: A) -> A
+    * }}}
+    *
+    * The expected codomain is substituted with the source lambda binder before
+    * checking the body.
+    */
   private def checkLambda(
       store: MlttTermStore,
       context: MlttContext,
@@ -836,6 +1044,17 @@ object MlttTypeChecker:
       case MlttTerm.Error => true
       case _              => false
 
+  /** Checks pair introduction against an expected Sigma type.
+    *
+    * Program example:
+    *
+    * {{{
+    * (x, y) <= Sigma(first: A). B(first)
+    * }}}
+    *
+    * The first component checks against the Sigma first type. The second checks
+    * against the second type after substituting the first component.
+    */
   private def checkPair(
       store: MlttTermStore,
       context: MlttContext,
@@ -858,6 +1077,17 @@ object MlttTypeChecker:
       case MlttTerm.Error => true
       case _              => false
 
+  /** Checks reflexivity introduction against an equality type.
+    *
+    * Program example:
+    *
+    * {{{
+    * Refl(x) <= Eq(A, x, x)
+    * }}}
+    *
+    * The witness checks against the equality value type, then must convert to
+    * both sides of the equality.
+    */
   private def checkRefl(
       store: MlttTermStore,
       context: MlttContext,
@@ -876,6 +1106,19 @@ object MlttTypeChecker:
       case MlttTerm.Error => true
       case _              => false
 
+  /** Checks constructors against an expected inductive family.
+    *
+    * Program example:
+    *
+    * {{{
+    * Z <= Nat
+    * Nil <= Vec(A, Z)
+    * Cons(k, head, tail) <= Vec(A, S(k))
+    * }}}
+    *
+    * This dispatcher keeps family-specific indexed constructor rules localized
+    * to Nat and Vec helpers.
+    */
   private def checkConstructor(
       store: MlttTermStore,
       context: MlttContext,
@@ -900,6 +1143,17 @@ object MlttTypeChecker:
       case MlttTerm.Error => true
       case _              => false
 
+  /** Checks Nat constructors.
+    *
+    * Program example:
+    *
+    * {{{
+    * Z <= Nat
+    * S(Z) <= Nat
+    * }}}
+    *
+    * `S` recursively checks its predecessor against the expected Nat type.
+    */
   private def checkNatConstructor(
       store: MlttTermStore,
       context: MlttContext,
@@ -914,6 +1168,18 @@ object MlttTypeChecker:
       true
     else false
 
+  /** Checks Vec constructors against the expected element and length indices.
+    *
+    * Program example:
+    *
+    * {{{
+    * Nil <= Vec(A, Z)
+    * Cons(k, head, tail) <= Vec(A, S(k))
+    * }}}
+    *
+    * `Nil` is valid only at zero length. `Cons` is valid only when the expected
+    * length normalizes to a successor.
+    */
   private def checkVecConstructor(
       store: MlttTermStore,
       context: MlttContext,
@@ -937,6 +1203,20 @@ object MlttTypeChecker:
       )
     false
 
+  /** Checks the indexed payload of `Cons`.
+    *
+    * Program example:
+    *
+    * {{{
+    * k : Nat
+    * head : A
+    * tail : Vec(A, k)
+    * Cons(k, head, tail) <= Vec(A, S(k))
+    * }}}
+    *
+    * The explicit length argument must convert to the predecessor exposed by
+    * the expected `S(k)` index.
+    */
   private def checkVecConsConstructor(
       store: MlttTermStore,
       context: MlttContext,
@@ -958,6 +1238,18 @@ object MlttTypeChecker:
         lengthOk.isOk
       case _ => false
 
+  /** Recognizes a constructor literal with the expected arity.
+    *
+    * Program example:
+    *
+    * {{{
+    * S(k) // constructor "S" with arity 1
+    * Nil  // constructor "Nil" with arity 0
+    * }}}
+    *
+    * Vec checking uses this as a small premise before applying the
+    * constructor-specific indexed introduction rule.
+    */
   private def isConstructor(
       store: MlttTermStore,
       term: Int,
@@ -969,6 +1261,19 @@ object MlttTypeChecker:
         ctorName == name && args.length == arity
       case _ => false
 
+  /** Recursively checks definitional equality after WHNF reduction.
+    *
+    * Program example:
+    *
+    * {{{
+    * (fun x: A => x)(y) == y
+    * Vec(A, S(k)) == Vec(A, S(k))
+    * Eq(A, x, x) == Eq(A, x, x)
+    * }}}
+    *
+    * The rule first tries display-stable exact equality, then WHNF equality,
+    * then recursively compares compatible term constructors.
+    */
   private def convertTerms(
       store: MlttTermStore,
       context: MlttContext,
@@ -1040,6 +1345,16 @@ object MlttTypeChecker:
       case (MlttTerm.Error, _) | (_, MlttTerm.Error) => true
       case _                                         => false
 
+  /** Converts corresponding elements in parameter, index, or spine lists.
+    *
+    * Program example:
+    *
+    * {{{
+    * Vec(A, S(k)) == Vec(A, S(k))
+    * }}}
+    *
+    * Lists must have equal length and every pair of terms must convert.
+    */
   private def convertTermLists(
       store: MlttTermStore,
       context: MlttContext,
@@ -1052,6 +1367,19 @@ object MlttTypeChecker:
         convertTerms(store, context, leftTerm, rightTerm, diagnostics)
       }
 
+  /** Reduces a term to weak-head normal form for conversion.
+    *
+    * Program example:
+    *
+    * {{{
+    * (fun x: A => x)(y) --> y
+    * let z = y; z       --> y
+    * fst((x, y))        --> x
+    * }}}
+    *
+    * WHNF only reduces enough to expose the head constructor needed by
+    * conversion and elimination rules.
+    */
   private def whnf(
       store: MlttTermStore,
       context: MlttContext,
@@ -1079,6 +1407,18 @@ object MlttTypeChecker:
         whnfSnd(store, context, term, pair, diagnostics, fuel)
       case _ => term
 
+  /** Reduces transparent pure definitions during conversion.
+    *
+    * Program example:
+    *
+    * {{{
+    * add_z_n = n
+    * add_z_n == n
+    * }}}
+    *
+    * Opaque or effectful definitions are not reduced and produce a conversion
+    * diagnostic.
+    */
   private def whnfVar(
       store: MlttTermStore,
       context: MlttContext,
@@ -1103,6 +1443,14 @@ object MlttTypeChecker:
           term
       case None => term
 
+  /** Performs beta reduction when a WHNF callee is a lambda.
+    *
+    * Program example:
+    *
+    * {{{
+    * (fun x: A => x)(y) --> y
+    * }}}
+    */
   private def whnfApply(
       store: MlttTermStore,
       context: MlttContext,
@@ -1123,6 +1471,14 @@ object MlttTypeChecker:
         )
       case _ => term
 
+  /** Reduces first projection from a concrete pair.
+    *
+    * Program example:
+    *
+    * {{{
+    * fst((x, y)) --> x
+    * }}}
+    */
   private def whnfFst(
       store: MlttTermStore,
       context: MlttContext,
@@ -1136,6 +1492,14 @@ object MlttTypeChecker:
         whnf(store, context, first, diagnostics, fuel - 1)
       case _ => term
 
+  /** Reduces second projection from a concrete pair.
+    *
+    * Program example:
+    *
+    * {{{
+    * snd((x, y)) --> y
+    * }}}
+    */
   private def whnfSnd(
       store: MlttTermStore,
       context: MlttContext,
@@ -1149,6 +1513,18 @@ object MlttTypeChecker:
         whnf(store, context, second, diagnostics, fuel - 1)
       case _ => term
 
+  /** Performs capture-oblivious substitution over the stored core term tree.
+    *
+    * Program example:
+    *
+    * {{{
+    * substitute(x, x := y) = y
+    * substitute((z: A) -> x, x := y) = (z: A) -> y
+    * }}}
+    *
+    * Current fixtures avoid binder capture cases. The helper preserves binders
+    * that shadow the substituted name and rebuilds all other term forms.
+    */
   private def substitute(
       store: MlttTermStore,
       term: Int,
@@ -1227,20 +1603,58 @@ object MlttTypeChecker:
       case MlttTerm.Error =>
         store.allocError()
 
+  /** Compares stored terms by stable syntax before recursive conversion.
+    *
+    * Program example:
+    *
+    * {{{
+    * Vec(A, S(k)) == Vec(A, S(k))
+    * }}}
+    *
+    * This is the cheap equality premise used before WHNF reduction and
+    * structural conversion recurse into compatible constructors.
+    */
   private def sameTerm(store: MlttTermStore, left: Int, right: Int): Boolean =
     display(store, left) == display(store, right)
 
+  /** Reads a universe level from a term.
+    *
+    * Program example:
+    *
+    * {{{
+    * Type0 => Some(0)
+    * A     => None
+    * }}}
+    */
   private def universeLevelOfTerm(store: MlttTermStore, id: Int): Option[Int] =
     store.termValue(id) match
       case MlttTerm.Universe(level) => Some(level)
       case _                        => None
 
+  /** Converts an inferred classifier `Type(n + 1)` into the classified type's
+    * universe level `n`.
+    *
+    * Program example:
+    *
+    * {{{
+    * infer(Type0) = Type1
+    * typeUniverseLevel(Type1) = 0
+    * }}}
+    */
   private def typeUniverseLevel(
       store: MlttTermStore,
       inferredType: Int,
   ): Option[Int] =
     universeLevelOfTerm(store, inferredType).map(level => (level - 1).max(0))
 
+  /** Reports that a type former operand did not infer to a universe.
+    *
+    * Program example:
+    *
+    * {{{
+    * (x: not_a_type) -> x
+    * }}}
+    */
   private def universeMismatch(
       store: MlttTermStore,
       context: MlttContext,
@@ -1255,6 +1669,17 @@ object MlttTypeChecker:
       display(store, actual),
     )
 
+  /** Reports public metavariables that remain unsolved after checking.
+    *
+    * Program example:
+    *
+    * {{{
+    * ?m0 <= A
+    * }}}
+    *
+    * The current checker does not perform general unification, so public metas
+    * must be solved exactly by the harness before check completion.
+    */
   private def reportUnsolvedMetas(
       context: MlttContext,
       metas: MlttMetaStore,

--- a/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/tyck/mltt/TypeChecker.scala
@@ -309,9 +309,8 @@ final case class MlttCheckResult(
   *     let, transparent pure definitions, and Sigma projections. Opaque or
   *     effectful definitions are not reduced during conversion.
   *
-  * Pipeline note: this object is exercised by tests and fixtures directly.
-  * `Cosmo0.check` and package checking currently return unsupported for
-  * non-`cosmo0.subset` profiles instead of routing source here.
+  * Pipeline note: direct tests can call this object, and `mltt.core` profile
+  * source fixtures reach it through `MlttProfileChecker` assertion directives.
   */
 object MlttTypeChecker:
   val WhnfConversionStrategy = "mltt.whnf-conversion"

--- a/packages/cosmo0/src/test/scala/cosmo0/CheckerProfileTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/CheckerProfileTests.scala
@@ -65,9 +65,22 @@ class CheckerProfileTests extends munit.FunSuite:
     assertEquals(result.status, PhaseStatus.Succeeded)
     assert(result.diagnostics.isEmpty)
 
-  test(
-    "experimental MLTT profile rejects object source as an unsupported checker result",
-  ):
+  test("MLTT profile executes source assertion directives"):
+    val result = Cosmo0().checkWithProfile(
+      """mltt: lambda-checks-pi
+        |mltt: application-infers-through-pi
+        |""".stripMargin,
+      CheckerProfiles.MlttCore.id,
+    )
+
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    assert(result.diagnostics.isEmpty)
+    val summary = result.value.get.typed.checkerArtifactSummary
+    assert(summary.contains("mltt_core_lambda_checks_pi"))
+    assert(summary.contains("mltt_core_application_infers_through_pi"))
+
+  test("MLTT profile rejects source that does not declare MLTT assertions"):
     val result = Cosmo0().checkWithProfile(
       """class Box {
         |  val value: i32
@@ -77,13 +90,12 @@ class CheckerProfileTests extends munit.FunSuite:
     )
 
     assertEquals(result.phase, Phase.Check)
-    assertEquals(result.status, PhaseStatus.Unsupported)
+    assertEquals(result.status, PhaseStatus.Failed)
     assertEquals(result.value, None)
     assertEquals(
       result.diagnostics.head.code,
-      CheckerProfiles.UnsupportedObjectDispatchCode,
+      "cosmo.type.mltt.no-profile-assertions",
     )
-    assert(result.diagnostics.head.message.contains("mltt.core"))
 
   test("unknown checker profile is a normal check failure"):
     val result = Cosmo0().checkWithProfile("val answer = 42", "unknown.profile")
@@ -115,8 +127,13 @@ class CheckerProfileTests extends munit.FunSuite:
     assertEquals(result.status, PhaseStatus.Succeeded)
     assert(result.diagnostics.isEmpty)
 
-  test("package checker profile metadata keeps experimental profiles isolated"):
-    val source = SourceFile("main.cos", "val answer = 42")
+  test("package checker profile metadata runs MLTT profile assertions"):
+    val source = SourceFile(
+      "main.cos",
+      """mltt: lambda-checks-pi
+        |mltt: vec-constructors-check
+        |""".stripMargin,
+    )
     val pkg = Cosmo0Package(
       "memory",
       Cosmo0PackageMetadata(
@@ -130,13 +147,13 @@ class CheckerProfileTests extends munit.FunSuite:
     val result = Cosmo0().checkPackage(pkg)
 
     assertEquals(result.phase, Phase.Check)
-    assertEquals(result.status, PhaseStatus.Unsupported)
-    assertEquals(
-      result.diagnostics.head.code,
-      CheckerProfiles.UnsupportedObjectDispatchCode,
-    )
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    assert(result.diagnostics.isEmpty)
+    val summary = result.value.get.checked.typed.checkerArtifactSummary
+    assert(summary.contains("mltt_core_lambda_checks_pi"))
+    assert(summary.contains("mltt_core_vec_constructors_check"))
 
-  test("fixture metadata can select the experimental MLTT profile"):
+  test("fixture metadata selects the MLTT profile and verifies MLTT features"):
     val loaded =
       Cosmo0().loadPackage("fixtures/cosmo0/package/mltt-core-profile")
 
@@ -153,11 +170,36 @@ class CheckerProfileTests extends munit.FunSuite:
     val checked = Cosmo0().checkPackage(loaded.value.get)
 
     assertEquals(checked.phase, Phase.Check)
-    assertEquals(checked.status, PhaseStatus.Unsupported)
-    assertEquals(
-      checked.diagnostics.head.code,
-      CheckerProfiles.UnsupportedObjectDispatchCode,
+    assertEquals(checked.status, PhaseStatus.Succeeded)
+    val summary = checked.value.get.checked.typed.checkerArtifactSummary
+    assert(summary.contains("mltt_core_lambda_checks_pi"))
+    assert(summary.contains("mltt_core_vec_constructors_check"))
+
+  test(
+    "fixture metadata selects dependent-pattern profile and verifies case trees",
+  ):
+    val loaded =
+      Cosmo0().loadPackage(
+        "fixtures/cosmo0/package/mltt-dependent-pattern-profile",
+      )
+
+    assertEquals(loaded.phase, Phase.Check)
+    assert(
+      loaded.isSuccess,
+      s"dependent-pattern profile fixture failed to load: ${loaded.diagnostics}",
     )
+    assertEquals(
+      loaded.value.get.metadata.checkerProfile,
+      Some(CheckerProfiles.MlttDependentPatterns.id),
+    )
+
+    val checked = Cosmo0().checkPackage(loaded.value.get)
+
+    assertEquals(checked.phase, Phase.Check)
+    assertEquals(checked.status, PhaseStatus.Succeeded)
+    val summary = checked.value.get.checked.typed.checkerArtifactSummary
+    assert(summary.contains("dependent_pattern_vec_head_elaborates"))
+    assert(summary.contains("dependent_pattern_impossible_nil_diagnostic"))
 
   test("typed artifact profile summary is deterministic"):
     val first =


### PR DESCRIPTION
## Summary
- route MLTT and dependent-pattern checker profiles through executable profile assertions
- add package fixtures that exercise MLTT core and dependent-pattern elaboration
- document tyck infer/check/elaboration rules with program examples and explanations

## Validation
- scripts/check-scala-style.sh
- sbt "cosmo0/testOnly cosmo0.CheckerProfileTests cosmo0.PackagePipelineTests cosmo0.MlttTypeCheckerTests cosmo0.DependentPatternTests"