### PR TITLE
dosc: add JIT compile-time evaluation OpenSpecs

### DIFF
--- a/docs/cosmo/book.typ
+++ b/docs/cosmo/book.typ
@@ -23,6 +23,7 @@
     #prefix-chapter("mltt-problem-ladder.typ")[MLTT Problem Ladder]
     #prefix-chapter("spec.typ")[cosmo0 Specification]
     #prefix-chapter("macro-expr.typ")[cosmo0 Macro Expressions]
+    #prefix-chapter("derive-macro.typ")[cosmo0 Derive Macros]
     #prefix-chapter("compile-time-evaluation.typ")[cosmo0 Compile-Time Evaluation]
   ],
 )

--- a/docs/cosmo/compile-time-evaluation.typ
+++ b/docs/cosmo/compile-time-evaluation.typ
@@ -23,10 +23,10 @@ has this shape:
 MacroFunctionInput:
   provider identity
   source package identity
-  selected macro source expression identity
+  selected macro payload identity
   reflection facts selected by the compiler
   admitted attributes and defaults selected by the compiler
-  selected Expr[Untyped] input when the macro kind accepts expressions
+  selected Expr[Untyped] macro payload when the macro kind accepts expressions
   source spans and hygiene/origin metadata
   C++ import and execution context
 
@@ -107,10 +107,11 @@ C++ types inside the session. It must not return raw compiler mutation handles.
 
 Macro functions are specified as pure computations over the input supplied by
 cosmo0 and the declared JIT execution context. For the same provider identity,
-source package, selected macro source expression, compiler-selected input facts,
-selected Expr[Untyped] input, C++ imports, provider source, target settings, and
-toolchain identity, repeated evaluation must produce the same generated output,
-diagnostics, generated-source summary, and native support binding metadata.
+source package, selected macro payload, compiler-selected input facts,
+selected Expr[Untyped] macro payload, C++ imports, provider source, target
+settings, and toolchain identity, repeated evaluation must produce the same
+generated output, diagnostics, generated-source summary, and native support
+binding metadata.
 
 The compiler may cache, discard, rerun, parallelize, or compare macro function
 evaluations. `cosmo-jit-sys` can execute ordinary C++ provider code, but if a
@@ -164,9 +165,10 @@ Provider behavior with undefined macro semantics:
 ```text
 var counter = 0
 
-macro provider(input):
+@macro def provider(input: Expr[Untyped]): Expr[Untyped] = {
   counter = counter + 1
   return generatedName("helper_" + counter)
+}
 ```
 
 These examples are not undefined because C++ JIT is incapable of file, random,

--- a/docs/cosmo/compile-time-evaluation.typ
+++ b/docs/cosmo/compile-time-evaluation.typ
@@ -23,10 +23,10 @@ has this shape:
 MacroFunctionInput:
   provider identity
   source package identity
-  macro call or macro target identity
+  selected macro source expression identity
   reflection facts selected by the compiler
   admitted attributes and defaults selected by the compiler
-  Expr[Untyped] fragments when the macro kind accepts expressions
+  selected Expr[Untyped] input when the macro kind accepts expressions
   source spans and hygiene/origin metadata
   C++ import and execution context
 
@@ -107,10 +107,10 @@ C++ types inside the session. It must not return raw compiler mutation handles.
 
 Macro functions are specified as pure computations over the input supplied by
 cosmo0 and the declared JIT execution context. For the same provider identity,
-source package, macro call or target, compiler-selected input facts, expression
-fragments, C++ imports, provider source, target settings, and toolchain identity,
-repeated evaluation must produce the same generated output, diagnostics,
-generated-source summary, and native support binding metadata.
+source package, selected macro source expression, compiler-selected input facts,
+selected Expr[Untyped] input, C++ imports, provider source, target settings, and
+toolchain identity, repeated evaluation must produce the same generated output,
+diagnostics, generated-source summary, and native support binding metadata.
 
 The compiler may cache, discard, rerun, parallelize, or compare macro function
 evaluations. `cosmo-jit-sys` can execute ordinary C++ provider code, but if a

--- a/docs/cosmo/derive-macro.typ
+++ b/docs/cosmo/derive-macro.typ
@@ -1,0 +1,175 @@
+= cosmo0 Derive Macros
+
+== Status
+
+This file owns the first cosmo0 derive macro design. It is intentionally
+narrower than general declaration macros and expression macros. The initial
+derive boundary only allows a provider to attach implementations of existing
+traits to an existing item. It does not introduce new public names, new members,
+new top-level declarations, or parser syntax.
+
+== Derive Boundary
+
+A derive macro is selected from an attribute on an existing item:
+
+```cos
+@derive(cli.Parser)
+class Config {
+  val package_name: String
+}
+```
+
+The attribute identifies a derive provider. The target item already exists in
+the parsed declaration index before the provider runs. The provider receives
+compiler-selected reflection facts for that item and may return one or more
+trait implementation records for the same item.
+
+Accepted first-slice output shape:
+
+```text
+DeriveOutput:
+  impl trait cli.Parser for Config { ... }
+```
+
+Rejected first-slice output shapes:
+
+```text
+new top-level function parse(...)
+new static method Config.parse(...)
+new field or variant on Config
+new type alias or class
+raw source text
+trusted TypedExpr
+```
+
+This keeps derive expansion an implementation-attachment phase, not a
+declaration-introduction phase.
+
+== Name Resolution Boundary
+
+Derive macros do not affect ordinary name resolution in the first slice.
+
+The resolver builds the package/module declaration index and resolves ordinary
+names before derive output is needed. Because derive output can only attach an
+implementation of an already-known trait to an already-known item, expansion
+does not add a new binding that later source can refer to by name.
+
+For example:
+
+```cos
+@derive(cli.Parser)
+class Config { ... }
+```
+
+may make `Config` satisfy trait `cli.Parser`, but it does not create a visible
+`parse` name, a `Config.parse` member, or a new module declaration. Later code
+that uses parser behavior must do so through trait resolution or an explicit
+trait API that was already name-resolved:
+
+```cos
+val config = cli.Parser.parse[Config](args)
+```
+
+In this shape:
+
+- `cli.Parser` is resolved as an ordinary trait/API path before derive output
+  is attached;
+- `Config` is resolved as an ordinary class before derive output is attached;
+- the derive macro only supplies the implementation evidence connecting them.
+
+== Provider Input
+
+The compiler supplies stable derive input selected from parsed declarations and
+admitted type facts:
+
+```text
+DeriveInput:
+  provider identity
+  source package identity
+  target item identity
+  target item kind
+  target item name, module path, visibility, and source span
+  admitted type parameters
+  fields, variants, defaults, attributes, and doc comments admitted by profile
+  selected trait identity
+  source spans and hygiene/origin metadata
+```
+
+The provider does not receive a mutable compiler module, a typed tree to patch,
+or a target runtime executable handle.
+
+== Provider Output
+
+The provider returns serialized output:
+
+```text
+DeriveOutput:
+  trait implementation records
+  consumed attributes
+  diagnostics
+  generated-source summary
+```
+
+Each implementation record must name:
+
+- the already-resolved trait being implemented;
+- the already-resolved target item;
+- generated method bodies or associated implementation data admitted by the
+  trait contract;
+- generated spans and origin spans.
+
+The compiler validates the output before attaching it. Generated expression
+fragments inside implementation bodies are `Expr[Untyped]` and return to
+ordinary type checking.
+
+== Trait Implementation Attachment
+
+Attaching a derive implementation is semantically equivalent to accepting an
+ordinary implementation block for the same trait and target, except that the
+implementation body is generated and carries derive origin metadata.
+
+The attachment phase validates:
+
+- the trait exists and is admitted by the derive provider;
+- the target item exists and is a supported item kind;
+- the generated implementation satisfies the trait's required members;
+- the same trait is not implemented twice for the same target in a conflicting
+  way;
+- all provider-consumed attributes are recorded;
+- unconsumed macro-owned attributes are diagnosed.
+
+Because the output is an implementation attachment, not a new declaration, the
+ordinary declaration index is unchanged by derive expansion.
+
+== Diagnostics
+
+Derive diagnostics must point both to the derive attribute and to the target
+item fact that caused the issue. Generated implementation diagnostics must carry
+the generated span and the origin span from the derive input.
+
+Examples:
+
+```text
+cosmo0.derive.unresolved-provider
+cosmo0.derive.unsupported-target
+cosmo0.derive.unsupported-trait
+cosmo0.derive.invalid-output
+cosmo0.derive.duplicate-impl
+cosmo0.derive.unconsumed-attribute
+```
+
+== Non-Goals
+
+The first derive macro slice does not provide:
+
+- new public declarations;
+- new members on the target item;
+- arbitrary generated classes, aliases, fields, or variants;
+- expression macro calls;
+- parser plugins or token-tree macros;
+- self-hosted provider package loading;
+- target runtime execution during expansion.
+
+Later declaration macro capabilities may introduce new names, but they must be
+specified separately because they do affect name resolution and declaration
+ordering.

--- a/docs/cosmo/derive-macro.typ
+++ b/docs/cosmo/derive-macro.typ
@@ -141,6 +141,51 @@ The attachment phase validates:
 Because the output is an implementation attachment, not a new declaration, the
 ordinary declaration index is unchanged by derive expansion.
 
+== Trait Resolution Dependency
+
+Derive output may affect trait resolution even though it does not affect
+ordinary name resolution. A generated implementation contributes an
+implementation fact:
+
+```text
+ImplFact(trait = cli.Parser, target = Config)
+```
+
+The implementation fact index is built from both source impl declarations and
+derive-generated implementation attachments:
+
+```text
+ImplFactIndex =
+  source impls
+  + derive-generated impls
+```
+
+Type checking of an item that requires trait evidence depends on the relevant
+implementation fact. For example:
+
+```cos
+val config = cli.Parser.parse[Config](args)
+```
+
+uses ordinary name resolution for `cli.Parser` and `Config`, but it cannot
+finish trait resolution until `ImplFact(cli.Parser for Config)` is available.
+If a method-like trait API such as `config.parse()` is admitted, selector
+resolution must also wait for the method-set fact that can include
+derive-generated impls:
+
+```text
+ResolveSelector(config.parse)
+  waits for TypeFact(config)
+  waits for MethodSetFact(Config, "parse")
+```
+
+The first derive slice keeps derive input smaller than this output dependency:
+derive expansion may depend on declaration header facts, selected trait
+identity, target item identity, fields, variants, attributes, defaults, doc
+comments, and admitted type facts. It must not depend on arbitrary body checking
+or trait-resolution facts unless a later inspector capability adds explicit
+dependency edges.
+
 == Diagnostics
 
 Derive diagnostics must point both to the derive attribute and to the target

--- a/docs/cosmo/macro-expr.typ
+++ b/docs/cosmo/macro-expr.typ
@@ -45,97 +45,126 @@ Provider-facing expression macro behavior is specified as a macro function
 implementation shape:
 
 ```text
-macro def provider(input: Expr[Untyped]): Expr[Untyped] = {
+@macro def provider(input: Expr[Untyped]): Expr[Untyped] = {
   val generated: Expr[Untyped] = ...
   return generated
 }
 ```
 
-The provider-facing input is the selected source expression as `Expr[Untyped]`.
-The compiler may still record provider identity, source spans, hygiene/origin
+The provider-facing input is a normalized macro payload as `Expr[Untyped]`. The
+compiler may still record provider identity, source spans, hygiene/origin
 metadata, diagnostics, and execution context in the surrounding macro execution
-record, but those are not a second public provider argument. Call syntax is one
-possible `Expr[Untyped]` shape, not the general macro ABI.
+record, but those are not a second public provider argument. Parenthesized
+arguments and method-like syntax feed `Expr.Args`; attached blocks feed
+`Expr.Block`; templates and interpolations feed `Expr.Template`.
 
 Generated expression output always returns to ordinary type checking. A provider
 may generate a candidate expression, but it cannot manufacture or inject a
 trusted checked expression object.
 
+== Macro Selection
+
+The `@macro` marker declares a compile-time provider. It does not change how
+the source expression is parsed, and it does not make macro lookup a textual
+match on a callee name.
+
+Macro selection follows the same resolved callee that the parsed expression
+would otherwise use for an ordinary operation:
+
+- `vec(1, 2, 3)` can select `@macro def vec(...)` only when ordinary name
+  resolution for the callee `vec` resolves to that macro provider.
+- `value.expand(2)` can select an `@macro def expand(...)` provider only when
+  member, method, or extension lookup for the selected member `.expand` resolves
+  to that macro provider. A free `@macro def expand(...)` in scope does not by
+  itself match every `.expand` selection by string name.
+- `j.path { ... }` can select a macro only when lookup for the selected target
+  `j.path` resolves to that macro provider.
+- `fmt"x $name y"` can select a macro only when interpolation tag lookup for
+  `fmt` resolves to that macro provider.
+
+After selection, the provider receives the selected macro payload as
+`Expr[Untyped]`.
+
 == Macro Input Shapes
 
-Different surface forms feed different `Expr[Untyped]` shapes to the macro
-function. The shape names below are illustrative; the stable rule is that the
-provider receives one parsed expression value, not raw tokens and not a special
-context value.
+Different surface forms feed one of three provider-facing `Expr[Untyped]`
+payload shapes to the macro function: `Expr.Args`, `Expr.Block`, or
+`Expr.Template`. The field names below are illustrative; the stable rule is that
+the provider receives one parsed expression value, not raw tokens and not a
+special context value.
 
-Call-like syntax feeds the whole call expression:
+Parenthesized argument syntax feeds an argument payload. The resolved provider
+identity is not repeated inside the payload:
 
 ```cos
 val xs = vec(1, 2, 3)
 ```
 
 ```text
-macro def vec(input: Expr[Untyped]): Expr[Untyped]
+@macro def vec(input: Expr[Untyped]): Expr[Untyped]
 
 input =
-  Expr.Call(
-    callee = Expr.Name("vec"),
-    args = [Expr.Int(1), Expr.Int(2), Expr.Int(3)],
+  Expr.Args(
+    receiver = None,
+    positional = [Expr.Int(1), Expr.Int(2), Expr.Int(3)],
+    named = [],
   )
 ```
 
-Method-like syntax feeds the selected expression shape, preserving the receiver
-inside the expression:
+Method-like syntax also feeds an argument payload. Member, method, or extension
+lookup has already selected the macro provider; the receiver is preserved as an
+ordinary expression field in the payload:
 
 ```cos
 val y = value.expand(2)
 ```
 
 ```text
-macro def expand(input: Expr[Untyped]): Expr[Untyped]
+resolved provider =
+  @macro def expand(input: Expr[Untyped]): Expr[Untyped]
 
 input =
-  Expr.Call(
-    callee = Expr.Select(Expr.Name("value"), "expand"),
-    args = [Expr.Int(2)],
+  Expr.Args(
+    receiver = Some(Expr.Name("value")),
+    positional = [Expr.Int(2)],
+    named = [],
   )
 ```
 
-Block-attached syntax feeds one expression whose target and block body are both
-part of the parsed expression:
+Block-attached syntax feeds a block payload. Lookup has already selected the
+macro provider; a receiver from the selected target is preserved when the
+surface form has one:
 
 ```cos
-val field = j.path { self.field(0) }
+val field = j.path { self.field }
 ```
 
 ```text
-macro def path(input: Expr[Untyped]): Expr[Untyped]
+resolved provider =
+  @macro def path(input: Expr[Untyped]): Expr[Untyped]
 
 input =
-  Expr.BlockApply(
-    target = Expr.Select(Expr.Name("j"), "path"),
-    body = Expr.Block([
-      Expr.Call(
-        callee = Expr.Select(Expr.Name("self"), "field"),
-        args = [Expr.Int(0)],
-      ),
-    ]),
+  Expr.Block(
+    receiver = Some(Expr.Name("j")),
+    statements = [
+      Expr.Select(Expr.Name("self"), "field"),
+    ],
   )
 ```
 
-Interpolation feeds one interpolation expression. Literal parts are structured
-data inside that expression node, while holes remain `Expr[Untyped]` values:
+Interpolation feeds a template payload. Tag lookup has already selected the
+macro provider; literal parts are structured data inside the payload, while
+holes remain `Expr[Untyped]` values:
 
 ```cos
 val message = fmt"x $name y"
 ```
 
 ```text
-macro def fmt(input: Expr[Untyped]): Expr[Untyped]
+@macro def fmt(input: Expr[Untyped]): Expr[Untyped]
 
 input =
-  Expr.Interpolate(
-    tag = Expr.Name("fmt"),
+  Expr.Template(
     parts = [
       Text("x "),
       Hole(Expr.Name("name")),
@@ -176,37 +205,39 @@ Accepted macro function implementation shape once expression macros are
 admitted. Helper method names on `Expr[Untyped]` are illustrative:
 
 ```text
-macro def vec(input: Expr[Untyped]): Expr[Untyped] = {
-  val items = input.callArgs()
+@macro def vec(input: Expr[Untyped]): Expr[Untyped] = {
+  val items = input.args().positional
   val output = quote_expr(Vec.from_array(Array(..items)))
   return output
 }
 ```
 
-Call-like use is still allowed, but it is only one accepted surface form:
+Parenthesized argument use is still allowed, but it is only one accepted surface
+form:
 
 ```cos
 val xs = vec(1, 2, 3)
 ```
 
 The same boundary can describe a block-attached application. The macro inspects
-the input expression to get the target and block body; the body is structured
-`Expr[Untyped]` data, not raw source text and not a checked expression:
+the input expression to get the optional receiver and block body; the body is
+structured `Expr[Untyped]` data, not raw source text and not a checked
+expression:
 
 ```cos
-val field = j.path { self.field(0) }
+val field = j.path { self.field }
 ```
 
 ```text
-macro def path(input: Expr[Untyped]): Expr[Untyped] = {
-  val receiver = input.blockTarget()
-  val body = input.blockBody()
+@macro def path(input: Expr[Untyped]): Expr[Untyped] = {
+  val receiver = input.block().receiver
+  val body = input.block().statements
   val output = build_path_access(receiver, body)
   return output
 }
 ```
 
-Interpolation may also be admitted without making the source expression look
+Template syntax may also be admitted without making the source expression look
 like an ordinary call:
 
 ```cos
@@ -214,8 +245,8 @@ val message = fmt"x $name y"
 ```
 
 ```text
-macro def fmt(input: Expr[Untyped]): Expr[Untyped] = {
-  val parts = input.interpolationParts()
+@macro def fmt(input: Expr[Untyped]): Expr[Untyped] = {
+  val parts = input.template().parts
   val output = build_format_expr(parts)
   return output
 }
@@ -228,13 +259,14 @@ Expr[Any] -> Expr[Any]
 Expr[i32] -> Expr[Vec[i32]]
 List[Expr[Untyped]] -> Expr[Untyped]
 Call(path: PathRef, args: List[Expr[Untyped]]) -> Expr[Untyped]
+Apply(target: Expr[Untyped], args: List[Expr[Untyped]]) -> Expr[Untyped]
 TokenStream -> TokenStream
 ```
 
 The rejected examples either confuse untyped source expressions with an
 object-language top type, imply typed quotation, claim checked output, add a
-separate public context value, force macros into a pre-extracted argument-list
-or function-call shape, or bypass the Cosmo parser.
+separate public context value, force macros into a pre-extracted argument-list,
+function-call shape, or generic apply shape, or bypass the Cosmo parser.
 
 == Review Rules
 
@@ -247,5 +279,7 @@ Macro expression proposals must preserve these rules:
   already checked.
 - expression macro provider input is `Expr[Untyped]`, not a separate context
   value, raw token stream, or pre-extracted argument list.
+- provider-facing macro input normalizes to `Expr.Args`, `Expr.Block`, or
+  `Expr.Template`, not call or apply nodes.
 - generated expression output must be deterministic and must re-enter ordinary
   checking before lowering.

--- a/docs/cosmo/macro-expr.typ
+++ b/docs/cosmo/macro-expr.typ
@@ -28,28 +28,121 @@ for an arbitrary object-language result type. Typed facts are requested through
 inspectors such as `Type.of(expr)`, and inspector output does not authorize a
 provider to mark an expression as typed.
 
-== Expression Macro Protocol
+== Expression Macro Function Contract
 
-Expression macros use ordinary Cosmo call syntax. The parser first accepts a
-normal source expression; name resolution decides whether the callee is a
-compile-time provider or an ordinary function.
+Expression macros are macro functions selected from already-parsed source
+expressions. The surface syntax does not have to be a function call. A call
+expression, method-like application, interpolation, block-attached application,
+or another syntax form admitted by a future capability may all select an
+expression macro after parsing and name resolution.
 
-The first protocol shape is:
+The parser first accepts ordinary source syntax. Name resolution and macro
+classification then decide whether the parsed expression targets a compile-time
+provider or an ordinary value-level operation. Macro selection must not depend
+on exposing a raw parser token stream to the provider.
+
+Provider-facing expression macro behavior is specified as a macro function
+implementation shape:
 
 ```text
-ExprMacroInput:
-  path: PathRef
-  args: List[Expr[Untyped]]
-  callSpan: SourceSpan
-
-ExprMacroOutput:
-  expr: Expr[Untyped]
-  diagnostics: List[MacroDiagnostic]
+macro def provider(input: Expr[Untyped]): Expr[Untyped] = {
+  val generated: Expr[Untyped] = ...
+  return generated
+}
 ```
+
+The provider-facing input is the selected source expression as `Expr[Untyped]`.
+The compiler may still record provider identity, source spans, hygiene/origin
+metadata, diagnostics, and execution context in the surrounding macro execution
+record, but those are not a second public provider argument. Call syntax is one
+possible `Expr[Untyped]` shape, not the general macro ABI.
 
 Generated expression output always returns to ordinary type checking. A provider
 may generate a candidate expression, but it cannot manufacture or inject a
 trusted checked expression object.
+
+== Macro Input Shapes
+
+Different surface forms feed different `Expr[Untyped]` shapes to the macro
+function. The shape names below are illustrative; the stable rule is that the
+provider receives one parsed expression value, not raw tokens and not a special
+context value.
+
+Call-like syntax feeds the whole call expression:
+
+```cos
+val xs = vec(1, 2, 3)
+```
+
+```text
+macro def vec(input: Expr[Untyped]): Expr[Untyped]
+
+input =
+  Expr.Call(
+    callee = Expr.Name("vec"),
+    args = [Expr.Int(1), Expr.Int(2), Expr.Int(3)],
+  )
+```
+
+Method-like syntax feeds the selected expression shape, preserving the receiver
+inside the expression:
+
+```cos
+val y = value.expand(2)
+```
+
+```text
+macro def expand(input: Expr[Untyped]): Expr[Untyped]
+
+input =
+  Expr.Call(
+    callee = Expr.Select(Expr.Name("value"), "expand"),
+    args = [Expr.Int(2)],
+  )
+```
+
+Block-attached syntax feeds one expression whose target and block body are both
+part of the parsed expression:
+
+```cos
+val field = j.path { self.field(0) }
+```
+
+```text
+macro def path(input: Expr[Untyped]): Expr[Untyped]
+
+input =
+  Expr.BlockApply(
+    target = Expr.Select(Expr.Name("j"), "path"),
+    body = Expr.Block([
+      Expr.Call(
+        callee = Expr.Select(Expr.Name("self"), "field"),
+        args = [Expr.Int(0)],
+      ),
+    ]),
+  )
+```
+
+Interpolation feeds one interpolation expression. Literal parts are structured
+data inside that expression node, while holes remain `Expr[Untyped]` values:
+
+```cos
+val message = fmt"x $name y"
+```
+
+```text
+macro def fmt(input: Expr[Untyped]): Expr[Untyped]
+
+input =
+  Expr.Interpolate(
+    tag = Expr.Name("fmt"),
+    parts = [
+      Text("x "),
+      Hole(Expr.Name("name")),
+      Text(" y"),
+    ],
+  )
+```
 
 == Typed Inspection
 
@@ -79,32 +172,69 @@ This boundary intentionally does not admit:
 
 == Examples
 
-Accepted macro expression shape once expression macros are admitted:
+Accepted macro function implementation shape once expression macros are
+admitted. Helper method names on `Expr[Untyped]` are illustrative:
+
+```text
+macro def vec(input: Expr[Untyped]): Expr[Untyped] = {
+  val items = input.callArgs()
+  val output = quote_expr(Vec.from_array(Array(..items)))
+  return output
+}
+```
+
+Call-like use is still allowed, but it is only one accepted surface form:
 
 ```cos
 val xs = vec(1, 2, 3)
 ```
 
-Provider-level sketch:
+The same boundary can describe a block-attached application. The macro inspects
+the input expression to get the target and block body; the body is structured
+`Expr[Untyped]` data, not raw source text and not a checked expression:
+
+```cos
+val field = j.path { self.field(0) }
+```
 
 ```text
-vec:
-  List[Expr[Untyped]] -> MacroResult[Expr[Untyped]]
+macro def path(input: Expr[Untyped]): Expr[Untyped] = {
+  val receiver = input.blockTarget()
+  val body = input.blockBody()
+  val output = build_path_access(receiver, body)
+  return output
+}
+```
 
-Type.of(arg0): TypeInfo
+Interpolation may also be admitted without making the source expression look
+like an ordinary call:
+
+```cos
+val message = fmt"x $name y"
+```
+
+```text
+macro def fmt(input: Expr[Untyped]): Expr[Untyped] = {
+  val parts = input.interpolationParts()
+  val output = build_format_expr(parts)
+  return output
+}
 ```
 
 Rejected provider API shapes:
 
 ```text
-List[Expr[Any]] -> Expr[Any]
-List[Expr[i32]] -> Expr[Vec[i32]]
+Expr[Any] -> Expr[Any]
+Expr[i32] -> Expr[Vec[i32]]
+List[Expr[Untyped]] -> Expr[Untyped]
+Call(path: PathRef, args: List[Expr[Untyped]]) -> Expr[Untyped]
 TokenStream -> TokenStream
 ```
 
 The rejected examples either confuse untyped source expressions with an
-object-language top type, imply typed quotation, claim checked output, or bypass
-the Cosmo parser.
+object-language top type, imply typed quotation, claim checked output, add a
+separate public context value, force macros into a pre-extracted argument-list
+or function-call shape, or bypass the Cosmo parser.
 
 == Review Rules
 
@@ -115,5 +245,7 @@ Macro expression proposals must preserve these rules:
 - typed facts come from inspectors such as `Type.of(expr)`.
 - inspector output is read-only and cannot be used to mark generated code as
   already checked.
+- expression macro provider input is `Expr[Untyped]`, not a separate context
+  value, raw token stream, or pre-extracted argument list.
 - generated expression output must be deterministic and must re-enter ordinary
   checking before lowering.

--- a/docs/cosmo/macro-expr.typ
+++ b/docs/cosmo/macro-expr.typ
@@ -77,13 +77,69 @@ would otherwise use for an ordinary operation:
   member, method, or extension lookup for the selected member `.expand` resolves
   to that macro provider. A free `@macro def expand(...)` in scope does not by
   itself match every `.expand` selection by string name.
-- `j.path { ... }` can select a macro only when lookup for the selected target
-  `j.path` resolves to that macro provider.
+- `path { ... }` can select a macro only when lookup for the selected target
+  `path` resolves to that macro provider.
 - `fmt"x $name y"` can select a macro only when interpolation tag lookup for
   `fmt` resolves to that macro provider.
 
 After selection, the provider receives the selected macro payload as
 `Expr[Untyped]`.
+
+== Single Payload Rule
+
+An expression macro consumes exactly one provider-facing payload. The payload is
+one `Expr.Args`, one `Expr.Block`, or one `Expr.Template`.
+
+Consecutive surface forms do not feed multiple provider parameters to the same
+macro invocation. This keeps the macro boundary closer to Rust's single
+delimited-input macro model than Scala's multiple-parameter-list macro model.
+
+Rejected as one macro invocation:
+
+```cos
+A(1) { check }
+```
+
+If `A(1)` selects a macro, the selected input is only:
+
+```text
+Expr.Args(
+  receiver = None,
+  positional = [Expr.Int(1)],
+  named = [],
+)
+```
+
+The trailing `{ check }` is not passed as a second macro payload. A later
+capability may define how an already-expanded result accepts a following block,
+but that is not part of this expression macro input boundary.
+
+When a macro needs both arguments and block-like data, the source must encode
+them inside one payload. For example:
+
+```cos
+A(args: (1), body: { check })
+```
+
+feeds one argument payload whose named values contain structured expressions:
+
+```text
+Expr.Args(
+  receiver = None,
+  positional = [],
+  named = [
+    "args" -> Expr.Args(
+      receiver = None,
+      positional = [Expr.Int(1)],
+      named = [],
+    ),
+    "body" -> Expr.Block(
+      receiver = None,
+      statements = [Expr.Name("check")],
+    ),
+  ],
+)
+```
 
 == Macro Input Shapes
 
@@ -132,11 +188,10 @@ input =
 ```
 
 Block-attached syntax feeds a block payload. Lookup has already selected the
-macro provider; a receiver from the selected target is preserved when the
-surface form has one:
+macro provider:
 
 ```cos
-val field = j.path { self.field }
+val field = path { self.field }
 ```
 
 ```text
@@ -145,7 +200,7 @@ resolved provider =
 
 input =
   Expr.Block(
-    receiver = Some(Expr.Name("j")),
+    receiver = None,
     statements = [
       Expr.Select(Expr.Name("self"), "field"),
     ],
@@ -220,19 +275,17 @@ val xs = vec(1, 2, 3)
 ```
 
 The same boundary can describe a block-attached application. The macro inspects
-the input expression to get the optional receiver and block body; the body is
-structured `Expr[Untyped]` data, not raw source text and not a checked
-expression:
+the input expression to get the block body; the body is structured
+`Expr[Untyped]` data, not raw source text and not a checked expression:
 
 ```cos
-val field = j.path { self.field }
+val field = path { self.field }
 ```
 
 ```text
 @macro def path(input: Expr[Untyped]): Expr[Untyped] = {
-  val receiver = input.block().receiver
   val body = input.block().statements
-  val output = build_path_access(receiver, body)
+  val output = build_path_access(body)
   return output
 }
 ```
@@ -258,6 +311,7 @@ Rejected provider API shapes:
 Expr[Any] -> Expr[Any]
 Expr[i32] -> Expr[Vec[i32]]
 List[Expr[Untyped]] -> Expr[Untyped]
+Args, Block -> Expr[Untyped]
 Call(path: PathRef, args: List[Expr[Untyped]]) -> Expr[Untyped]
 Apply(target: Expr[Untyped], args: List[Expr[Untyped]]) -> Expr[Untyped]
 TokenStream -> TokenStream
@@ -266,7 +320,8 @@ TokenStream -> TokenStream
 The rejected examples either confuse untyped source expressions with an
 object-language top type, imply typed quotation, claim checked output, add a
 separate public context value, force macros into a pre-extracted argument-list,
-function-call shape, or generic apply shape, or bypass the Cosmo parser.
+multiple provider parameters, function-call shape, or generic apply shape, or
+bypass the Cosmo parser.
 
 == Review Rules
 
@@ -279,6 +334,7 @@ Macro expression proposals must preserve these rules:
   already checked.
 - expression macro provider input is `Expr[Untyped]`, not a separate context
   value, raw token stream, or pre-extracted argument list.
+- an expression macro consumes exactly one provider-facing payload.
 - provider-facing macro input normalizes to `Expr.Args`, `Expr.Block`, or
   `Expr.Template`, not call or apply nodes.
 - generated expression output must be deterministic and must re-enter ordinary

--- a/docs/cosmo/name-resolution.typ
+++ b/docs/cosmo/name-resolution.typ
@@ -2,35 +2,112 @@
 
 == Status
 
-This file owns source name lookup, declaration binding, qualified lookup, foreign namespace aliases, and name-resolution diagnostics for the cosmo0 bootstrap subset.
+This file owns source name lookup, declaration binding, qualified lookup,
+foreign namespace aliases, delayed resolution obligations, and name-resolution
+diagnostics for the cosmo0 bootstrap subset.
 
 == Resolver Inputs and Outputs
 
-Name resolution consumes one already-parsed module after import elaboration has separated ordinary Cosmo imports from C++ namespace imports. Its inputs are:
+Name resolution consumes already-parsed source after import elaboration has
+separated ordinary Cosmo imports from C++ namespace imports. It is incremental:
+Cosmo resolves the leading segment of path-like syntax as early as possible,
+then resolves later segments when the required facts become available. Its
+inputs are:
 
 - the module source span and declaration list;
+- the package/module declaration index built from parsed declaration headers;
 - ordinary Cosmo import declarations, which may contribute package dependency edges;
 - C++ namespace import declarations, which bind a local alias to a canonical C++ namespace and a bounded set of contributing headers;
 - class members, function parameters, local declarations, and expression/type paths.
 
-The resolver output is a typed binding environment containing module declarations, class/member scopes, local scopes, expression/type references, diagnostics, and the foreign namespace alias table. The foreign alias table records:
+The resolver output is a binding environment containing module declarations,
+class/member scopes, local scopes, expression/type references, delayed
+resolution obligations, diagnostics, and the foreign namespace alias table. The
+foreign alias table records:
 
 - canonical C++ namespace path, such as `::std`;
 - local alias, such as `cstd`;
 - contributing header names, such as `c++/vector` and `c++/string`;
 - the source span of the alias declaration used for diagnostics.
 
+== Cosmo Resolution Model
+
+Cosmo name resolution is prefix-first and fact-driven. A path-like expression is
+not required to resolve every segment in one pass. The first segment is resolved
+against the current lexical, module, import, type, foreign-alias, and provider
+indexes. Any remaining suffix is stored as a deterministic resolution
+obligation.
+
+For example:
+
+```cos
+value.expand(2)
+```
+
+The first resolution step only proves where `value` is bound:
+
+```text
+ResolveHead("value") -> Binding(value)
+```
+
+The selector `.expand` is not classified by string name. It is resolved after
+the compiler has the facts required by selector lookup, such as the receiver
+type or namespace kind:
+
+```text
+Binding(value)
+  -> TypeFact(value)
+  -> ResolveSelector(receiver = value, selector = "expand")
+  -> ordinary method, extension method, associated item, or macro provider
+```
+
+This keeps source checking schedulable without pretending that every path can
+be fully resolved during parsing. The compiler may run independent head
+resolution, signature checking, provider lookup, and type-fact production tasks
+in parallel, but it merges diagnostics and generated output in deterministic
+source order.
+
+== Resolution Facts And Obligations
+
+The resolver tracks facts separately from the final typed tree:
+
+- `NameFact`: a leading segment has a stable binding id, namespace kind,
+  visibility, and source span.
+- `SignatureFact`: a declaration header is known, such as function
+  parameters/return type, class field signatures, or a macro provider ABI.
+- `TypeFact`: an expression, local binding, or value declaration has an
+  inferred or checked type.
+- `ProviderFact`: a macro provider path resolves to a provider identity and
+  accepted input/output shape.
+- `ExecutableProviderFact`: a macro provider host artifact has been checked and
+  compiled for compile-time execution.
+
+A delayed obligation declares the facts it needs. An obligation becomes
+runnable when those facts are available. This model lets `pkg.Type.member`,
+`value.field`, `value.expand(2)`, and foreign namespace suffixes use the same
+prefix-first scheduling model while still preserving their different lookup
+rules.
+
 == Phase Order
 
-Resolution is deterministic and ordered:
+Resolution is deterministic and ordered by facts, not by a blind pass over
+source items:
 
-1. collect module-level ordinary declarations and ordinary imports;
-2. collect C++ namespace imports and merge compatible aliases;
-3. collect class/member scopes and function parameter scopes;
-4. resolve type paths, expression names, selections, variant constructors, and local declarations;
-5. report unresolved, duplicate, and conflicting alias diagnostics before lowering.
+1. build a package/module declaration index from parsed declaration headers;
+2. collect module-level ordinary declarations and ordinary imports;
+3. collect C++ namespace imports and merge compatible aliases;
+4. collect class/member scopes, function signatures, macro provider headers,
+   and function parameter scopes;
+5. resolve the leading segment of type paths, expression names, selector
+   receivers, variant constructors, macro provider paths, and local references;
+6. run delayed suffix, selector, provider, and foreign-namespace obligations
+   when their required facts are available;
+7. report unresolved, duplicate, conflicting alias, failed obligation, and
+   unsupported-cycle diagnostics before lowering.
 
-Repeated input order must not change the final alias/header set except for the stable order of first contributing headers.
+Repeated input order must not change the final alias/header set, diagnostic
+order, generated declaration order, or macro invocation order except for stable
+source-order tie-breaks.
 
 == Unqualified Lookup
 
@@ -46,10 +123,17 @@ import std as cstd from "c++/vector"
 
 == Qualified Lookup
 
-Qualified lookup resolves the leftmost segment first, then interprets the suffix by the binding kind:
+Qualified lookup resolves the leftmost segment first, then interprets the suffix
+by the binding kind. The suffix may be resolved immediately for namespace-like
+bindings, or delayed until type/provider facts are available for term-like
+bindings:
 
 - ordinary class and module-like bindings resolve members or variant constructors through the existing Cosmo scope environment;
 - a foreign namespace alias resolves the remaining suffix as a C++ qualified symbol rooted at the alias's canonical namespace;
+- a term binding stores selector suffixes as obligations until the receiver type
+  is known;
+- a macro provider binding stores macro classification obligations until the
+  selected provider path, payload shape, and provider executable facts are known;
 - unresolved leftmost segments report `cosmo1.name.unresolved-name`.
 
 For example:
@@ -60,6 +144,38 @@ type CppVector[T] = cstd::vector[T]
 ```
 
 The leftmost segment `cstd` resolves to the foreign namespace alias. The suffix `vector` is interpreted as `::std::vector` and is validated against the bounded header set before backend use.
+
+== Selector And Macro Classification
+
+Selector lookup is not textual matching. For expression syntax such as:
+
+```cos
+value.expand(2)
+```
+
+the resolver first resolves `value`. After `value` has a type fact, member,
+method, and extension lookup decide what `.expand` denotes. If that resolved
+target is a macro provider, macro classification runs and the provider receives
+the normalized macro payload selected by the macro expression boundary. If the
+resolved target is an ordinary method or value-level callable, the expression is
+checked as an ordinary call.
+
+A free `@macro def expand(...)` in scope does not by itself match every
+`.expand` selector. The selected member, method, or extension lookup result must
+resolve to that provider.
+
+== Top-Level And Block-Local Scheduling
+
+Top-level modules and declarations are planned from the package/module index and
+the delayed-obligation graph. Source order is a deterministic tie-breaker, not
+the semantic checking order, when independent top-level tasks can run in
+parallel.
+
+Block-local items are different. Local `val` and `var` declarations mutate the
+lexical scope for later items in the same block. Cosmo therefore checks
+block-local items left-to-right unless a later local dataflow planner proves a
+subgroup independent without changing scope visibility, mutation, diagnostics,
+or inferred types.
 
 == C++ Namespace Imports
 

--- a/docs/cosmo/name-resolution.typ
+++ b/docs/cosmo/name-resolution.typ
@@ -52,11 +52,12 @@ ResolveHead("value") -> Binding(value)
 
 The selector `.expand` is not classified by string name. It is resolved after
 the compiler has the facts required by selector lookup, such as the receiver
-type or namespace kind:
+type, namespace kind, or method-set facts:
 
 ```text
 Binding(value)
   -> TypeFact(value)
+  -> MethodSetFact(TypeFact(value), "expand") when trait or extension lookup can contribute
   -> ResolveSelector(receiver = value, selector = "expand")
   -> ordinary method, extension method, associated item, or macro provider
 ```
@@ -81,6 +82,13 @@ The resolver tracks facts separately from the final typed tree:
   accepted input/output shape.
 - `ExecutableProviderFact`: a macro provider host artifact has been checked and
   compiled for compile-time execution.
+- `ImplFact`: an existing trait is implemented for an existing target item.
+  These facts may come from source `impl` declarations or from derive-generated
+  implementation attachments.
+- `MethodSetFact(receiver, selector)`: the selector candidates available for a
+  receiver type and selector name after inherent methods, admitted extension
+  methods, source impl facts, and derive-generated impl facts have been
+  accounted for.
 
 A delayed obligation declares the facts it needs. An obligation becomes
 runnable when those facts are available. This model lets `pkg.Type.member`,
@@ -100,9 +108,11 @@ source items:
    and function parameter scopes;
 5. resolve the leading segment of type paths, expression names, selector
    receivers, variant constructors, macro provider paths, and local references;
-6. run delayed suffix, selector, provider, and foreign-namespace obligations
+6. collect source impl facts and derive-generated impl facts into implementation
+   and method-set indexes;
+7. run delayed suffix, selector, provider, and foreign-namespace obligations
    when their required facts are available;
-7. report unresolved, duplicate, conflicting alias, failed obligation, and
+8. report unresolved, duplicate, conflicting alias, failed obligation, and
    unsupported-cycle diagnostics before lowering.
 
 Repeated input order must not change the final alias/header set, diagnostic
@@ -163,6 +173,31 @@ checked as an ordinary call.
 A free `@macro def expand(...)` in scope does not by itself match every
 `.expand` selector. The selected member, method, or extension lookup result must
 resolve to that provider.
+
+Selector resolution is delayed only as far as its lookup rules require. An
+inherent method on the receiver type can be selected as soon as the receiver
+type and class/member method index are known. A selector that may be supplied by
+trait or extension lookup must wait for the relevant method-set fact:
+
+```text
+ResolveSelector(x.parse)
+  waits for TypeFact(x)
+  waits for MethodSetFact(TypeFact(x), "parse") when trait or extension lookup can contribute
+```
+
+`MethodSetFact(T, "parse")` includes candidates from source impls and
+derive-generated impls for `T`. Therefore derive expansion may affect selector
+resolution and trait-resolution obligations even though it does not add ordinary
+name-resolution bindings. Implementations may conservatively wait for the full
+`ImplFactIndex(T)` before resolving a selector, but the semantic dependency is
+only on facts that can contribute to that receiver type and selector name.
+
+For example, if `@derive(cli.Parser)` attaches `cli.Parser for Config`, then
+`cli.Parser.parse[Config](args)` uses ordinary name resolution for `cli.Parser`
+and `Config`, but the call type-checking waits for `ImplFact(cli.Parser for
+Config)`. If a method-like form such as `config.parse()` is admitted through a
+trait or extension API, its selector target similarly waits for
+`MethodSetFact(Config, "parse")`.
 
 == Top-Level And Block-Local Scheduling
 

--- a/docs/cosmo/notes/cosmo-macro-expr-computation.md
+++ b/docs/cosmo/notes/cosmo-macro-expr-computation.md
@@ -6,7 +6,7 @@ with the rest of the site and reviewed through the same ownership rules.
 Current pages:
 
 - `docs/cosmo/macro-expr.typ` owns `Expr[T = Untyped]`, expression macro
-  input/output, typed inspector access, and expression macro non-goals.
+  function contracts, typed inspector access, and expression macro non-goals.
 - `docs/cosmo/compile-time-evaluation.typ` owns macro function input/output
   records, macro function purity, full C++ compile-time execution through
   `cosmo-jit-sys`, and target runtime separation.

--- a/docs/cosmo/spec.typ
+++ b/docs/cosmo/spec.typ
@@ -58,6 +58,9 @@ The accepted example is intentionally simple: it uses concrete classes, fields, 
 - `runtime.typ` owns primitive descriptors, extern ABI hooks, and backend runtime requirements.
 - `package.typ` owns package metadata, imports, source loading, module ordering, and stage validation.
 - `macro-expr.typ` owns the provider-facing `Expr[T = Untyped]` boundary, expression macro function contract, and typed inspector rules.
+- `derive-macro.typ` owns the first derive macro boundary, where providers may
+  attach trait implementations to existing items without adding new names to
+  ordinary name resolution.
 - `compile-time-evaluation.typ` owns macro function input/output records, macro output purity, full C++ compile-time execution through `cosmo-jit-sys`, and target runtime separation.
 - `testing.typ` owns positive, negative, deterministic, and bug regression test policy.
 

--- a/docs/cosmo/spec.typ
+++ b/docs/cosmo/spec.typ
@@ -57,7 +57,7 @@ The accepted example is intentionally simple: it uses concrete classes, fields, 
 - `std.typ` owns core0 standard interfaces and capability identifiers.
 - `runtime.typ` owns primitive descriptors, extern ABI hooks, and backend runtime requirements.
 - `package.typ` owns package metadata, imports, source loading, module ordering, and stage validation.
-- `macro-expr.typ` owns the provider-facing `Expr[T = Untyped]` boundary, expression macro protocol, and typed inspector rules.
+- `macro-expr.typ` owns the provider-facing `Expr[T = Untyped]` boundary, expression macro function contract, and typed inspector rules.
 - `compile-time-evaluation.typ` owns macro function input/output records, macro output purity, full C++ compile-time execution through `cosmo-jit-sys`, and target runtime separation.
 - `testing.typ` owns positive, negative, deterministic, and bug regression test policy.
 

--- a/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/.openspec.yaml
+++ b/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/README.md
+++ b/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/README.md
@@ -1,0 +1,3 @@
+# add-cosmo-jit-sys-clang-repl-poc
+
+Add cosmo-jit-sys clang-repl proof of concept and benchmark coverage.

--- a/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/design.md
+++ b/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/design.md
@@ -1,0 +1,121 @@
+## Context
+
+`cosmo-clang-sys` already integrates Clang through a CMake-built native support
+library and uses `packages/cosmo-clang-sys/config/llvm-manifest.json` to fetch
+or locate LLVM/Clang artifacts. That manifest already includes `clang-repl`
+where `llvm-dist` publishes it. The compile-time evaluation design now needs a
+separate component whose job is execution, not C++ namespace lookup.
+
+This change is an implementation slice for proving the execution substrate. It
+does not expose macro provider APIs and does not change accepted cosmo0 source
+semantics.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `packages/cosmo-jit-sys` as the native component for clang-repl backed
+  execution.
+- Prove that the selected LLVM/Clang distribution can run clang-repl code in
+  the repository build environment.
+- Provide a C ABI that returns structured status, diagnostics, stdout/stderr
+  summaries, and integer smoke results.
+- Add benchmark output that can compare cold, warm, and heavy-header JIT costs
+  across commits and toolchains.
+
+**Non-Goals:**
+
+- Implement full macro function input/output records.
+- Evaluate arbitrary Cosmo expressions or type-level programs.
+- Connect macro expansion, reflection, hygiene, or generated source validation.
+- Promise stable absolute benchmark thresholds in CI.
+
+## Decisions
+
+### Reuse The Existing LLVM Distribution Contract
+
+`cosmo-jit-sys` should use the same LLVM version, manifest, cache directory, and
+toolchain options as `cosmo-clang-sys`. If direct reuse of
+`packages/cosmo-clang-sys/CosmoLLVM.cmake` would create an ownership problem,
+the implementation should move the helper to a shared CMake location and update
+both native packages.
+
+Alternative considered: add a second manifest and download cache for JIT. That
+would make the two Clang integrations drift and would double the failure modes
+for users configuring `COSMO_LLVM_PATH`, `COSMO_LLVM_OFFLINE`, and
+`COSMO_GCC_TOOLCHAIN`.
+
+### Keep Clang Types Behind A C ABI
+
+The public boundary should use `cosmo_jit_sys_*` symbols, string views, opaque
+handles, fixed-width scalar values, and explicit dispose functions. Clang,
+LLVM, and clang-repl implementation types must stay private to the native
+package.
+
+Alternative considered: call clang-repl or Clang C++ APIs directly from
+Scala.js or the package driver. That would leak toolchain lifetime and ABI
+details into consumers that should only see structured compile-time execution
+results.
+
+### Start With A Smoke-Oriented Execution Surface
+
+The first API should be intentionally narrow: create a session, evaluate a C++
+snippet, run or materialize a named entry point needed by smoke tests, and
+return structured status/diagnostics. The API may be process-backed by the
+`clang-repl` executable or in-process through Clang interpreter APIs; consumers
+must not depend on that implementation detail.
+
+Alternative considered: design the final macro-provider protocol now. The
+macro protocol still depends on reflection, hygiene, and macro output
+validation decisions. A smoke-oriented JIT surface proves the risky native
+toolchain path without forcing those decisions early.
+
+### Benchmark For Trend Data, Not Absolute Gates
+
+The benchmark should record cold session creation, first snippet evaluation,
+warm repeated evaluation, artifact/toolchain identity, host platform, and input
+shape. It should include a heavy-header shape that adds the repository
+nlohmann JSON include root and evaluates a snippet using `nlohmann::json`.
+The report should identify the include root used, for example
+`target/cosmo/externals/json/single_include`, so results are attributable to the
+same dependency layout as package builds. It should emit structured data under
+`target/cosmo/bench/` and keep CI validation to "benchmark runs and reports
+measurements" unless a later change adds calibrated thresholds.
+
+Alternative considered: fail CI if startup or evaluation exceeds a fixed
+duration. That would be brittle across LLVM builds, local hardware, debug vs
+release profiles, and sandboxed CI hosts.
+
+## Risks / Trade-offs
+
+clang-repl APIs or packaging differ across platforms -> Keep the implementation
+behind `cosmo-jit-sys`, diagnose missing support clearly, and initially require
+the smoke benchmark only on platforms where the manifest provides clang-repl.
+
+Process-backed sessions may be slower than in-process interpreter APIs -> The
+benchmark makes the cost visible, and the C ABI leaves room to replace the
+backend without changing cosmo0 consumers.
+
+Shared CMake helper movement can disturb `cosmo-clang-sys` -> Keep the helper
+refactor mechanical, preserve existing cache option names, and rerun the
+current package-run and CMake smoke checks.
+
+## Migration Plan
+
+1. Add or share the CMake/LLVM helper so both native packages resolve the same
+   LLVM/Clang install.
+2. Add `packages/cosmo-jit-sys` with the `cosmoJit` target and
+   `cosmo_jit_sys_*` C ABI.
+3. Add smoke execution coverage proving clang-repl runs a C++ snippet and
+   returns a deterministic result.
+4. Add benchmark coverage for integer, standard-header, and nlohmann JSON
+   header inputs, then document the command and output path.
+5. Keep package manifests unchanged until a later consumer explicitly requests
+   `cosmo-jit-sys`.
+
+## Open Questions
+
+- Whether the first implementation should use the clang-repl executable as a
+  subprocess or Clang interpreter APIs directly.
+- Whether benchmark comparison baselines should live in versioned fixtures or
+  only in generated `target/` artifacts.

--- a/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/proposal.md
+++ b/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+`docs/cosmo/compile-time-evaluation.typ` makes `cosmo-jit-sys` the C++
+compile-time execution substrate for later macro providers, but the repository
+does not yet have that component or proof that the selected clang-repl artifact
+can execute provider code in the local build pipeline.
+
+## What Changes
+
+- Add a native `cosmo-jit-sys` support component that owns clang-repl based
+  execution behind a narrow C ABI.
+- Reuse the repository LLVM/Clang distribution and CMake discovery conventions
+  already used by `cosmo-clang-sys`, including the manifest component that
+  supplies `clang-repl`.
+- Add a clang-repl proof-of-concept smoke path that executes C++ code and
+  returns a structured result instead of only proving that the binary exists.
+- Add benchmark coverage for cold session startup, first evaluation, warm
+  repeated evaluation, and a heavy header input that includes
+  `nlohmann/json.hpp`, with machine/toolchain metadata recorded for comparison.
+- Keep macro expansion and full compile-time evaluation integration outside
+  this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo-jit-sys`: Defines the native clang-repl execution support component,
+  C ABI boundary, smoke execution contract, and benchmark reporting for future
+  compile-time evaluation consumers.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Adds a native support package under `packages/cosmo-jit-sys`.
+- May move or share LLVM/Clang CMake helper files so `cosmo-clang-sys` and
+  `cosmo-jit-sys` use the same manifest, cache, and toolchain options.
+- Adds focused native smoke tests and benchmark scripts or test targets,
+  including a benchmark shape for the repository nlohmann JSON header.
+- Establishes the dependency that later compile-time evaluation probes can use
+  without adding the full macro system.

--- a/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/specs/cosmo-jit-sys/spec.md
+++ b/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/specs/cosmo-jit-sys/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Native clang-repl Support Component
+
+The repository SHALL provide a native `cosmo-jit-sys` support component that
+uses the repository LLVM/Clang toolchain contract to run clang-repl based C++
+compile-time execution.
+
+#### Scenario: cosmo-jit-sys configures with clang-repl available
+
+- **WHEN** the CMake build configures `cosmo-jit-sys` with an LLVM/Clang
+  installation or manifest cache that includes clang-repl support
+- **THEN** it defines a native `cosmoJit` target
+- **AND** it produces the platform's native `cosmo-jit-sys` library artifact
+- **AND** it uses the same LLVM version, manifest, cache, offline mode, target
+  platform, target architecture, and GNU toolchain options as the existing
+  Clang support pipeline
+
+#### Scenario: clang-repl support is missing
+
+- **WHEN** the CMake build enables `cosmo-jit-sys` but cannot locate the
+  required clang-repl executable, library, or headers for the selected backend
+- **THEN** configuration fails with a diagnostic that names the missing
+  clang-repl requirement
+- **AND** the diagnostic explains how to set `COSMO_LLVM_PATH` or use the
+  repository LLVM manifest cache
+
+### Requirement: Stable C ABI Boundary
+
+`cosmo-jit-sys` SHALL expose a stable C ABI for compiler and driver consumers,
+and SHALL NOT expose Clang, LLVM, or clang-repl implementation types across the
+library boundary.
+
+#### Scenario: Consumer creates and disposes a JIT session
+
+- **WHEN** a consumer creates a `cosmo-jit-sys` session through the C ABI
+- **THEN** exported symbols use the `cosmo_jit_sys_` prefix
+- **AND** the consumer receives only opaque handles and C ABI value structs
+- **AND** `cosmo-jit-sys` provides matching dispose functions for every owned
+  handle or result
+
+#### Scenario: Consumer evaluates a snippet
+
+- **WHEN** a consumer submits a C++ snippet to an active `cosmo-jit-sys` session
+- **THEN** the result reports a stable status code, diagnostics, captured output
+  summary, and generated artifact summary when applicable
+- **AND** Clang and LLVM implementation objects remain private to
+  `cosmo-jit-sys`
+
+### Requirement: clang-repl Execution Proof
+
+`cosmo-jit-sys` SHALL include a proof-of-concept smoke path that demonstrates
+clang-repl can execute C++ code, not merely that the toolchain can be located.
+
+#### Scenario: Integer smoke snippet executes
+
+- **WHEN** the smoke runner evaluates a C++ snippet whose exported entry point
+  computes `1 + 1`
+- **THEN** `cosmo-jit-sys` reports successful execution
+- **AND** the structured result contains the integer value `2`
+- **AND** diagnostics are empty or marked non-fatal
+
+#### Scenario: C++ standard library smoke snippet executes
+
+- **WHEN** the smoke runner evaluates a C++ snippet that includes a standard C++
+  header and instantiates a standard library type
+- **THEN** clang-repl accepts the snippet through `cosmo-jit-sys`
+- **AND** the result proves the snippet executed under Clang's C++ semantics
+
+### Requirement: JIT Benchmark Reporting
+
+`cosmo-jit-sys` SHALL provide benchmark coverage that measures the JIT path
+used by the proof of concept and emits structured results suitable for
+comparison across commits and toolchains. The benchmark SHALL include both
+lightweight snippets and a heavy-header input that includes `nlohmann/json.hpp`.
+
+#### Scenario: Benchmark records cold and warm timings
+
+- **WHEN** the `cosmo-jit-sys` benchmark runs
+- **THEN** it records cold session startup time, first snippet evaluation time,
+  and warm repeated evaluation time
+- **AND** it records host platform, LLVM/Clang version, clang-repl backend
+  identity, build profile, and benchmark input shape
+- **AND** it writes a structured report under `target/cosmo/bench/`
+
+#### Scenario: Benchmark includes nlohmann JSON header input
+
+- **WHEN** the `cosmo-jit-sys` benchmark runs with repository external headers
+  available
+- **THEN** one benchmark input adds the nlohmann JSON include root, such as
+  `target/cosmo/externals/json/single_include`
+- **AND** the evaluated C++ snippet includes `nlohmann/json.hpp`
+- **AND** the snippet constructs or parses a `nlohmann::json` value and returns
+  a deterministic scalar result
+- **AND** the structured report records the input shape as a nlohmann JSON
+  heavy-header benchmark
+
+#### Scenario: Benchmark avoids unstable absolute thresholds
+
+- **WHEN** the benchmark is run in CI or a developer machine
+- **THEN** success requires the benchmark to complete and report measurements
+- **AND** the benchmark does not fail solely because a machine-specific timing
+  exceeds an uncalibrated absolute threshold

--- a/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/tasks.md
+++ b/openspec/changes/add-cosmo-jit-sys-clang-repl-poc/tasks.md
@@ -1,0 +1,55 @@
+## 1. Native Package Setup
+
+- [ ] 1.1 Add `packages/cosmo-jit-sys` with CMake project metadata, source,
+  include, test, and benchmark directories.
+- [ ] 1.2 Reuse or move the existing LLVM/Clang CMake helper so
+  `cosmo-clang-sys` and `cosmo-jit-sys` share LLVM version, manifest, cache,
+  offline, target platform, target architecture, and GNU toolchain options.
+- [ ] 1.3 Add a `cosmoJit` native target and platform library artifact with
+  position-independent code and the required Clang/LLVM include and link
+  settings.
+- [ ] 1.4 Add a clear configure-time diagnostic for missing clang-repl support.
+
+## 2. C ABI And Session Model
+
+- [ ] 2.1 Add `include/cosmo_jit_sys.h` with `cosmo_jit_sys_*` status values,
+  string views, session options, snippet requests, result structs, opaque
+  handles, and dispose functions.
+- [ ] 2.2 Implement session creation and disposal without exposing Clang, LLVM,
+  or clang-repl implementation types.
+- [ ] 2.3 Implement snippet evaluation that returns status, diagnostics,
+  captured output summary, integer smoke result, and generated artifact summary
+  where available.
+- [ ] 2.4 Add defensive validation for null pointers, empty snippets, missing
+  entry points, and oversized smoke inputs.
+
+## 3. clang-repl Proof Of Concept
+
+- [ ] 3.1 Add a smoke runner or CTest target that evaluates an exported C++
+  entry point computing `1 + 1` and asserts result `2`.
+- [ ] 3.2 Add a second smoke snippet that includes a standard C++ header and
+  instantiates a standard library type under clang-repl.
+- [ ] 3.3 Document the smoke command, required LLVM environment variables, and
+  expected failure message when clang-repl is unavailable.
+
+## 4. Benchmark Coverage
+
+- [ ] 4.1 Add a benchmark command for cold session startup, first snippet
+  evaluation, and warm repeated evaluation.
+- [ ] 4.2 Write benchmark reports under `target/cosmo/bench/cosmo-jit-sys/`
+  with host, toolchain, build profile, backend, input shape, and timing data.
+- [ ] 4.3 Add a heavy-header benchmark input that includes
+  `nlohmann/json.hpp` from the repository JSON external include root,
+  constructs or parses a `nlohmann::json` value, returns a deterministic scalar
+  result, and records the include root in the report.
+- [ ] 4.4 Keep benchmark pass/fail based on successful execution and report
+  generation rather than uncalibrated absolute timing thresholds.
+
+## 5. Validation
+
+- [ ] 5.1 Run existing package-run and native CMake tests that cover
+  `cosmo-clang-sys` after any shared CMake helper refactor.
+- [ ] 5.2 Run the `cosmo-jit-sys` configure, build, smoke, and benchmark paths
+  on a toolchain with clang-repl available.
+- [ ] 5.3 Record any platform limitations or skipped clang-repl support in the
+  change notes before handoff.

--- a/openspec/changes/add-derived-cli-library/design.md
+++ b/openspec/changes/add-derived-cli-library/design.md
@@ -24,7 +24,8 @@ palc-style parser later.
   and subcommand behavior.
 - Use CLI11 behind a private support boundary for parsing, help, version, and
   common validation behavior.
-- Generate ordinary Cosmo methods such as `Cli::parse(args)`.
+- Generate implementations of existing CLI traits, used through already
+  name-resolved trait APIs such as `cli.Parser.parse[Cli](args)`.
 - Keep parse errors structured and renderable without forcing immediate process
   exit.
 - Validate schema mistakes at compile time where reflection metadata is enough.
@@ -63,13 +64,13 @@ reported as Cosmo `CliError` data.
 Alternative considered: bind CLI11 classes into Cosmo directly. That would leak
 C++ lifetime, template, and exception behavior into the source-facing API.
 
-### Generate Typed Construction Code
+### Generate Typed Trait Implementation Code
 
 The derive provider should generate code that maps parsed matches into the
-target struct. The CLI backend should not construct arbitrary Cosmo objects by
-reflection. For example, it can return a match table, while generated Cosmo code
-extracts `package`, `output`, or `subcommand` values and calls the struct
-constructor.
+target struct inside a generated trait implementation. The CLI backend should
+not construct arbitrary Cosmo objects by reflection. For example, it can return
+a match table, while generated implementation code extracts `package`,
+`output`, or `subcommand` values and calls the struct constructor.
 
 Alternative considered: have CLI11 construct the final Cosmo struct. That makes
 the support library depend on Cosmo object layout and backend internals.
@@ -132,7 +133,8 @@ creates parse-at-runtime behavior for what should be source-checked.
    `introduce-cosmo0-macro-system`.
 2. Add the Cosmo `cosmo.cli` schema, matches, and error data model.
 3. Add the CLI11 support boundary and deterministic dependency staging.
-4. Implement `@derive(cli.Parser)` for a small single-command struct.
+4. Implement `@derive(cli.Parser)` for a small single-command struct as a
+   generated `cli.Parser for T` implementation.
 5. Add `Args` and `Subcommand` derives.
 6. Migrate `packages/cosmoc/src/main.cos` to derived parsing.
 7. Add fixture packages and CLI golden tests for help, errors, and parsed values.

--- a/openspec/changes/add-derived-cli-library/proposal.md
+++ b/openspec/changes/add-derived-cli-library/proposal.md
@@ -11,7 +11,7 @@ behavior underneath.
 - Add a `cosmo.cli` library with `@derive(cli.Parser)`,
   `@derive(cli.Args)`, and `@derive(cli.Subcommand)` support.
 - Use macro reflection to turn typed structs and sum types into validated CLI
-  schema data and generated `parse(args)` methods.
+  schema data and generated implementations of existing CLI traits.
 - Wrap CLI11 behind a private support boundary so Cosmo source does not depend
   on C++ parser APIs directly.
 - Support the first derived CLI surface: short/long options, bool flags,
@@ -29,7 +29,8 @@ behavior underneath.
 ### New Capabilities
 
 - `core0-derived-cli`: Defines the source-facing derived CLI parser API,
-  attribute semantics, type mapping, generated methods, errors, and validation.
+  attribute semantics, type mapping, generated trait implementations, errors,
+  and validation.
 - `cli11-sys`: Defines the CLI11 support boundary, schema/matches exchange,
   exception handling, dependency staging, and package build integration.
 
@@ -41,8 +42,9 @@ behavior underneath.
 
 ## Impact
 
-- Depends on `introduce-cosmo0-macro-system` for derive expansion, reflection
-  metadata, generated declarations, and attribute consumption.
+- Depends on `introduce-cosmo0-macro-system` and
+  `implement-cosmo0-derive-macros` for derive expansion, reflection metadata,
+  generated trait implementation attachments, and attribute consumption.
 - Adds a new Cosmo library package such as `library/cli` or `library/std/src/cli`
   depending on the final std/package boundary.
 - Adds a CLI11-backed native support component or support-library wrapper.

--- a/openspec/changes/add-derived-cli-library/specs/cli11-sys/spec.md
+++ b/openspec/changes/add-derived-cli-library/specs/cli11-sys/spec.md
@@ -15,7 +15,7 @@ library rather than exposing CLI11 classes or templates to ordinary Cosmo source
 
 - **WHEN** an external Cosmo package imports the public CLI library
 - **THEN** raw CLI11 wrapper declarations remain private implementation details
-- **AND** the public API is expressed through Cosmo `CliSchema`, `CliMatches`, `CliError`, and derive-generated methods
+- **AND** the public API is expressed through Cosmo `CliSchema`, `CliMatches`, `CliError`, and derive-generated trait implementations
 
 ### Requirement: CLI11 Schema And Match Exchange
 

--- a/openspec/changes/add-derived-cli-library/specs/core0-derived-cli/spec.md
+++ b/openspec/changes/add-derived-cli-library/specs/core0-derived-cli/spec.md
@@ -2,14 +2,15 @@
 
 ### Requirement: Derived Parser Surface
 
-Cosmo SHALL provide a source-facing CLI derive API that generates typed parsers
-from annotated declarations.
+Cosmo SHALL provide a source-facing CLI derive API that generates
+implementations of existing CLI traits from annotated declarations.
 
-#### Scenario: Parser derive generates parse method
+#### Scenario: Parser derive generates parser trait implementation
 
 - **WHEN** a class is annotated with `@derive(cli.Parser)`
-- **THEN** macro expansion generates a public `parse(args: Vec[String]): Result[Self, CliError]` entry point for that class
-- **AND** the generated parser constructs the annotated class from parsed argument values
+- **THEN** macro expansion generates an implementation of the existing `cli.Parser` trait for that class
+- **AND** the implementation constructs the annotated class from parsed argument values
+- **AND** no new `parse` member or top-level parse function is added to ordinary name resolution
 
 #### Scenario: Args derive can be flattened
 
@@ -80,18 +81,18 @@ process exit from the library by default.
 
 #### Scenario: Valid arguments construct parser struct
 
-- **WHEN** `Cli::parse(args)` receives valid arguments for the derived schema
+- **WHEN** `cli.Parser.parse[Cli](args)` receives valid arguments for the derived schema
 - **THEN** it returns `Result[Cli, CliError]::Ok` containing the typed parser struct
 
 #### Scenario: Invalid arguments return structured error
 
-- **WHEN** `Cli::parse(args)` receives an unknown option, missing value, invalid value, or missing required argument
+- **WHEN** `cli.Parser.parse[Cli](args)` receives an unknown option, missing value, invalid value, or missing required argument
 - **THEN** it returns `Result[Cli, CliError]::Err`
 - **AND** the error includes a renderable message and intended process exit code
 
 #### Scenario: Help and version are structured
 
-- **WHEN** `Cli::parse(args)` receives help or version arguments handled by the CLI backend
+- **WHEN** `cli.Parser.parse[Cli](args)` receives help or version arguments handled by the CLI backend
 - **THEN** it returns a structured result that lets the program print the backend-rendered text and exit with the conventional successful status
 
 ### Requirement: Typed Defaults

--- a/openspec/changes/add-derived-cli-library/tasks.md
+++ b/openspec/changes/add-derived-cli-library/tasks.md
@@ -8,8 +8,8 @@
 ## 2. Macro Provider
 
 - [ ] 2.1 Register `cli.Parser`, `cli.Args`, and `cli.Subcommand` derive providers.
-- [ ] 2.2 Generate `schema()` and `parse(args: Vec[String])` methods for a simple parser struct.
-- [ ] 2.3 Generate typed extraction and target struct construction from `CliMatches`.
+- [ ] 2.2 Generate `cli.Parser for T` implementation records for a simple parser struct.
+- [ ] 2.3 Generate typed extraction and target struct construction from `CliMatches` inside the trait implementation.
 - [ ] 2.4 Add compile-time diagnostics for duplicate flags, unsupported types, ambiguous positionals, invalid subcommands, and unconsumed attributes.
 - [ ] 2.5 Add generated-source golden tests for representative derived CLI declarations.
 

--- a/openspec/changes/implement-cosmo0-derive-macros/.openspec.yaml
+++ b/openspec/changes/implement-cosmo0-derive-macros/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/implement-cosmo0-derive-macros/design.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/design.md
@@ -1,0 +1,115 @@
+## Context
+
+The broader macro-system proposal includes derive reflection and generated
+declaration concepts, but the first implementation should avoid changing name
+resolution. A derive provider that creates new declarations or members would
+make later source depend on expansion output. By restricting derive output to
+trait implementation attachments, the compiler can index declarations and
+resolve names before derive expansion affects trait satisfaction.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve `@derive(path)` attributes on supported item declarations.
+- Resolve derive provider paths and selected trait paths deterministically.
+- Provide stable reflection input for the already-indexed target item.
+- Accept only generated trait implementation records for the target item.
+- Validate generated implementations through the ordinary trait/impl checker.
+- Keep ordinary name resolution unchanged by derive expansion.
+- Emit deterministic diagnostics and generated implementation summaries.
+
+**Non-Goals:**
+
+- Generate new top-level declarations, members, fields, variants, classes, or
+  aliases.
+- Make `Config.parse` or any other new name visible through derive expansion.
+- Implement expression macro calls.
+- Load self-hosted macro provider packages.
+- Execute provider code through `cosmo-jit-sys`.
+- Expose trusted typed expressions or compiler mutation handles to providers.
+
+## Decisions
+
+### Restrict Output To Trait Implementation Attachments
+
+The first derive provider output is an implementation attachment:
+
+```text
+impl trait cli.Parser for Config { ... }
+```
+
+The trait and target item must already be resolved. Generated method bodies or
+associated implementation data are validated as part of the implementation.
+
+Alternative considered: let derive generate static methods or top-level helper
+functions. That is useful for some libraries, but it introduces new bindings and
+therefore affects name resolution and declaration ordering.
+
+### Run After Declaration Indexing
+
+Derive expansion runs after the declaration index, trait headers, class headers,
+and supported item facts are available. It does not require ordinary function
+body checking to finish before provider input is built.
+
+Alternative considered: run derive during parsing. That would not have stable
+trait/target identities or enough reflected field/type facts.
+
+### Keep Name Resolution Non-Interfering
+
+Because derive output cannot introduce names, the ordinary binding set remains
+the same before and after derive expansion. Later code can use the generated
+capability only through trait APIs whose names were already resolved.
+
+Alternative considered: allow derive output to add members, then rerun name
+resolution. That makes the first implementation much larger and overlaps with
+general declaration macro design.
+
+### Use Compiler-Hosted Providers First
+
+The implementation may start with compiler-hosted derive smoke providers. They
+must still use the same serialized derive input/output shape that future
+self-hosted providers will use.
+
+Alternative considered: wait for self-hosted provider packages. That would
+delay proving the derive attachment model and the CLI parser direction.
+
+### Validate Generated Implementations Before Attachment
+
+Provider output is not trusted. The compiler validates the target item, trait,
+generated members, origin metadata, and duplicate implementation behavior before
+attaching the impl to the checked package.
+
+Alternative considered: attach provider output directly and rely on later
+failures. That would produce weaker diagnostics and make invalid output harder
+to isolate.
+
+## Risks / Trade-offs
+
+- Trait-implementation-only derive is less expressive -> keep this as the first
+  slice and leave declaration-generating derives for a later capability.
+- CLI-style libraries may want convenient static methods -> route first APIs
+  through trait functions such as `cli.Parser.parse[Config](args)`.
+- Compiler-hosted providers can become special cases -> keep their input/output
+  protocol identical to future providers.
+- Generated impl validation can overlap with ordinary impl checking -> reuse
+  ordinary trait/impl validation where possible and keep derive-specific checks
+  focused on provider output integrity.
+
+## Migration Plan
+
+1. Add the derive macro design document and OpenSpec capability.
+2. Preserve and validate `@derive(path)` attributes on supported target items.
+3. Add compiler-hosted smoke derive providers that return trait implementation
+   records only.
+4. Validate and attach generated implementations without changing the ordinary
+   declaration index.
+5. Add generated implementation summaries and diagnostics.
+6. Leave declaration-generating derive output to a later proposal.
+
+## Open Questions
+
+- Whether the derive attribute path names the provider directly, the trait being
+  derived, or a provider/trait pair selected by registry metadata.
+- Which target item kinds are admitted in the first fixture set: classes only,
+  or classes plus sum-like variants.

--- a/openspec/changes/implement-cosmo0-derive-macros/design.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/design.md
@@ -17,6 +17,8 @@ resolve names before derive expansion affects trait satisfaction.
 - Accept only generated trait implementation records for the target item.
 - Validate generated implementations through the ordinary trait/impl checker.
 - Keep ordinary name resolution unchanged by derive expansion.
+- Feed derive-generated implementation facts into trait resolution and
+  method-set selector resolution.
 - Emit deterministic diagnostics and generated implementation summaries.
 
 **Non-Goals:**
@@ -60,6 +62,13 @@ trait/target identities or enough reflected field/type facts.
 Because derive output cannot introduce names, the ordinary binding set remains
 the same before and after derive expansion. Later code can use the generated
 capability only through trait APIs whose names were already resolved.
+
+Derive output still affects trait resolution. A generated implementation
+attachment contributes an `ImplFact(trait for target)` to the implementation
+fact index. Type checking that needs that trait evidence waits for the fact.
+Method-like selector resolution also waits for `MethodSetFact(receiver,
+selector)` when trait or extension lookup can contribute candidates, because
+derive-generated impls may add candidates to that method set.
 
 Alternative considered: allow derive output to add members, then rerun name
 resolution. That makes the first implementation much larger and overlaps with

--- a/openspec/changes/implement-cosmo0-derive-macros/proposal.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Cosmo needs a first derive macro implementation that is useful for library
+features such as CLI parsing without forcing the compiler to support general
+declaration-generation macros. The safe initial boundary is to let derive
+providers attach implementations of existing traits to existing items, while
+leaving ordinary name resolution unchanged.
+
+## What Changes
+
+- Add a gated derive macro implementation slice for `@derive(path)` attributes
+  on supported item declarations.
+- Resolve the derive provider and selected trait through the normal
+  prefix-first resolver and provider registry.
+- Build stable derive input from the existing target item metadata, admitted
+  field/variant facts, attributes, defaults, doc comments, and source spans.
+- Restrict first-slice provider output to trait implementation attachments for
+  the existing target item.
+- Reject generated top-level declarations, generated members, generated fields,
+  generated variants, raw source text, and trusted typed expression artifacts.
+- Validate generated implementation records and attach them after declaration
+  indexing without changing the ordinary name-resolution binding set.
+- Add deterministic diagnostics for unresolved providers, unsupported targets,
+  unsupported traits, invalid output, duplicate implementations, and unconsumed
+  attributes.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo0-derive-macros`: Defines the first derive macro implementation slice:
+  provider selection, reflection input, trait-implementation-only output,
+  attachment validation, generated implementation diagnostics, and
+  name-resolution non-interference.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Depends on `introduce-cosmo0-macro-system` for macro input/output,
+  reflection, attribute preservation, and deterministic execution rules.
+- Uses the derive boundary documented in `docs/cosmo/derive-macro.typ`.
+- Adds provider registry entries or compiler-hosted smoke providers for focused
+  derive fixtures.
+- Touches attribute preservation, declaration indexing, trait implementation
+  validation, generated origin metadata, and diagnostics.
+- Does not require expression macro calls, self-hosted provider packages, or
+  provider execution through `cosmo-jit-sys` in the first implementation.

--- a/openspec/changes/implement-cosmo0-derive-macros/proposal.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/proposal.md
@@ -20,6 +20,8 @@ leaving ordinary name resolution unchanged.
   generated variants, raw source text, and trusted typed expression artifacts.
 - Validate generated implementation records and attach them after declaration
   indexing without changing the ordinary name-resolution binding set.
+- Add derive-generated implementation facts to the trait-resolution and
+  method-set indexes used by later type checking and selector resolution.
 - Add deterministic diagnostics for unresolved providers, unsupported targets,
   unsupported traits, invalid output, duplicate implementations, and unconsumed
   attributes.
@@ -30,8 +32,8 @@ leaving ordinary name resolution unchanged.
 
 - `cosmo0-derive-macros`: Defines the first derive macro implementation slice:
   provider selection, reflection input, trait-implementation-only output,
-  attachment validation, generated implementation diagnostics, and
-  name-resolution non-interference.
+  attachment validation, generated implementation diagnostics,
+  trait-resolution dependencies, and name-resolution non-interference.
 
 ### Modified Capabilities
 
@@ -45,6 +47,7 @@ leaving ordinary name resolution unchanged.
 - Adds provider registry entries or compiler-hosted smoke providers for focused
   derive fixtures.
 - Touches attribute preservation, declaration indexing, trait implementation
-  validation, generated origin metadata, and diagnostics.
+  validation, trait-resolution fact indexing, generated origin metadata, and
+  diagnostics.
 - Does not require expression macro calls, self-hosted provider packages, or
   provider execution through `cosmo-jit-sys` in the first implementation.

--- a/openspec/changes/implement-cosmo0-derive-macros/specs/cosmo0-derive-macros/spec.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/specs/cosmo0-derive-macros/spec.md
@@ -59,6 +59,38 @@ name-resolution environment in the first slice.
 - **AND** the derive output supplies implementation evidence rather than a new
   binding
 
+### Requirement: Derive Contributes Trait Implementation Facts
+
+cosmo0 derive expansion SHALL contribute implementation facts that can be used
+by trait resolution and selector method-set resolution.
+
+#### Scenario: Generated impl fact satisfies trait use
+
+- **WHEN** `@derive(cli.Parser)` attaches an implementation for `Config`
+- **AND** later source requires `cli.Parser for Config`
+- **THEN** trait resolution waits for and consumes the derive-generated
+  `ImplFact(cli.Parser for Config)`
+- **AND** ordinary name resolution is not rerun
+
+#### Scenario: Method-like selector waits for method-set fact
+
+- **WHEN** a method-like selector such as `config.parse()` can be supplied by a
+  trait or extension implementation
+- **THEN** selector resolution waits for `TypeFact(config)`
+- **AND** it waits for the method-set fact for the receiver type and selector
+  name when trait or extension lookup can contribute candidates
+- **AND** derive-generated implementation facts are included in that method-set
+  fact
+
+#### Scenario: Derive input does not depend on trait resolution
+
+- **WHEN** cosmo0 builds derive input in the first derive slice
+- **THEN** the input may depend on declaration headers, selected trait identity,
+  target item identity, fields, variants, attributes, defaults, doc comments,
+  and admitted type facts
+- **AND** it does not depend on arbitrary body checking or trait-resolution
+  facts unless a later capability admits explicit inspector dependencies
+
 ### Requirement: Derive Input Uses Existing Item Facts
 
 cosmo0 SHALL build derive input from compiler-selected facts for the annotated

--- a/openspec/changes/implement-cosmo0-derive-macros/specs/cosmo0-derive-macros/spec.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/specs/cosmo0-derive-macros/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Gated Derive Macro Implementation
+
+cosmo0 SHALL provide a gated derive macro implementation slice for supported
+item declarations.
+
+#### Scenario: Derive profile is disabled
+
+- **WHEN** normal cosmo0 checking encounters `@derive(path)` without the derive
+  profile enabled
+- **THEN** cosmo0 preserves existing unsupported decorator behavior
+- **AND** it does not invoke a derive provider
+
+#### Scenario: Derive profile is enabled
+
+- **WHEN** the derive profile is enabled
+- **AND** a supported item declaration has `@derive(path)`
+- **THEN** cosmo0 resolves the derive provider and builds a stable derive input
+  record for that existing item
+
+### Requirement: Derive Output Is Trait Implementation Only
+
+cosmo0 SHALL restrict first-slice derive provider output to implementations of
+existing traits for existing target items.
+
+#### Scenario: Provider returns trait implementation
+
+- **WHEN** a derive provider returns an implementation record for an already
+  resolved trait and the annotated target item
+- **THEN** cosmo0 validates the implementation record
+- **AND** attaches the implementation when validation succeeds
+
+#### Scenario: Provider returns new declaration
+
+- **WHEN** a derive provider returns a new top-level declaration, member, field,
+  variant, alias, class, raw source text, or trusted typed expression artifact
+- **THEN** cosmo0 reports an invalid derive output diagnostic
+- **AND** the output does not enter later compiler phases
+
+### Requirement: Derive Does Not Affect Name Resolution
+
+cosmo0 derive expansion SHALL NOT add new bindings to the ordinary
+name-resolution environment in the first slice.
+
+#### Scenario: Generated trait impl does not create new name
+
+- **WHEN** `@derive(cli.Parser)` attaches an implementation for `Config`
+- **THEN** the ordinary declaration index remains unchanged
+- **AND** no new top-level function, static method, field, variant, or alias
+  becomes name-resolvable because of the derive output
+
+#### Scenario: Trait API uses existing names
+
+- **WHEN** later source uses parser behavior through a trait API such as
+  `cli.Parser.parse[Config](args)`
+- **THEN** `cli.Parser` and `Config` resolve through ordinary name resolution
+  before derive output is attached
+- **AND** the derive output supplies implementation evidence rather than a new
+  binding
+
+### Requirement: Derive Input Uses Existing Item Facts
+
+cosmo0 SHALL build derive input from compiler-selected facts for the annotated
+item.
+
+#### Scenario: Class metadata is supplied
+
+- **WHEN** a derive provider is invoked for a supported class declaration
+- **THEN** the input includes target identity, module path, visibility, source
+  spans, admitted type parameters, fields, defaults, attributes, doc comments,
+  and selected trait identity
+
+#### Scenario: Provider cannot mutate compiler state
+
+- **WHEN** a derive provider receives input
+- **THEN** it does not receive a mutable compiler module, typed tree patch
+  handle, lowering IR handle, backend output handle, or target runtime
+  executable handle
+
+### Requirement: Generated Implementation Validation
+
+cosmo0 SHALL validate generated implementation records before attachment.
+
+#### Scenario: Generated implementation satisfies trait
+
+- **WHEN** a generated implementation provides the members required by the
+  selected trait with accepted signatures and bodies
+- **THEN** cosmo0 accepts the implementation and records generated origin spans
+
+#### Scenario: Duplicate implementation is rejected
+
+- **WHEN** a generated implementation conflicts with an existing implementation
+  for the same trait and target item
+- **THEN** cosmo0 reports a duplicate derive implementation diagnostic
+- **AND** it does not silently replace the existing implementation
+
+### Requirement: Derive Diagnostics Are Deterministic
+
+cosmo0 SHALL report derive diagnostics and generated implementation summaries
+in deterministic order.
+
+#### Scenario: Invalid provider output is reported
+
+- **WHEN** a derive provider returns malformed implementation output
+- **THEN** cosmo0 reports an invalid derive output diagnostic at the derive
+  attribute and generated output origin
+
+#### Scenario: Repeated derive expansion is stable
+
+- **WHEN** the same derive fixture is checked twice with the same provider
+  registry and source inputs
+- **THEN** provider input, provider output, consumed attributes, generated
+  implementation summaries, and diagnostics are stable

--- a/openspec/changes/implement-cosmo0-derive-macros/tasks.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/tasks.md
@@ -1,0 +1,52 @@
+## 1. Attribute And Registry
+
+- [ ] 1.1 Preserve `@derive(path)` attributes on supported item declarations in
+  the gated derive profile.
+- [ ] 1.2 Add deterministic provider registry entries or compiler-hosted smoke
+  providers for derive fixtures.
+- [ ] 1.3 Resolve derive provider paths and selected trait paths through the
+  prefix-first resolver.
+- [ ] 1.4 Report missing, duplicate, disabled, or invalid provider diagnostics.
+
+## 2. Derive Input
+
+- [ ] 2.1 Build stable derive input records for already-indexed target items.
+- [ ] 2.2 Include target identity, item kind, module path, visibility, source
+  spans, admitted type parameters, fields, variants, defaults, attributes, and
+  doc comments.
+- [ ] 2.3 Include selected trait identity and trait requirement facts needed for
+  generated implementation validation.
+- [ ] 2.4 Add deterministic display or fixture serialization for derive input.
+
+## 3. Provider Output
+
+- [ ] 3.1 Accept only generated trait implementation records for the target item.
+- [ ] 3.2 Reject generated top-level declarations, members, fields, variants,
+  aliases, raw source text, and typed expression artifacts.
+- [ ] 3.3 Track consumed attributes and reject unconsumed macro-owned
+  attributes.
+- [ ] 3.4 Attach stable generated spans and derive origin metadata to generated
+  implementation records.
+
+## 4. Implementation Attachment
+
+- [ ] 4.1 Validate generated implementations through ordinary trait/impl
+  checking where possible.
+- [ ] 4.2 Reject duplicate or conflicting trait implementations for the same
+  target item.
+- [ ] 4.3 Attach valid generated implementations without adding names to the
+  ordinary declaration index.
+- [ ] 4.4 Add generated implementation summaries for tests and debugging.
+
+## 5. Fixtures And Validation
+
+- [ ] 5.1 Add a positive class derive fixture that makes the class satisfy an
+  existing trait through a generated implementation.
+- [ ] 5.2 Add coverage proving derive does not make a new method or top-level
+  name resolvable.
+- [ ] 5.3 Add unsupported target, unsupported trait, invalid output,
+  duplicate-impl, unresolved provider, and unconsumed attribute fixtures.
+- [ ] 5.4 Verify repeated runs produce stable provider input, output,
+  diagnostics, and summaries.
+- [ ] 5.5 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+  Scala sources are edited.

--- a/openspec/changes/implement-cosmo0-derive-macros/tasks.md
+++ b/openspec/changes/implement-cosmo0-derive-macros/tasks.md
@@ -34,9 +34,13 @@
   checking where possible.
 - [ ] 4.2 Reject duplicate or conflicting trait implementations for the same
   target item.
-- [ ] 4.3 Attach valid generated implementations without adding names to the
+- [ ] 4.3 Build an implementation fact index from source impls and
+  derive-generated implementation attachments.
+- [ ] 4.4 Attach valid generated implementations without adding names to the
   ordinary declaration index.
-- [ ] 4.4 Add generated implementation summaries for tests and debugging.
+- [ ] 4.5 Add method-set facts for receiver type and selector name where
+  derive-generated impls can contribute trait or extension candidates.
+- [ ] 4.6 Add generated implementation summaries for tests and debugging.
 
 ## 5. Fixtures And Validation
 
@@ -44,9 +48,13 @@
   existing trait through a generated implementation.
 - [ ] 5.2 Add coverage proving derive does not make a new method or top-level
   name resolvable.
-- [ ] 5.3 Add unsupported target, unsupported trait, invalid output,
+- [ ] 5.3 Add coverage proving trait uses wait for derive-generated impl facts
+  without rerunning ordinary name resolution.
+- [ ] 5.4 Add coverage proving method-like selector resolution waits for
+  method-set facts when trait or extension lookup can contribute candidates.
+- [ ] 5.5 Add unsupported target, unsupported trait, invalid output,
   duplicate-impl, unresolved provider, and unconsumed attribute fixtures.
-- [ ] 5.4 Verify repeated runs produce stable provider input, output,
+- [ ] 5.6 Verify repeated runs produce stable provider input, output,
   diagnostics, and summaries.
-- [ ] 5.5 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+- [ ] 5.7 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
   Scala sources are edited.

--- a/openspec/changes/implement-cosmo0-macro-calls/.openspec.yaml
+++ b/openspec/changes/implement-cosmo0-macro-calls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/implement-cosmo0-macro-calls/design.md
+++ b/openspec/changes/implement-cosmo0-macro-calls/design.md
@@ -1,0 +1,120 @@
+## Context
+
+The active macro-system proposal defines the public expression macro shape:
+
+```text
+@macro def provider(input: Expr[Untyped]): Expr[Untyped]
+```
+
+It also defines that provider input is a normalized payload such as
+`Expr.Args`, `Expr.Block`, or `Expr.Template`. This change implements a narrow
+expression macro-call slice so the compiler can prove target selection,
+payload construction, provider invocation, generated expression validation, and
+ordinary rechecking.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Support compiler-hosted expression macro providers in a gated profile.
+- Select free call, method-like, block-attached, and template macro sites
+  through resolved targets, not by string name.
+- Construct exactly one normalized payload for each accepted macro invocation.
+- Invoke providers through the macro function input/output boundary.
+- Validate provider output and splice generated `Expr[Untyped]` back into the
+  untyped expression tree for ordinary checking.
+- Emit deterministic diagnostics and expansion summaries for fixtures.
+
+**Non-Goals:**
+
+- Implement custom derive macros or declaration-generation workflows.
+- Load self-hosted macro provider packages.
+- Compile provider code through `cosmo-jit-sys` in this slice.
+- Expose typed expression trees to macro providers.
+- Support multiple provider payloads for one surface form such as
+  `A(1) { block }`.
+- Allow macro providers to mutate typed modules, lowering IR, backend output, or
+  compiler global state.
+
+## Decisions
+
+### Use Resolved Targets For Macro Classification
+
+Macro calls are classified only after name/member/tag resolution selects a macro
+provider. A free `@macro def expand(...)` does not match every `.expand`
+selector. Method-like macro calls wait for receiver facts before resolving the
+selected member or extension.
+
+Alternative considered: classify macros by syntax and callee text during
+parsing. That would make `value.expand(2)` unsound and conflict with ordinary
+member/extension lookup.
+
+### Keep One Payload Per Invocation
+
+Each accepted invocation passes exactly one normalized payload. Parenthesized
+argument syntax and method-like syntax become `Expr.Args`; attached blocks
+become `Expr.Block`; templates and interpolations become `Expr.Template`.
+
+Alternative considered: expose multiple provider parameters matching surface
+syntax. That would make the macro ABI depend on parser shapes and conflict with
+the current single-payload boundary.
+
+### Start With Compiler-Hosted Providers
+
+The first macro-call implementation should use registered compiler-hosted smoke
+providers. They still receive serialized macro input and return serialized
+macro output, but they avoid blocking this slice on self-hosted provider
+package compilation.
+
+Alternative considered: require JIT-backed self-hosted providers first. That
+would merge expression call implementation with macro package graph, provider
+ABI generation, and native execution work.
+
+### Recheck Generated Expressions
+
+Provider output is an untrusted `Expr[Untyped]`. The compiler validates the
+shape, assigns origin metadata, splices it into the untyped tree, and then runs
+ordinary resolution and type checking. The provider cannot return a trusted
+`TypedExpr`.
+
+Alternative considered: let providers return typed artifacts. That would bypass
+ordinary type checking and make macro output a type-system escape hatch.
+
+### Keep Expansion Deterministic
+
+Runnable macro invocations may be evaluated in parallel, but diagnostics,
+generated expression summaries, and reintegration order are sorted by stable
+invocation identity and source span.
+
+Alternative considered: preserve provider execution order as source semantics.
+That would conflict with the macro purity contract and limit parallel
+expansion.
+
+## Risks / Trade-offs
+
+- Macro calls can obscure generated code -> emit generated-expression summaries
+  for fixtures and attach origin spans.
+- Compiler-hosted providers can become permanent special cases -> require the
+  same input/output contract that future self-hosted providers must satisfy.
+- Method-like macro calls need receiver facts -> model unresolved selectors as
+  delayed obligations instead of forcing source-order checking.
+- Generated output can recursively introduce macros -> reject or bound recursive
+  expansion in this slice.
+
+## Migration Plan
+
+1. Land the macro-system documentation and compile-time evaluation boundary.
+2. Add compiler-hosted smoke providers and deterministic provider registry
+   diagnostics.
+3. Implement resolved-target macro classification for accepted call sites.
+4. Add payload construction for `Expr.Args`, `Expr.Block`, and `Expr.Template`.
+5. Invoke providers, validate generated expressions, and recheck output.
+6. Leave self-hosted provider packages and JIT-backed provider execution for a
+   later change.
+
+## Open Questions
+
+- Which smoke providers should be kept as long-term fixtures versus removed
+  once self-hosted providers exist.
+- Whether recursive macro expansion should be rejected outright in the first
+  implementation or allowed with a small deterministic expansion depth.

--- a/openspec/changes/implement-cosmo0-macro-calls/proposal.md
+++ b/openspec/changes/implement-cosmo0-macro-calls/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The macro-system design defines `Expr[Untyped]` and normalized macro payloads,
+but cosmo0 still needs an implementation slice that proves expression macro
+calls can be selected, invoked, and rechecked. A focused macro-call proposal
+keeps this separate from derive reflection and full self-hosted macro packages.
+
+## What Changes
+
+- Add a gated implementation slice for expression macro calls.
+- Resolve macro call targets through ordinary prefix-first name/member/tag
+  resolution rather than textual name matching.
+- Normalize accepted call-site syntax into one provider-facing payload:
+  `Expr.Args`, `Expr.Block`, or `Expr.Template`.
+- Invoke compiler-hosted smoke providers through the macro function
+  input/output boundary.
+- Validate generated `Expr[Untyped]` output and re-enter ordinary name
+  resolution and type checking.
+- Add deterministic diagnostics for disabled macro calls, unresolved providers,
+  invalid provider signatures, unsupported payload shapes, invalid output, and
+  expansion cycles.
+- Keep derive macros, self-hosted macro packages, provider package dependency
+  graphs, and arbitrary typed quotation out of scope for this slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo0-expression-macro-calls`: Defines expression macro call selection,
+  single-payload normalization, provider invocation, generated expression
+  validation, and diagnostics.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Depends on `introduce-cosmo0-macro-system` for the macro value boundary and
+  compile-time evaluation contract.
+- Uses the prefix-first resolution model documented in
+  `docs/cosmo/name-resolution.typ`.
+- Adds compiler-hosted smoke providers and fixtures before self-hosted provider
+  package execution exists.
+- Touches parser/elaborator preservation, resolver classification, macro
+  expansion, type checking reintegration, and diagnostics in implementation.

--- a/openspec/changes/implement-cosmo0-macro-calls/specs/cosmo0-expression-macro-calls/spec.md
+++ b/openspec/changes/implement-cosmo0-macro-calls/specs/cosmo0-expression-macro-calls/spec.md
@@ -33,9 +33,20 @@ selects a macro provider target.
 #### Scenario: Method-like selector resolves to macro provider
 
 - **WHEN** `value.expand(2)` is parsed
-- **AND** receiver facts make member, method, or extension lookup runnable
+- **AND** receiver type facts make member lookup runnable
+- **AND** method-set facts are available when trait or extension lookup can
+  contribute `.expand` candidates
 - **AND** that lookup resolves `.expand` to a macro provider
 - **THEN** cosmo0 classifies the expression as a macro invocation
+
+#### Scenario: Derive-generated impl contributes method-like macro provider
+
+- **WHEN** a derive-generated implementation contributes a trait or extension
+  method named `.expand` for the receiver type
+- **THEN** method-like macro classification waits for the corresponding
+  method-set fact
+- **AND** the selector is classified only after that fact resolves `.expand` to
+  a macro provider
 
 #### Scenario: Free macro does not match selector by text
 

--- a/openspec/changes/implement-cosmo0-macro-calls/specs/cosmo0-expression-macro-calls/spec.md
+++ b/openspec/changes/implement-cosmo0-macro-calls/specs/cosmo0-expression-macro-calls/spec.md
@@ -1,0 +1,123 @@
+## ADDED Requirements
+
+### Requirement: Gated Expression Macro Calls
+
+cosmo0 SHALL provide a gated expression macro-call implementation slice that is
+disabled by default until an accepted profile enables it.
+
+#### Scenario: Macro calls are disabled by default
+
+- **WHEN** normal cosmo0 checking encounters source that would be an expression
+  macro call in the gated profile
+- **THEN** cosmo0 preserves existing ordinary or unsupported behavior
+- **AND** it does not invoke a macro provider
+
+#### Scenario: Enabled profile invokes expression macro
+
+- **WHEN** the expression macro-call profile is enabled
+- **AND** an accepted call site resolves to a registered macro provider
+- **THEN** cosmo0 invokes the provider through the macro function input/output
+  boundary
+
+### Requirement: Resolved-Target Macro Classification
+
+cosmo0 SHALL classify expression macro calls only after ordinary resolution
+selects a macro provider target.
+
+#### Scenario: Free call resolves to macro provider
+
+- **WHEN** `vec(1, 2, 3)` is parsed
+- **AND** ordinary callee resolution selects `@macro def vec(...)`
+- **THEN** cosmo0 classifies the expression as a macro invocation
+
+#### Scenario: Method-like selector resolves to macro provider
+
+- **WHEN** `value.expand(2)` is parsed
+- **AND** receiver facts make member, method, or extension lookup runnable
+- **AND** that lookup resolves `.expand` to a macro provider
+- **THEN** cosmo0 classifies the expression as a macro invocation
+
+#### Scenario: Free macro does not match selector by text
+
+- **WHEN** a free `@macro def expand(...)` is in scope
+- **AND** `.expand` lookup on `value` does not resolve to that provider
+- **THEN** `value.expand(2)` is not classified as a macro by string name alone
+
+### Requirement: Single Normalized Payload
+
+Each expression macro invocation SHALL provide exactly one normalized
+`Expr[Untyped]` payload to the provider.
+
+#### Scenario: Parenthesized arguments produce Args
+
+- **WHEN** an accepted parenthesized call site selects a macro provider
+- **THEN** the provider receives one `Expr.Args` payload containing positional
+  and named arguments
+
+#### Scenario: Method-like syntax preserves receiver
+
+- **WHEN** an accepted method-like call site selects a macro provider
+- **THEN** the provider receives one `Expr.Args` payload with the receiver
+  preserved as an ordinary expression field
+
+#### Scenario: Attached block produces Block
+
+- **WHEN** an accepted block-attached site selects a macro provider
+- **THEN** the provider receives one `Expr.Block` payload
+
+#### Scenario: Template produces Template
+
+- **WHEN** an accepted template or interpolation site selects a macro provider
+- **THEN** the provider receives one `Expr.Template` payload containing
+  structured literal parts and expression holes
+
+#### Scenario: Multiple surface forms are not multiple provider arguments
+
+- **WHEN** source uses a form such as `A(1) { block }`
+- **THEN** cosmo0 does not pass two provider arguments for one macro invocation
+- **AND** the form is either rejected by the macro-call profile or handled by a
+  later capability
+
+### Requirement: Provider Output Re-enters Ordinary Checking
+
+Expression macro providers SHALL return untrusted generated `Expr[Untyped]`
+output that is validated and checked by ordinary compiler phases.
+
+#### Scenario: Generated expression is rechecked
+
+- **WHEN** an expression macro provider returns generated `Expr[Untyped]`
+  output
+- **THEN** cosmo0 validates the output shape and origin metadata
+- **AND** the generated expression re-enters ordinary name resolution and type
+  checking
+
+#### Scenario: Typed expression injection is rejected
+
+- **WHEN** a provider attempts to return a trusted typed expression artifact or
+  direct compiler mutation handle
+- **THEN** cosmo0 rejects the output with a macro diagnostic
+- **AND** the artifact does not enter the checked program
+
+### Requirement: Macro Call Diagnostics Are Deterministic
+
+cosmo0 SHALL report expression macro-call diagnostics in deterministic order.
+
+#### Scenario: Provider is missing
+
+- **WHEN** an enabled macro call resolves to a provider path that is not
+  registered or not available in the profile
+- **THEN** cosmo0 reports an unresolved or disabled macro provider diagnostic
+  at the selected macro site
+
+#### Scenario: Provider output is invalid
+
+- **WHEN** a provider returns malformed expression output
+- **THEN** cosmo0 reports an invalid macro output diagnostic
+- **AND** the malformed output is not spliced into the source tree
+
+#### Scenario: Repeated expansion is stable
+
+- **WHEN** the same enabled macro-call fixture is checked twice with the same
+  provider registry and source inputs
+- **THEN** macro invocation order, provider inputs, generated expression
+  summaries, diagnostics, and checked output are stable

--- a/openspec/changes/implement-cosmo0-macro-calls/tasks.md
+++ b/openspec/changes/implement-cosmo0-macro-calls/tasks.md
@@ -1,0 +1,50 @@
+## 1. Provider Registry
+
+- [ ] 1.1 Add a gated compiler-hosted expression macro provider registry for
+  smoke providers.
+- [ ] 1.2 Validate provider signatures as
+  `@macro def provider(input: Expr[Untyped]): Expr[Untyped]`.
+- [ ] 1.3 Add deterministic diagnostics for missing, duplicate, disabled, and
+  invalid provider entries.
+
+## 2. Macro Classification
+
+- [ ] 2.1 Classify free call macro sites only when ordinary callee resolution
+  selects a macro provider.
+- [ ] 2.2 Classify method-like macro sites only after receiver facts make
+  member, method, or extension lookup runnable.
+- [ ] 2.3 Classify block-attached sites only after target lookup selects a
+  macro provider.
+- [ ] 2.4 Classify template/interpolation sites only after tag lookup selects a
+  macro provider.
+- [ ] 2.5 Reject textual macro matching and unsupported payload shapes with
+  stable diagnostics.
+
+## 3. Payload Construction
+
+- [ ] 3.1 Build `Expr.Args` payloads for parenthesized argument syntax.
+- [ ] 3.2 Preserve receivers in `Expr.Args` for method-like syntax.
+- [ ] 3.3 Build `Expr.Block` payloads for accepted block-attached syntax.
+- [ ] 3.4 Build `Expr.Template` payloads for accepted template/interpolation
+  syntax.
+- [ ] 3.5 Enforce the single-payload rule for forms such as `A(1) { block }`.
+
+## 4. Provider Invocation
+
+- [ ] 4.1 Serialize macro function input with provider identity, source package
+  identity, invocation identity, payload, spans, and origin metadata.
+- [ ] 4.2 Invoke compiler-hosted smoke providers through the same input/output
+  protocol future providers must use.
+- [ ] 4.3 Validate provider diagnostics and generated `Expr[Untyped]` output.
+- [ ] 4.4 Assign stable generated origins before reintegrating output.
+
+## 5. Rechecking And Diagnostics
+
+- [ ] 5.1 Splice generated expression output back into the untyped expression
+  tree and run ordinary resolution/type checking.
+- [ ] 5.2 Reject typed-expression injection or direct compiler mutation attempts.
+- [ ] 5.3 Add generated-expression summaries for fixtures.
+- [ ] 5.4 Add coverage for disabled macro calls, unresolved providers, invalid
+  output, expansion recursion, and deterministic ordering.
+- [ ] 5.5 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+  Scala sources are edited.

--- a/openspec/changes/implement-cosmo0-macro-calls/tasks.md
+++ b/openspec/changes/implement-cosmo0-macro-calls/tasks.md
@@ -11,13 +11,15 @@
 
 - [ ] 2.1 Classify free call macro sites only when ordinary callee resolution
   selects a macro provider.
-- [ ] 2.2 Classify method-like macro sites only after receiver facts make
-  member, method, or extension lookup runnable.
-- [ ] 2.3 Classify block-attached sites only after target lookup selects a
+- [ ] 2.2 Classify method-like macro sites only after receiver type facts make
+  inherent member lookup runnable.
+- [ ] 2.3 Wait for method-set facts keyed by receiver type and selector name
+  when trait or extension lookup can contribute method-like macro candidates.
+- [ ] 2.4 Classify block-attached sites only after target lookup selects a
   macro provider.
-- [ ] 2.4 Classify template/interpolation sites only after tag lookup selects a
+- [ ] 2.5 Classify template/interpolation sites only after tag lookup selects a
   macro provider.
-- [ ] 2.5 Reject textual macro matching and unsupported payload shapes with
+- [ ] 2.6 Reject textual macro matching and unsupported payload shapes with
   stable diagnostics.
 
 ## 3. Payload Construction

--- a/openspec/changes/introduce-cosmo0-macro-system/design.md
+++ b/openspec/changes/introduce-cosmo0-macro-system/design.md
@@ -16,13 +16,13 @@ schema, RPC, and test-discovery libraries.
 
 **Goals:**
 
-- Add a macro expansion phase that can generate ordinary cosmo0 declarations.
+- Add a macro expansion phase that can generate validated cosmo0 artifacts.
 - Support custom derive macros on classes and sum types.
 - Preserve macro-owned attributes on declarations, fields, variants, and
   functions long enough for macro providers to inspect them.
 - Provide typed reflection metadata for derive providers.
 - Keep generated output deterministic and reviewable.
-- Give generated declarations stable names and diagnostics with source spans.
+- Give generated artifacts stable origins and diagnostics with source spans.
 - Allow a compiler-hosted macro provider implementation as the first bridge.
 - Keep the macro contract compatible with later self-hosted macro packages.
 - Define how macro providers are computed instead of leaving provider execution
@@ -38,6 +38,8 @@ schema, RPC, and test-discovery libraries.
 
 - Add arbitrary expression quotation or function-like expression macros in the
   first slice.
+- Let first-slice derive macros add new top-level declarations, members, fields,
+  variants, classes, aliases, or ordinary name-resolution bindings.
 - Define macro semantics where output depends on ambient filesystem, command,
   network, time, randomness, or runtime effects.
 - Require all macro providers to be written in Cosmo before the macro execution
@@ -64,14 +66,19 @@ attributes. They should not need fully checked function bodies.
 Alternative considered: run macros directly during parsing. That cannot support
 type-aware derives such as CLI value parsing or future serialization derives.
 
-Alternative considered: run macros after complete type checking. That makes
-generated methods unavailable to name resolution and type checking of user code.
+Alternative considered: run all macros after complete type checking. That makes
+generated artifacts unavailable to later checking. First-slice derive output is
+more constrained: it attaches trait implementations without adding new names,
+so it can run after declaration indexing without forcing ordinary name
+resolution to be rebuilt.
 
-### Treat Derived Code As Ordinary Generated Declarations
+### Treat Generated Output As Structured Artifacts
 
-A macro provider should return generated declarations plus diagnostics, not a
-private backend hook. The generated declarations then enter the same
-resolution, checking, lowering, and backend paths as hand-written declarations.
+A macro provider should return structured generated artifacts plus diagnostics,
+not a private backend hook. General declaration macros may return generated
+declarations in a later slice. First-slice derive providers return trait
+implementation attachments that enter ordinary impl validation without changing
+the declaration index.
 
 Alternative considered: special-case each derive in the compiler. That would
 ship features quickly but would make every library derive a compiler feature.
@@ -90,9 +97,10 @@ macro providers re-parse syntax and would produce weaker diagnostics.
 ### Use Conservative Hygiene
 
 Generated helper names should be fresh by default and should not shadow user
-names silently. When a macro intentionally exposes a generated member such as
-`Cli::parse`, the provider must declare that public output and conflict with
-user declarations deterministically.
+names silently. First-slice derive macros avoid this issue by not exposing new
+members or top-level declarations at all. Later declaration macros that expose
+public generated names must declare that output and conflict with user
+declarations deterministically.
 
 Alternative considered: let generated text behave exactly like pasted source.
 That is easy to implement but quickly creates fragile name-capture behavior.
@@ -101,8 +109,8 @@ That is easy to implement but quickly creates fragile name-capture behavior.
 
 The first implementation may register macro providers in Scala-side cosmo0
 infrastructure. The provider contract should still be specified in source terms:
-metadata in, generated declarations and diagnostics out. This lets the CLI
-derive prove the macro system before self-hosted macro packages exist.
+metadata in, generated artifacts and diagnostics out. This lets the CLI derive
+prove the macro system before self-hosted macro packages exist.
 
 Alternative considered: require self-hosted Cosmo macro execution first. That
 would make the CLI library depend on a larger compiler bootstrapping problem.

--- a/openspec/changes/introduce-cosmo0-macro-system/proposal.md
+++ b/openspec/changes/introduce-cosmo0-macro-system/proposal.md
@@ -9,16 +9,19 @@ remain outside the accepted source boundary.
 ## What Changes
 
 - Introduce a deterministic cosmo0 macro expansion phase for source-level
-  generated declarations.
+  generated artifacts.
 - Add accepted decorator storage for macro-owned declaration, field, variant,
   and function metadata instead of rejecting every non-extern decorator.
 - Add custom derive support through `@derive(path)` on class-like declarations
-  and sum types.
+  and sum types, with the first derive slice restricted to attaching existing
+  trait implementations to existing items.
 - Add the compile-time reflection metadata needed by derive macros: type name,
   fields, field types, variants, defaults, attributes, doc comments, visibility,
   and source spans.
 - Define macro hygiene, generated-name behavior, generated span reporting, and
   duplicate/conflict diagnostics.
+- Define that first-slice derive macros do not introduce new ordinary
+  name-resolution bindings.
 - Define a conservative macro execution boundary that is deterministic and does
   not grant arbitrary filesystem, command, network, or runtime side effects.
 - Specify macro functions as pure computations over cosmo0-provided inputs; the
@@ -38,7 +41,7 @@ remain outside the accepted source boundary.
 ### New Capabilities
 
 - `cosmo0-macro-expansion`: Defines macro expansion phases, decorator
-  preservation, generated declarations, hygiene, deterministic expansion, and
+  preservation, generated artifacts, hygiene, deterministic expansion, and
   diagnostics.
 - `cosmo0-derived-reflection`: Defines the reflection metadata and derive macro
   provider contract used by source-level `@derive(...)` macros.
@@ -56,7 +59,7 @@ remain outside the accepted source boundary.
 - Parser and elaborator must preserve accepted macro decorators and reject only
   invalid or unsupported macro shapes.
 - Package checking needs a macro expansion stage before ordinary type checking
-  and lowering consume generated declarations.
+  and lowering consume generated artifacts.
 - Name resolution and diagnostics need generated-span and generated-name support.
 - The first implementation may host macro providers in compiler infrastructure
   before self-hosted macro packages are available.

--- a/openspec/changes/introduce-cosmo0-macro-system/specs/cosmo0-derived-reflection/spec.md
+++ b/openspec/changes/introduce-cosmo0-macro-system/specs/cosmo0-derived-reflection/spec.md
@@ -18,24 +18,25 @@ metadata for the annotated declaration.
 ### Requirement: Derive Macro Contract
 
 cosmo0 SHALL invoke `@derive(path)` providers with a stable metadata input and
-SHALL accept only provider outputs that are valid generated declarations or
-diagnostics.
+SHALL accept only provider outputs that are valid generated trait
+implementation attachments or diagnostics in the first derive slice.
 
-#### Scenario: Provider generates static methods
+#### Scenario: Provider generates trait implementation
 
-- **WHEN** a derive provider returns a generated static method for the target type
-- **THEN** cosmo0 attaches the method to the target type during generated declaration integration
+- **WHEN** a derive provider returns a generated implementation for an existing trait and the target type
+- **THEN** cosmo0 validates and attaches the implementation to the target type
+- **AND** the derive output does not add a new top-level name or target member to ordinary name resolution
 
 #### Scenario: Provider output is invalid
 
-- **WHEN** a derive provider returns malformed generated declarations or unsupported generated syntax
+- **WHEN** a derive provider returns malformed implementation output or unsupported generated syntax
 - **THEN** macro expansion reports an invalid provider output diagnostic
 - **AND** the malformed output does not enter later compiler phases
 
 #### Scenario: Provider cannot synthesize trusted typed expressions
 
 - **WHEN** a derive provider emits generated code for the target type
-- **THEN** it emits generated declarations containing untyped `Expr[Untyped]` source-expression fragments that are checked later
+- **THEN** it emits generated implementation records containing untyped `Expr[Untyped]` source-expression fragments that are checked later
 - **AND** it cannot directly inject trusted typed expression artifacts into the checked program
 
 ### Requirement: Macro Attribute Consumption
@@ -61,15 +62,15 @@ without requiring runtime type metadata in compiled programs.
 #### Scenario: Generated program does not carry reflection tables
 
 - **WHEN** a package uses a derive macro that inspects field metadata at compile time
-- **THEN** the emitted runtime program contains only the generated declarations needed by the package
+- **THEN** the emitted runtime program contains only the generated trait implementations needed by the package
 - **AND** it does not include general-purpose reflection tables unless a separate runtime reflection capability is selected
 
 ### Requirement: Generated Source Inspection
 
 cosmo0 SHALL provide deterministic inspection output for macro-generated
-declarations for tests and debugging.
+derive implementations for tests and debugging.
 
-#### Scenario: Expansion summary lists generated declarations
+#### Scenario: Expansion summary lists generated implementations
 
 - **WHEN** a package with derive macros is checked with generated-source inspection enabled
-- **THEN** the output lists each macro invocation, consumed attributes, generated public declarations, generated private helpers, and originating source spans in deterministic order
+- **THEN** the output lists each macro invocation, consumed attributes, generated trait implementations, generated private implementation helpers, and originating source spans in deterministic order

--- a/openspec/changes/introduce-cosmo0-macro-system/specs/cosmo0-macro-expansion/spec.md
+++ b/openspec/changes/introduce-cosmo0-macro-system/specs/cosmo0-macro-expansion/spec.md
@@ -3,19 +3,19 @@
 ### Requirement: Deterministic Macro Expansion Phase
 
 cosmo0 SHALL provide a deterministic macro expansion phase that turns accepted
-macro decorators into ordinary generated declarations before type checking and
-lowering depend on those declarations.
+macro decorators into validated generated artifacts before type checking and
+lowering depend on those artifacts.
 
-#### Scenario: Derive expands before generated method use
+#### Scenario: Derive attaches trait implementation before trait use
 
-- **WHEN** a class annotated with `@derive(example.MakeParse)` generates a public static `parse` method
-- **THEN** later source in the same package can resolve and type-check calls to that generated method
-- **AND** the generated method enters ordinary lowering and backend emission
+- **WHEN** a class annotated with `@derive(example.MakeParse)` generates an implementation of an existing trait for that class
+- **THEN** later source in the same package can type-check uses that require the trait implementation
+- **AND** the derive output does not add a new top-level name or target member to ordinary name resolution
 
 #### Scenario: Repeated expansion is stable
 
 - **WHEN** the same package is checked twice with the same macro providers and source inputs
-- **THEN** macro expansion produces the same generated declarations, diagnostics, and generated-source summary order
+- **THEN** macro expansion produces the same generated artifacts, diagnostics, and generated-source summary order
 
 ### Requirement: Macro Attribute Preservation
 
@@ -31,7 +31,7 @@ shapes until the macro expansion phase consumes or rejects them.
 
 - **WHEN** a macro attribute uses an unsupported argument shape for the selected provider
 - **THEN** expansion reports a macro diagnostic at the attribute span
-- **AND** generated declarations for that macro invocation are not accepted
+- **AND** generated artifacts for that macro invocation are not accepted
 
 ### Requirement: Macro Provider Registry
 
@@ -63,8 +63,8 @@ instead of by executing arbitrary target program code.
 #### Scenario: Provider returns bounded macro output
 
 - **WHEN** a macro provider finishes evaluation
-- **THEN** it returns generated declarations, consumed attributes, diagnostics, and optional generated-source summary data
-- **AND** later compiler phases accept only the generated declarations that pass ordinary validation
+- **THEN** it returns generated artifacts, consumed attributes, diagnostics, and optional generated-source summary data
+- **AND** later compiler phases accept only generated artifacts that pass ordinary validation
 
 #### Scenario: Provider attempts target runtime execution
 
@@ -80,7 +80,7 @@ input supplied by cosmo0.
 #### Scenario: Compiler reruns a macro function
 
 - **WHEN** cosmo0 evaluates the same macro function repeatedly with the same provider identity, serialized macro function input, C++ imports, provider source, target settings, and toolchain identity
-- **THEN** each evaluation is required to produce the same generated declarations, expression output, consumed attributes, diagnostics, and generated-source summary data
+- **THEN** each evaluation is required to produce the same generated artifacts, expression output, consumed attributes, diagnostics, and generated-source summary data
 - **AND** cosmo0 may cache, discard, rerun, or compare macro function evaluations
 
 #### Scenario: Macro function depends on hidden state
@@ -99,6 +99,13 @@ generated declaration model rather than unvalidated source text.
 - **WHEN** a macro provider generates a helper method
 - **THEN** the provider output represents that method as a generated declaration tree with generated spans and origin spans
 - **AND** cosmo0 validates the tree before integrating it into the package
+
+#### Scenario: Derive provider returns implementation attachment
+
+- **WHEN** a derive provider generates behavior for a target item in the first derive slice
+- **THEN** the provider output represents that behavior as a generated trait implementation attachment
+- **AND** cosmo0 validates the attachment before integrating it into the package
+- **AND** the attachment does not introduce a new ordinary name-resolution binding
 
 #### Scenario: Raw generated source text is rejected as primary output
 

--- a/openspec/changes/introduce-cosmo0-macro-system/tasks.md
+++ b/openspec/changes/introduce-cosmo0-macro-system/tasks.md
@@ -4,7 +4,9 @@
 - [ ] 1.2 Add `docs/cosmo/compile-time-evaluation.typ` covering macro function input/output records, macro output purity, full C++ compile-time execution through `cosmo-jit-sys`, and target runtime separation.
 - [ ] 1.3 Link macro documentation from `docs/cosmo/spec.typ`, include it in the website book summary, and update the docs validation script.
 - [ ] 1.4 Add examples for `@derive(...)`, declaration attributes, expression macros, generated output, and unsupported macro shapes.
-- [ ] 1.5 Document the first compiler-hosted provider boundary and the future self-hosted provider path.
+- [ ] 1.5 Document that first-slice derive output attaches trait implementations
+  without adding new ordinary name-resolution bindings.
+- [ ] 1.6 Document the first compiler-hosted provider boundary and the future self-hosted provider path.
 
 ## 2. Syntax And Attribute Preservation
 
@@ -32,8 +34,8 @@
 
 - [ ] 5.1 Add a package pipeline phase that runs after declaration-shape collection and before body checking/lowering.
 - [ ] 5.2 Add a macro provider registry keyed by resolved derive/provider paths.
-- [ ] 5.3 Define the provider input/output contract: serialized macro function input in, generated declaration trees and diagnostics out.
-- [ ] 5.4 Integrate generated declarations into name resolution and type checking.
+- [ ] 5.3 Define the provider input/output contract: serialized macro function input in, generated artifacts and diagnostics out.
+- [ ] 5.4 Integrate first-slice derive implementation attachments into trait checking without rebuilding ordinary name resolution.
 - [ ] 5.5 Add generated-span plumbing for diagnostics and generated-source summaries.
 
 ## 6. Compile-Time Evaluation Boundary
@@ -55,7 +57,7 @@
 
 ## 8. Derive Provider Smoke Path
 
-- [ ] 8.1 Implement a minimal compiler-hosted derive provider that generates a simple static method from reflected fields.
-- [ ] 8.2 Add positive tests proving user code can call the generated method.
+- [ ] 8.1 Implement a minimal compiler-hosted derive provider that generates a simple trait implementation from reflected fields.
+- [ ] 8.2 Add positive tests proving user code can use the generated trait implementation through an already-resolved trait API.
 - [ ] 8.3 Add negative tests for unresolved derive provider paths and unsupported target types.
 - [ ] 8.4 Add end-to-end tests that keep generated code in ordinary checking and C++ backend paths.

--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/.openspec.yaml
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/README.md
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/README.md
@@ -1,0 +1,3 @@
+# probe-cosmo0-cte-with-cosmo-jit-sys
+
+Probe minimal cosmo0 compile-time evaluation through cosmo-jit-sys without full macro-system integration.

--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/design.md
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/design.md
@@ -1,0 +1,99 @@
+## Context
+
+`docs/cosmo/compile-time-evaluation.typ` defines the long-term compile-time
+evaluation model around macro function input/output records and C++ execution
+through `cosmo-jit-sys`. The active macro-system proposal owns that full model.
+This change is narrower: after `cosmo-jit-sys` exists, prove that cosmo0 can
+make a structured JIT request during compilation and consume a structured
+result.
+
+The chosen smoke input is intentionally small: `type x = 1 + 1`. It exercises
+the "compile-time value affects type-level declaration" path without requiring
+the full macro protocol.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a gated compile-time evaluation probe in cosmo0.
+- Lower the smoke expression `1 + 1` into a `cosmo-jit-sys` request.
+- Verify that successful JIT execution makes `type x = 1 + 1` resolve to `2`
+  in the probe result.
+- Return stable diagnostics when the JIT dependency is disabled, unavailable,
+  or returns a failing result.
+
+**Non-Goals:**
+
+- Accept arbitrary type-level arithmetic in normal cosmo0 programs.
+- Implement macro providers, macro function records, reflection metadata,
+  hygiene, generated declarations, or generated expression validation.
+- Replace the existing type checker with a JIT-driven evaluator.
+- Require the target package executable to be built before compile-time
+  evaluation.
+
+## Decisions
+
+### Gate The Probe Explicitly
+
+The probe should be enabled only through a test harness, feature flag, or
+driver option. Without that opt-in, normal cosmo0 behavior remains unchanged and
+unsupported compile-time expression forms continue to produce existing
+diagnostics.
+
+Alternative considered: immediately make `type x = 1 + 1` accepted source.
+That would silently add source-facing type-level arithmetic before the full type
+and macro semantics are ready.
+
+### Use A Structured Request Instead Of Shelling Out From The Typer
+
+The cosmo0 side should call a small adapter that models a `CosmoJitRequest` and
+`CosmoJitResult` shape, even if the first implementation is test-only. The
+adapter should pass provider identity, source identity, snippet source, target
+settings, and toolchain identity through `cosmo-jit-sys`.
+
+Alternative considered: invoke `clang-repl` directly from a Scala test. That
+would prove less than the desired compiler boundary because it bypasses
+`cosmo-jit-sys` and would not exercise the future macro execution substrate.
+
+### Restrict The Recognized Expression Shape
+
+The implementation should recognize only the literal smoke shape needed for the
+test: one integer addition in a type alias initializer. Anything else remains
+unsupported by this probe and is left to the macro-system change.
+
+Alternative considered: add a small interpreter for integer expressions. That
+would conflict with the documentation rule that compile-time C++ capability
+uses `cosmo-jit-sys`, and it would distract from proving the JIT boundary.
+
+## Risks / Trade-offs
+
+Probe code may become accidental production semantics -> Keep it gated, name it
+as a probe in APIs and diagnostics, and add non-goal comments around the
+recognizer.
+
+Native JIT availability can make tests platform-sensitive -> Split pure adapter
+tests from toolchain-backed integration tests and skip or diagnose the native
+smoke when clang-repl is unavailable.
+
+The smoke input looks like a general language feature -> Documentation and
+diagnostics must state that this change does not admit general type-level
+arithmetic.
+
+## Migration Plan
+
+1. Land `add-cosmo-jit-sys-clang-repl-poc`.
+2. Add a cosmo0 JIT adapter that consumes the minimal `cosmo-jit-sys` C ABI or
+   a test double with the same request/result shape.
+3. Add the gated recognizer for `type x = 1 + 1`.
+4. Add tests for successful result `2`, disabled JIT diagnostics, and failing
+   JIT diagnostics.
+5. Leave the probe isolated so `introduce-cosmo0-macro-system` can replace or
+   absorb it when implementing the full compile-time evaluation boundary.
+
+## Open Questions
+
+- Whether the probe should live in the Scala.js compiler package, a Node driver
+  harness, or a native-only integration test until compiler native FFI is
+  settled.
+- Whether the smoke result should be represented as an integer type-level value
+  placeholder or as a test-only alias evaluation record.

--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/proposal.md
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+After `cosmo-jit-sys` proves clang-repl execution, cosmo0 needs a small
+end-to-end probe showing that the compiler can route a compile-time evaluation
+request through that substrate. The probe should validate the integration
+boundary without preempting the full macro system design.
+
+## What Changes
+
+- Add an experimental, gated cosmo0 compile-time evaluation probe that depends
+  on `cosmo-jit-sys`.
+- Recognize a deliberately tiny smoke input, `type x = 1 + 1`, and route its
+  arithmetic through a structured JIT request.
+- Assert that the probe resolves the alias to the computed value `2` and
+  reports stable diagnostics when JIT execution is unavailable or fails.
+- Keep general type-level arithmetic, macro provider execution, reflection,
+  hygiene, generated declarations, and full macro output validation out of
+  scope for this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo0-cte-jit-probe`: Defines the temporary, gated cosmo0 compile-time
+  evaluation smoke integration through `cosmo-jit-sys`.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Depends on `add-cosmo-jit-sys-clang-repl-poc`.
+- Adds a small cosmo0 compile/checker or driver integration point guarded as an
+  experiment.
+- Adds a focused test or fixture for `type x = 1 + 1`.
+- Does not change the full `cosmo0-compile-time-evaluation` macro contract in
+  `introduce-cosmo0-macro-system`.

--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/specs/cosmo0-cte-jit-probe/spec.md
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/specs/cosmo0-cte-jit-probe/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Gated Compile-Time Evaluation Probe
+
+cosmo0 SHALL provide an experimental compile-time evaluation probe that is
+disabled by default and enabled only for focused tests or explicit developer
+opt-in.
+
+#### Scenario: Probe is disabled by default
+
+- **WHEN** a normal cosmo0 compile or check run encounters `type x = 1 + 1`
+  without the probe enabled
+- **THEN** cosmo0 preserves the existing unsupported type-alias target behavior
+- **AND** it does not route the expression through `cosmo-jit-sys`
+
+#### Scenario: Probe is enabled explicitly
+
+- **WHEN** the compile-time evaluation probe is enabled for a focused test or
+  developer run
+- **AND** the source contains the smoke declaration `type x = 1 + 1`
+- **THEN** cosmo0 identifies the declaration as a probe-supported compile-time
+  evaluation request
+- **AND** unsupported compile-time expression shapes remain outside the probe
+
+### Requirement: cosmo-jit-sys Request Boundary
+
+The probe SHALL route the smoke expression through `cosmo-jit-sys` using a
+structured request/result boundary rather than evaluating the arithmetic in a
+Scala, JavaScript, or handwritten host interpreter.
+
+#### Scenario: Smoke expression is evaluated by JIT
+
+- **WHEN** the enabled probe evaluates `type x = 1 + 1`
+- **THEN** cosmo0 sends a structured JIT request to `cosmo-jit-sys` containing
+  the source identity, declaration identity, expression payload, target
+  settings, and toolchain identity needed by the smoke
+- **AND** `cosmo-jit-sys` executes a C++ snippet through clang-repl
+- **AND** cosmo0 consumes the structured result from `cosmo-jit-sys`
+
+#### Scenario: Host approximation is not used
+
+- **WHEN** the probe computes the smoke result
+- **THEN** it does not use a JavaScript arithmetic evaluator, a Scala-only
+  constant folder, or a handwritten C++ semantic approximation for the accepted
+  probe path
+
+### Requirement: Smoke Alias Result
+
+The probe SHALL make the smoke declaration observable as the computed
+compile-time value `2` in the probe result.
+
+#### Scenario: type x equals two
+
+- **WHEN** the enabled probe checks a module containing `type x = 1 + 1`
+- **AND** `cosmo-jit-sys` returns a successful integer result
+- **THEN** the probe records that `x` evaluated to `2`
+- **AND** the check reports no compile-time evaluation diagnostic for that
+  declaration
+
+#### Scenario: Non-smoke declarations are not accepted
+
+- **WHEN** the enabled probe encounters a compile-time expression other than
+  the supported integer addition smoke shape
+- **THEN** cosmo0 reports that the expression is outside the temporary
+  compile-time evaluation probe
+- **AND** it does not treat the expression as accepted full compile-time
+  evaluation
+
+### Requirement: JIT Failure Diagnostics
+
+The probe SHALL report stable diagnostics when `cosmo-jit-sys` is disabled,
+unavailable, or returns a failed execution result.
+
+#### Scenario: JIT dependency unavailable
+
+- **WHEN** the probe is enabled but `cosmo-jit-sys` cannot be loaded or
+  configured
+- **THEN** cosmo0 reports a diagnostic with code
+  `cosmo0.cte-jit-probe.unavailable`
+- **AND** the diagnostic includes the source span of the compile-time
+  declaration being evaluated
+
+#### Scenario: JIT execution fails
+
+- **WHEN** `cosmo-jit-sys` returns a failed status for the smoke request
+- **THEN** cosmo0 reports a diagnostic with code
+  `cosmo0.cte-jit-probe.execution-failed`
+- **AND** it includes the structured JIT diagnostic summary without exposing
+  Clang or LLVM implementation objects

--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/tasks.md
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-jit-sys/tasks.md
@@ -1,0 +1,46 @@
+## 1. Preconditions
+
+- [ ] 1.1 Complete or depend on `add-cosmo-jit-sys-clang-repl-poc` so a
+  `cosmo-jit-sys` smoke API is available.
+- [ ] 1.2 Decide whether the probe runs from a Scala.js compiler adapter, a Node
+  driver harness, or a native integration test while native FFI boundaries are
+  still limited.
+
+## 2. Probe Boundary
+
+- [ ] 2.1 Add a minimal `CosmoJitRequest`/`CosmoJitResult` adapter for the probe
+  that carries source identity, declaration identity, expression payload, target
+  settings, toolchain identity, diagnostics, and integer smoke result.
+- [ ] 2.2 Add an explicit feature flag, test option, or harness-only entry point
+  that keeps the compile-time evaluation probe disabled by default.
+- [ ] 2.3 Route the enabled probe through `cosmo-jit-sys` rather than a
+  JavaScript, Scala, or handwritten arithmetic evaluator.
+
+## 3. Smoke Recognition
+
+- [ ] 3.1 Recognize only the top-level smoke declaration `type x = 1 + 1` when
+  the probe is enabled.
+- [ ] 3.2 Convert the recognized smoke expression into the C++ snippet or
+  payload expected by `cosmo-jit-sys`.
+- [ ] 3.3 Record successful result `2` as a probe result for alias `x` without
+  treating arbitrary type-level arithmetic as accepted source behavior.
+
+## 4. Diagnostics
+
+- [ ] 4.1 Preserve the existing unsupported type-alias behavior when the probe
+  is disabled.
+- [ ] 4.2 Add `cosmo0.cte-jit-probe.unavailable` when the enabled probe cannot
+  load or configure `cosmo-jit-sys`.
+- [ ] 4.3 Add `cosmo0.cte-jit-probe.execution-failed` when `cosmo-jit-sys`
+  returns a failed execution result.
+- [ ] 4.4 Add a diagnostic for expressions outside the temporary probe shape.
+
+## 5. Validation
+
+- [ ] 5.1 Add a focused test or fixture proving enabled `type x = 1 + 1`
+  produces probe result `2`.
+- [ ] 5.2 Add disabled-probe coverage proving normal cosmo0 behavior is
+  unchanged.
+- [ ] 5.3 Add failure-path coverage for unavailable JIT and failed JIT result.
+- [ ] 5.4 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+  Scala sources are edited.

--- a/openspec/changes/validate-cosmo0-cte-function-call-graph/.openspec.yaml
+++ b/openspec/changes/validate-cosmo0-cte-function-call-graph/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/validate-cosmo0-cte-function-call-graph/design.md
+++ b/openspec/changes/validate-cosmo0-cte-function-call-graph/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`probe-cosmo0-cte-with-cosmo-jit-sys` validates one tiny request:
+`type x = 1 + 1`. That proves the CTE/JIT boundary, but it does not prove the
+next scheduling problem: compile-time execution often depends on helper
+functions, and those helpers may appear before or after the requesting
+declaration in source order. Macro providers will also need recursive helpers
+and mutually recursive helper groups.
+
+This change validates the scheduler and execution shape without turning cosmo0
+into a full constant-evaluation language.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Build a deterministic graph of compile-time callable declarations.
+- Resolve call heads early and delay tail/callee resolution until required facts
+  are available.
+- Compile independent callable groups in dependency order.
+- Check each callable header/body at most once per validation plan; repeated
+  call sites reuse the same callable facts and artifact.
+- Compile recursive callable SCCs as one host artifact when they are otherwise
+  supported by the validation profile.
+- Execute selected constant function call entries through `cosmo-jit-sys` or a
+  request-compatible test double.
+- Prove stable diagnostics for unsupported and failing call graph shapes.
+
+**Non-Goals:**
+
+- Define production `const def` syntax or general constant evaluation semantics.
+- Interpret function bodies in Scala or JavaScript.
+- Add full macro provider execution, reflection metadata, generated
+  declarations, or expression macro expansion.
+- Accept arbitrary recursive compile-time programs without resource bounds.
+- Change ordinary runtime function checking or lowering behavior.
+
+## Decisions
+
+### Keep The Feature Gated
+
+The validation mode should be enabled only by tests, a developer flag, or a
+fixture harness. Without the gate, source that looks like compile-time function
+evaluation continues to follow existing cosmo0 behavior.
+
+Alternative considered: make constant function calls part of normal cosmo0
+immediately. That would expose source-facing semantics before the macro
+execution and resource-bound rules are settled.
+
+### Plan From Declaration Headers And Prefix Resolution
+
+The planner first indexes declaration headers and resolves the leading segment
+of call expressions. It records delayed call obligations for suffixes or
+overload-like cases that need more facts. This index makes source order a
+tie-breaker, not a reason to recheck the same helper once for each caller.
+
+For the validation slice, a call dependency edge points from the caller artifact
+to the callee artifact after the callee head resolves to a compile-time
+callable. Unknown heads and unsupported call shapes produce deterministic
+diagnostics. A callable body is checked once, then its checked facts and host
+artifact are reused by all entry calls that depend on it.
+
+Alternative considered: scan source items in declaration order and compile each
+function when encountered. That misses out-of-order dependencies and does not
+prove the scheduling model needed by macro-host execution.
+
+### Compile Callable SCCs As Host Artifacts
+
+Non-recursive callables can be compiled in topological order. A direct or
+mutual recursive function group is a strongly connected component. If the SCC
+contains only supported compile-time callable declarations, it is compiled as
+one host artifact and invoked through a selected entry point.
+
+Alternative considered: reject every recursive call graph. That would avoid
+resource-bound complexity, but it would fail to validate the recursive helper
+shape that macro providers are expected to need.
+
+### Execute Through The JIT Boundary
+
+The validation result should flow through the same structured
+`CosmoJitRequest`/`CosmoJitResult` shape as the existing CTE probe. A pure test
+double may be used for deterministic unit tests, but the accepted integration
+path routes through `cosmo-jit-sys`.
+
+Alternative considered: add a Scala constant folder for the fixtures. That
+would validate neither the macro-host compilation boundary nor C++ execution
+through clang-repl.
+
+### Bound Recursive Execution
+
+Recursive fixture execution must have explicit bounds such as timeout,
+invocation budget, or JIT adapter limits. Exceeding the bound is a diagnostic,
+not a reason to preserve source-order execution.
+
+Alternative considered: rely on host process behavior for non-terminating
+recursion. That would make tests flaky and diagnostics unstable.
+
+## Risks / Trade-offs
+
+- Probe syntax can be mistaken for production constant evaluation -> keep the
+  mode gated and name diagnostics as validation/probe diagnostics.
+- Recursive execution can hang -> enforce adapter-level bounds and failure
+  diagnostics.
+- JIT availability is platform-sensitive -> split pure graph-planner tests from
+  toolchain-backed integration tests.
+- Graph planning can overfit to fixtures -> include out-of-source-order,
+  dependent, direct recursive, and mutual recursive cases.
+
+## Migration Plan
+
+1. Keep `probe-cosmo0-cte-with-cosmo-jit-sys` as the first JIT boundary smoke.
+2. Add the callable graph data model and deterministic planner.
+3. Add adapter-compatible CTE requests for callable artifacts and entry calls.
+4. Add dependent helper and recursive fixtures.
+5. Keep the slice gated until macro-provider execution decides which source
+   syntax and profile become production semantics.
+
+## Open Questions
+
+- Whether validation fixtures should use a temporary source marker such as
+  `@const` or be injected as harness-level compile-time callable records.
+- Which recursion bound should be enforced by the Scala-side adapter versus the
+  native `cosmo-jit-sys` layer.

--- a/openspec/changes/validate-cosmo0-cte-function-call-graph/proposal.md
+++ b/openspec/changes/validate-cosmo0-cte-function-call-graph/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The current compile-time evaluation probe proves one literal arithmetic request,
+but macro-host execution will need helper functions, dependent compile-time
+calls, and recursive call graphs. cosmo0 needs a focused validation slice that
+proves compile-time call scheduling can use a dependency graph instead of a
+source-order loop.
+
+## What Changes
+
+- Add a gated compile-time evaluation validation mode for constant function call
+  fixtures.
+- Build a compile-time callable graph from parsed declaration headers and
+  prefix-first call resolution.
+- Validate function calls whose callees depend on other constant functions,
+  including source-order-independent helper lookup.
+- Validate direct and mutual recursive constant function calls by compiling a
+  callable strongly connected component as one host artifact.
+- Route execution through the existing `cosmo-jit-sys` request/result boundary
+  or an adapter-compatible test double.
+- Report deterministic diagnostics for unresolved call heads, unsupported call
+  shapes, unavailable JIT execution, and recursion that does not finish within
+  the validation bounds.
+- Keep general constant evaluation, arbitrary type-level arithmetic, macro
+  providers, generated declarations, and production `const` semantics out of
+  scope for this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `cosmo0-cte-function-call-graph`: Defines the gated compile-time function
+  call graph validation slice, including dependent constant calls, recursive
+  callable SCCs, JIT execution, and stable diagnostics.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Depends on `probe-cosmo0-cte-with-cosmo-jit-sys` for the structured CTE/JIT
+  request boundary.
+- Adds a small planner for compile-time callable headers and call obligations.
+- Adds focused fixtures for dependent helper calls, source-order-independent
+  helper lookup, direct recursion, mutual recursion, cycle/timeout diagnostics,
+  and deterministic result ordering.
+- Does not change normal cosmo0 compile-time behavior unless the validation
+  mode is explicitly enabled.

--- a/openspec/changes/validate-cosmo0-cte-function-call-graph/specs/cosmo0-cte-function-call-graph/spec.md
+++ b/openspec/changes/validate-cosmo0-cte-function-call-graph/specs/cosmo0-cte-function-call-graph/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Gated Compile-Time Callable Graph
+
+cosmo0 SHALL provide a gated validation mode that builds a deterministic graph
+for compile-time callable fixtures without enabling production constant
+function evaluation by default.
+
+#### Scenario: Validation mode is disabled
+
+- **WHEN** normal cosmo0 checking encounters source that resembles a
+  compile-time function call fixture
+- **THEN** cosmo0 preserves the existing unsupported or ordinary checking
+  behavior
+- **AND** it does not route the source through the callable graph validation
+  mode
+
+#### Scenario: Callable headers are indexed before entries execute
+
+- **WHEN** the validation mode is enabled
+- **THEN** cosmo0 indexes compile-time callable headers before evaluating
+  selected entry calls
+- **AND** source order does not decide whether an otherwise valid helper can be
+  found
+
+### Requirement: Dependent Constant Function Calls
+
+The validation mode SHALL support constant function call entries whose result
+depends on other accepted constant functions.
+
+#### Scenario: Helper and caller are source-order independent
+
+- **WHEN** an enabled fixture defines a constant helper function and a constant
+  caller that invokes the helper in either source order
+- **THEN** cosmo0 resolves the helper call through the callable graph
+- **AND** the entry result is produced through the CTE/JIT boundary
+- **AND** the helper header, body, and host artifact are checked or compiled at
+  most once per validation plan
+
+### Requirement: Recursive Constant Function Calls
+
+The validation mode SHALL classify recursive callable groups as strongly
+connected components and SHALL execute supported groups as one host artifact.
+
+#### Scenario: Direct recursion terminates within bounds
+
+- **WHEN** an enabled fixture defines a directly recursive constant function
+  with an entry input that terminates within the configured validation bounds
+- **THEN** cosmo0 compiles the recursive callable SCC as one host artifact
+- **AND** the entry result is reported deterministically
+
+#### Scenario: Mutual recursion terminates within bounds
+
+- **WHEN** an enabled fixture defines mutually recursive constant functions
+  with an entry input that terminates within the configured validation bounds
+- **THEN** cosmo0 compiles the mutual recursion SCC as one host artifact
+- **AND** the entry result is reported deterministically
+
+#### Scenario: Recursive execution exceeds bounds
+
+- **WHEN** recursive compile-time execution exceeds the configured validation
+  bound
+- **THEN** cosmo0 reports a stable recursion-bound diagnostic
+- **AND** it does not depend on host process hangs or source-order behavior
+
+### Requirement: Callable Graph Diagnostics
+
+cosmo0 SHALL report stable diagnostics for unsupported callable graph shapes.
+
+#### Scenario: Call head is unresolved
+
+- **WHEN** a compile-time callable fixture calls a name whose leading segment
+  cannot be resolved
+- **THEN** cosmo0 reports an unresolved compile-time call diagnostic at the call
+  head span
+
+#### Scenario: Unsupported call shape is rejected
+
+- **WHEN** a compile-time callable fixture uses a call shape outside the
+  validation profile
+- **THEN** cosmo0 reports that the shape is unsupported by the callable graph
+  validation mode
+- **AND** it does not silently execute the call in a host interpreter
+
+### Requirement: Callable Execution Uses CTE Boundary
+
+Accepted callable graph entries SHALL execute through the structured
+compile-time evaluation boundary.
+
+#### Scenario: Callable artifact executes through JIT
+
+- **WHEN** an accepted callable graph entry is evaluated in integration mode
+- **THEN** cosmo0 sends a structured request containing the callable artifact,
+  entry identity, argument payloads, source identity, target settings, bounds,
+  and toolchain identity
+- **AND** `cosmo-jit-sys` or a request-compatible adapter returns a structured
+  result and diagnostics
+
+#### Scenario: Host approximation is not used
+
+- **WHEN** the validation mode computes a callable result
+- **THEN** it does not use a Scala, JavaScript, or handwritten constant-folder
+  approximation for the accepted execution path

--- a/openspec/changes/validate-cosmo0-cte-function-call-graph/tasks.md
+++ b/openspec/changes/validate-cosmo0-cte-function-call-graph/tasks.md
@@ -1,0 +1,46 @@
+## 1. Planner Model
+
+- [ ] 1.1 Add a gated compile-time callable graph model with stable callable,
+  call-site, and artifact ids.
+- [ ] 1.2 Index validation callable headers before body or entry evaluation.
+- [ ] 1.3 Resolve call heads with the prefix-first resolver and store delayed
+  call obligations for facts that are not ready.
+- [ ] 1.4 Produce deterministic graph diagnostics for unresolved heads and
+  unsupported call shapes.
+
+## 2. Dependency Scheduling
+
+- [ ] 2.1 Build call dependency edges after call obligations resolve.
+- [ ] 2.2 Topologically schedule non-recursive callable artifacts.
+- [ ] 2.3 Detect strongly connected components and classify supported direct or
+  mutual recursive callable groups.
+- [ ] 2.4 Reject unsupported callable cycles with stable diagnostics.
+
+## 3. CTE/JIT Boundary
+
+- [ ] 3.1 Extend the probe adapter shape to carry callable artifact source,
+  entry call identity, argument payloads, bounds, target settings, and toolchain
+  identity.
+- [ ] 3.2 Route accepted callable artifacts through `cosmo-jit-sys` for
+  integration execution or a request-compatible test double for pure tests.
+- [ ] 3.3 Enforce recursion execution bounds and report a stable failure
+  diagnostic when a bound is exceeded.
+
+## 4. Fixtures
+
+- [ ] 4.1 Add a dependent helper fixture where a constant function call uses a
+  helper fact produced by the callable graph.
+- [ ] 4.2 Add a source-order-independence fixture where caller and helper appear
+  in both source orders, and assert the helper is checked once per plan.
+- [ ] 4.3 Add a direct recursion fixture with a bounded terminating result.
+- [ ] 4.4 Add a mutual recursion fixture with a bounded terminating result.
+- [ ] 4.5 Add unresolved, unsupported, unavailable-JIT, failed-JIT, and
+  recursion-bound diagnostics fixtures.
+
+## 5. Validation
+
+- [ ] 5.1 Assert deterministic graph, artifact, diagnostic, and result ordering
+  across repeated runs.
+- [ ] 5.2 Verify the validation mode is disabled by default.
+- [ ] 5.3 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+  Scala sources are edited.


### PR DESCRIPTION
## Summary
- replace the old `cosmo-jit-sys` / clang-repl compile-time execution direction with a `cosmo-cte-sys` provider-entry compilation design that rejects clangInterpreter as the semantic substrate because it can diverge from ordinary Clang compilation
- add the `add-cosmo-cte-sys-pch-function-compile-poc` OpenSpec change for stable C ABI requests/results, cached PCH/precompiled contexts, cold/warm benchmarks, and single-provider-function compile/load/invoke validation
- replace the gated CTE probe with `probe-cosmo0-cte-with-cosmo-cte-sys`, routing `type x = 1 + 1` through generated provider-entry C++ instead of Scala/JavaScript/handwritten host evaluation or clangInterpreter
- refine the cosmo0 macro expression boundary around `@macro def provider(input: Expr[Untyped]): Expr[Untyped]`, with normalized single payload shapes: `Expr.Args`, `Expr.Block`, and `Expr.Template`
- document prefix-first name resolution with delayed obligations, including `ImplFact` and `MethodSetFact(receiver, selector)` so selector resolution can wait for trait and extension facts without rerunning ordinary name resolution
- add the derive macro design and OpenSpec slice: first-slice derives only attach implementations of existing traits to existing items, do not add new ordinary bindings, and feed trait-resolution / method-set facts
- add the expression macro call implementation proposal, including resolved-target classification for free, method-like, block-attached, and template macro sites
- align the derived CLI proposal with the derive boundary by modeling `@derive(cli.Parser)` as generated `cli.Parser for T` evidence used through existing trait APIs such as `cli.Parser.parse[T](args)`

## Validation
- `openspec status --change add-cosmo-cte-sys-pch-function-compile-poc`
- `openspec status --change probe-cosmo0-cte-with-cosmo-cte-sys`
- `openspec status --change implement-cosmo0-derive-macros`
- `openspec status --change implement-cosmo0-macro-calls`
- `openspec status --change introduce-cosmo0-macro-system`
- `openspec status --change add-derived-cli-library`
- `openspec status --change validate-cosmo0-cte-function-call-graph`
- `typst compile --root . docs/cosmo/book.typ /tmp/cosmo-book.pdf`
- `git diff --check`

## Notes
- These changes are documentation and OpenSpec updates only; no Scala sources were edited.
- The derive boundary intentionally separates ordinary name resolution from trait-resolution dependencies: derive output can add impl evidence, but not names.
- CTE now depends on compiling generated provider entries against cached PCH/precompiled context state, not on maintaining a clangInterpreter session.
