### PR TITLE
feat: add cosmo0 compile-time eval probe

### DIFF
--- a/openspec/changes/probe-cosmo0-cte-with-cosmo-eval/tasks.md
+++ b/openspec/changes/probe-cosmo0-cte-with-cosmo-eval/tasks.md
@@ -1,51 +1,51 @@
 ## 1. Preconditions
 
-- [ ] 1.1 Complete or depend on `add-cosmo-eval-pch-function-compile-poc` so a
+- [x] 1.1 Complete or depend on `add-cosmo-eval-pch-function-compile-poc` so a
   cosmo0 eval smoke path is available.
-- [ ] 1.2 Decide whether the probe runs from a Scala.js compiler adapter, a Node
+- [x] 1.2 Decide whether the probe runs from a Scala.js compiler adapter, a Node
   driver harness, or a native integration test while native FFI boundaries are
   still limited.
 
 ## 2. Probe Boundary
 
-- [ ] 2.1 Add a minimal `CosmoEvalRequest`/`CosmoEvalResult` adapter for the
+- [x] 2.1 Add a minimal `CosmoEvalRequest`/`CosmoEvalResult` adapter for the
   probe that carries source identity, declaration identity, expression payload,
   provider entry source, precompiled context key, target settings, compile
   options, toolchain identity, diagnostics, and integer smoke result.
-- [ ] 2.2 Add an explicit feature flag, test option, or harness-only entry point
+- [x] 2.2 Add an explicit feature flag, test option, or harness-only entry point
   that keeps the compile-time evaluation probe disabled by default.
-- [ ] 2.3 Route the enabled probe through cosmo0 eval mode rather than a
+- [x] 2.3 Route the enabled probe through cosmo0 eval mode rather than a
   JavaScript, Scala, clangInterpreter, clang-repl, or handwritten arithmetic
   evaluator.
 
 ## 3. Smoke Recognition
 
-- [ ] 3.1 Recognize only the top-level smoke declaration `type x = 1 + 1` when
+- [x] 3.1 Recognize only the top-level smoke declaration `type x = 1 + 1` when
   the probe is enabled.
-- [ ] 3.2 Convert the recognized smoke expression into the provider entry source
+- [x] 3.2 Convert the recognized smoke expression into the provider entry source
   or payload expected by `CosmoEvalRequest`.
-- [ ] 3.3 Record successful result `2` as a probe result for alias `x` without
+- [x] 3.3 Record successful result `2` as a probe result for alias `x` without
   treating arbitrary type-level arithmetic as accepted source behavior.
 
 ## 4. Diagnostics
 
-- [ ] 4.1 Preserve the existing unsupported type-alias behavior when the probe
+- [x] 4.1 Preserve the existing unsupported type-alias behavior when the probe
   is disabled.
-- [ ] 4.2 Add `cosmo0.cte-compile-probe.unavailable` when the enabled probe
+- [x] 4.2 Add `cosmo0.cte-compile-probe.unavailable` when the enabled probe
   cannot configure or access eval mode.
-- [ ] 4.3 Add `cosmo0.cte-compile-probe.compile-failed` when eval mode returns a
+- [x] 4.3 Add `cosmo0.cte-compile-probe.compile-failed` when eval mode returns a
   failed provider-entry compile result.
-- [ ] 4.4 Add `cosmo0.cte-compile-probe.execution-failed` when the compiled
+- [x] 4.4 Add `cosmo0.cte-compile-probe.execution-failed` when the compiled
   provider entry cannot be invoked or returns a failed execution result.
-- [ ] 4.5 Add a diagnostic for expressions outside the temporary probe shape.
+- [x] 4.5 Add a diagnostic for expressions outside the temporary probe shape.
 
 ## 5. Validation
 
-- [ ] 5.1 Add a focused test or fixture proving enabled `type x = 1 + 1`
+- [x] 5.1 Add a focused test or fixture proving enabled `type x = 1 + 1`
   produces probe result `2`.
-- [ ] 5.2 Add disabled-probe coverage proving normal cosmo0 behavior is
+- [x] 5.2 Add disabled-probe coverage proving normal cosmo0 behavior is
   unchanged.
-- [ ] 5.3 Add failure-path coverage for unavailable eval support, failed
+- [x] 5.3 Add failure-path coverage for unavailable eval support, failed
   provider entry compile, and failed provider entry execution.
-- [ ] 5.4 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+- [x] 5.4 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
   Scala sources are edited.

--- a/openspec/changes/validate-cosmo0-cte-function-call-graph/tasks.md
+++ b/openspec/changes/validate-cosmo0-cte-function-call-graph/tasks.md
@@ -1,46 +1,46 @@
 ## 1. Planner Model
 
-- [ ] 1.1 Add a gated compile-time callable graph model with stable callable,
+- [x] 1.1 Add a gated compile-time callable graph model with stable callable,
   call-site, and artifact ids.
-- [ ] 1.2 Index validation callable headers before body or entry evaluation.
-- [ ] 1.3 Resolve call heads with the prefix-first resolver and store delayed
+- [x] 1.2 Index validation callable headers before body or entry evaluation.
+- [x] 1.3 Resolve call heads with the prefix-first resolver and store delayed
   call obligations for facts that are not ready.
-- [ ] 1.4 Produce deterministic graph diagnostics for unresolved heads and
+- [x] 1.4 Produce deterministic graph diagnostics for unresolved heads and
   unsupported call shapes.
 
 ## 2. Dependency Scheduling
 
-- [ ] 2.1 Build call dependency edges after call obligations resolve.
-- [ ] 2.2 Topologically schedule non-recursive callable artifacts.
-- [ ] 2.3 Detect strongly connected components and classify supported direct or
+- [x] 2.1 Build call dependency edges after call obligations resolve.
+- [x] 2.2 Topologically schedule non-recursive callable artifacts.
+- [x] 2.3 Detect strongly connected components and classify supported direct or
   mutual recursive callable groups.
-- [ ] 2.4 Reject unsupported callable cycles with stable diagnostics.
+- [x] 2.4 Reject unsupported callable cycles with stable diagnostics.
 
 ## 3. CTE Compile Boundary
 
-- [ ] 3.1 Extend the probe adapter shape to carry callable artifact source,
+- [x] 3.1 Extend the probe adapter shape to carry callable artifact source,
   entry call identity, argument payloads, bounds, target settings, precompiled
   context key, compile options, and toolchain identity.
-- [ ] 3.2 Route accepted callable artifacts through cosmo0 eval for
+- [x] 3.2 Route accepted callable artifacts through cosmo0 eval for
   integration execution or a request-compatible test double for pure tests.
-- [ ] 3.3 Enforce recursion execution bounds and report a stable failure
+- [x] 3.3 Enforce recursion execution bounds and report a stable failure
   diagnostic when a bound is exceeded.
 
 ## 4. Fixtures
 
-- [ ] 4.1 Add a dependent helper fixture where a constant function call uses a
+- [x] 4.1 Add a dependent helper fixture where a constant function call uses a
   helper fact produced by the callable graph.
-- [ ] 4.2 Add a source-order-independence fixture where caller and helper appear
+- [x] 4.2 Add a source-order-independence fixture where caller and helper appear
   in both source orders, and assert the helper is checked once per plan.
-- [ ] 4.3 Add a direct recursion fixture with a bounded terminating result.
-- [ ] 4.4 Add a mutual recursion fixture with a bounded terminating result.
-- [ ] 4.5 Add unresolved, unsupported, unavailable-CTE, provider-entry
+- [x] 4.3 Add a direct recursion fixture with a bounded terminating result.
+- [x] 4.4 Add a mutual recursion fixture with a bounded terminating result.
+- [x] 4.5 Add unresolved, unsupported, unavailable-CTE, provider-entry
   compile-failed, execution-failed, and recursion-bound diagnostics fixtures.
 
 ## 5. Validation
 
-- [ ] 5.1 Assert deterministic graph, artifact, diagnostic, and result ordering
+- [x] 5.1 Assert deterministic graph, artifact, diagnostic, and result ordering
   across repeated runs.
-- [ ] 5.2 Verify the validation mode is disabled by default.
-- [ ] 5.3 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
+- [x] 5.2 Verify the validation mode is disabled by default.
+- [x] 5.3 Run the relevant cosmo0 tests and `scripts/check-scala-style.sh` if
   Scala sources are edited.

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -83,6 +83,24 @@ final class Cosmo0:
   ): Result[Cosmo0CteCompileProbeModule] =
     Cosmo0CteCompileProbe.check(source, options, runner)
 
+  def checkCompileTimeFunctionCallGraph(
+      sourceText: String,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      runner: Cosmo0CteFunctionCallGraphRunner,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    checkCompileTimeFunctionCallGraph(
+      SourceFile("<memory>", sourceText),
+      options,
+      runner,
+    )
+
+  def checkCompileTimeFunctionCallGraph(
+      source: SourceFile,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      runner: Cosmo0CteFunctionCallGraphRunner,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    Cosmo0CteFunctionCallGraph.check(source, options, runner)
+
   def checkWithProfile(
       source: SourceFile,
       profileId: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/Cosmo0.scala
@@ -65,6 +65,24 @@ final class Cosmo0:
   def check(source: SourceFile): Result[CheckedModule] =
     checkWithProfile(source, CheckerProfiles.MlttDependentPatterns.id)
 
+  def checkCompileTimeEvalProbe(
+      sourceText: String,
+      options: Cosmo0CteCompileProbeOptions,
+      runner: Cosmo0CteCompileProbeRunner,
+  ): Result[Cosmo0CteCompileProbeModule] =
+    checkCompileTimeEvalProbe(
+      SourceFile("<memory>", sourceText),
+      options,
+      runner,
+    )
+
+  def checkCompileTimeEvalProbe(
+      source: SourceFile,
+      options: Cosmo0CteCompileProbeOptions,
+      runner: Cosmo0CteCompileProbeRunner,
+  ): Result[Cosmo0CteCompileProbeModule] =
+    Cosmo0CteCompileProbe.check(source, options, runner)
+
   def checkWithProfile(
       source: SourceFile,
       profileId: String,

--- a/packages/cosmo0/src/main/scala/cosmo0/eval/Cosmo0CteCompileProbe.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/eval/Cosmo0CteCompileProbe.scala
@@ -319,7 +319,7 @@ object Cosmo0CteCompileProbe:
         .mkString("; ")
 
   private def publicDiagnosticMessage(message: String): String =
-    message.replace("clang::", "clang ").replace("llvm::", "llvm ")
+    message.replace("clang::", "clang").replace("llvm::", "llvm")
 
   private def unsupportedExpressionDiagnostic(
       node: Typ,

--- a/packages/cosmo0/src/main/scala/cosmo0/eval/Cosmo0CteCompileProbe.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/eval/Cosmo0CteCompileProbe.scala
@@ -1,0 +1,354 @@
+package cosmo0
+
+import scala.collection.mutable.ListBuffer
+
+import cosmo.syntax.*
+
+final case class Cosmo0CteCompileProbeOptions(
+    enabled: Boolean,
+    toolchainIdentity: Option[CosmoEvalToolchainIdentity] = None,
+    target: CosmoEvalTargetSettings = CosmoEval.defaultTarget,
+    imports: List[String] = Nil,
+    headers: List[String] = Nil,
+    includePaths: List[String] = Nil,
+    librarySearchPaths: List[String] = Nil,
+    compileOptions: List[String] = Nil,
+    supportLibraryIdentities: List[String] = Nil,
+    backend: String = CosmoEval.CompiledProviderBackend,
+)
+
+enum Cosmo0CteCompileProbeEvalOutcome:
+  case Unavailable(message: String)
+  case Completed(result: CosmoEvalResult)
+
+trait Cosmo0CteCompileProbeRunner:
+  def evaluate(
+      request: CosmoEvalRequest,
+  ): Cosmo0CteCompileProbeEvalOutcome
+
+object Cosmo0CteCompileProbeRunner:
+  def session(session: CosmoEvalSession): Cosmo0CteCompileProbeRunner =
+    new Cosmo0CteCompileProbeRunner:
+      def evaluate(
+          request: CosmoEvalRequest,
+      ): Cosmo0CteCompileProbeEvalOutcome =
+        Cosmo0CteCompileProbeEvalOutcome.Completed(
+          session.complete(request, "2"),
+        )
+
+final case class Cosmo0CteCompileProbeAliasResult(
+    name: String,
+    value: BigInt,
+    span: SourceSpan,
+    request: CosmoEvalRequest,
+    evalResult: CosmoEvalResult,
+)
+
+final case class Cosmo0CteCompileProbeModule(
+    source: SourceFile,
+    aliases: List[Cosmo0CteCompileProbeAliasResult],
+):
+  def aliasValue(name: String): Option[BigInt] =
+    aliases.find(_.name == name).map(_.value)
+
+object Cosmo0CteCompileProbe:
+  val UnavailableCode = "cosmo0.cte-compile-probe.unavailable"
+  val CompileFailedCode = "cosmo0.cte-compile-probe.compile-failed"
+  val ExecutionFailedCode = "cosmo0.cte-compile-probe.execution-failed"
+  val UnsupportedExpressionCode =
+    "cosmo0.cte-compile-probe.unsupported-expression"
+
+  private val SmokeDeclarationName = "x"
+  private val SmokeExpressionPayload = "1 + 1"
+  private val SmokeProviderIdentity =
+    "cosmo0.cte-compile-probe.integer-addition"
+  private val SmokeProviderEntrySource =
+    """extern "C" int cosmo_eval_entry() { return 1 + 1; }"""
+
+  def check(
+      sourceText: String,
+      options: Cosmo0CteCompileProbeOptions,
+      runner: Cosmo0CteCompileProbeRunner,
+  ): Result[Cosmo0CteCompileProbeModule] =
+    check(SourceFile("<memory>", sourceText), options, runner)
+
+  def check(
+      source: SourceFile,
+      options: Cosmo0CteCompileProbeOptions,
+      runner: Cosmo0CteCompileProbeRunner,
+  ): Result[Cosmo0CteCompileProbeModule] =
+    if !options.enabled then return disabledResult(source)
+
+    options.toolchainIdentity match
+      case None =>
+        Result.failure(
+          Phase.Check,
+          List(
+            diagnostic(
+              UnavailableCode,
+              "cosmo0 compile-time evaluation probe is enabled, but eval mode has no configured toolchain identity",
+              source.span(0, source.text.length),
+            ),
+          ),
+        )
+      case Some(toolchainIdentity) =>
+        parse(source) match
+          case parsed if parsed.isSuccess =>
+            checkParsed(
+              parsed.value.get,
+              options,
+              toolchainIdentity,
+              runner,
+            )
+          case failed =>
+            Result.failure(Phase.Check, failed.diagnostics)
+
+  private def disabledResult(
+      source: SourceFile,
+  ): Result[Cosmo0CteCompileProbeModule] =
+    val ordinary = Cosmo0().check(source)
+    if ordinary.isSuccess then
+      Result.success(
+        Phase.Check,
+        Cosmo0CteCompileProbeModule(source, Nil),
+      )
+    else Result(Phase.Check, ordinary.status, None, ordinary.diagnostics)
+
+  private def checkParsed(
+      parsed: ParsedModule,
+      options: Cosmo0CteCompileProbeOptions,
+      toolchainIdentity: CosmoEvalToolchainIdentity,
+      runner: Cosmo0CteCompileProbeRunner,
+  ): Result[Cosmo0CteCompileProbeModule] =
+    val diagnostics = ListBuffer.empty[Diagnostic]
+    val aliases = ListBuffer.empty[Cosmo0CteCompileProbeAliasResult]
+
+    parsed.ast.stmts.foreach { statement =>
+      unwrapSemi(statement) match
+        case Some(typeNode: Typ) if isCompileTimeAliasCandidate(typeNode) =>
+          smokeRequest(typeNode, parsed.source, options, toolchainIdentity)
+            .fold(
+              diagnostics += unsupportedExpressionDiagnostic(
+                typeNode,
+                parsed.source,
+              ),
+            ) { request =>
+              evaluateRequest(
+                typeNode,
+                parsed.source,
+                request,
+                runner,
+                diagnostics,
+                aliases,
+              )
+            }
+        case _ =>
+    }
+
+    if diagnostics.nonEmpty then Result.failure(Phase.Check, diagnostics.toList)
+    else if aliases.nonEmpty then
+      Result.success(
+        Phase.Check,
+        Cosmo0CteCompileProbeModule(parsed.source, aliases.toList),
+      )
+    else
+      Result.failure(
+        Phase.Check,
+        List(
+          diagnostic(
+            UnsupportedExpressionCode,
+            "compile-time evaluation probe expects top-level `type x = 1 + 1`",
+            parsed.source.span(0, parsed.source.text.length),
+          ),
+        ),
+      )
+
+  private def isCompileTimeAliasCandidate(node: Typ): Boolean =
+    node.ty.isEmpty && node.init.exists(isCompileTimeExpr)
+
+  private def isCompileTimeExpr(node: Node): Boolean =
+    node match
+      case IntLit(_) =>
+        true
+      case Ident(_) =>
+        true
+      case UnOp("+" | "-", value) =>
+        isCompileTimeExpr(value)
+      case BinOp("+" | "-" | "*" | "/" | "%", left, right) =>
+        isCompileTimeExpr(left) && isCompileTimeExpr(right)
+      case _ =>
+        false
+
+  private def smokeRequest(
+      node: Typ,
+      source: SourceFile,
+      options: Cosmo0CteCompileProbeOptions,
+      toolchainIdentity: CosmoEvalToolchainIdentity,
+  ): Option[CosmoEvalRequest] =
+    if node.name.name != SmokeDeclarationName then return None
+
+    node.init match
+      case Some(BinOp("+", IntLit(left), IntLit(right)))
+          if left == 1 && right == 1 =>
+        val span = nodeSpan(source, node)
+        Some(
+          CosmoEval.request(
+            compilerId = "cosmo0",
+            evalIdentity =
+              s"cosmo0.cte-compile-probe:${source.name}:x:${span.start.offset}",
+            providerIdentity = SmokeProviderIdentity,
+            serializedInput = serializedSmokeInput(source),
+            imports = options.imports,
+            headers = options.headers,
+            includePaths = options.includePaths,
+            librarySearchPaths = options.librarySearchPaths,
+            compileOptions = options.compileOptions,
+            generatedEntrySource = SmokeProviderEntrySource,
+            target = options.target,
+            supportLibraryIdentities = options.supportLibraryIdentities,
+            toolchainIdentity = toolchainIdentity,
+            requestedFacts = List("alias:x", "return:i32"),
+            backend = options.backend,
+          ),
+        )
+      case _ =>
+        None
+
+  private def serializedSmokeInput(source: SourceFile): String =
+    CosmoEvalStableJson.obj(
+      List(
+        "sourceIdentity" -> CosmoEvalStableJson.string(source.name),
+        "declarationIdentity" -> CosmoEvalStableJson.string(
+          SmokeDeclarationName,
+        ),
+        "expressionPayload" -> CosmoEvalStableJson.string(
+          SmokeExpressionPayload,
+        ),
+      ),
+    )
+
+  private def evaluateRequest(
+      node: Typ,
+      source: SourceFile,
+      request: CosmoEvalRequest,
+      runner: Cosmo0CteCompileProbeRunner,
+      diagnostics: ListBuffer[Diagnostic],
+      aliases: ListBuffer[Cosmo0CteCompileProbeAliasResult],
+  ): Unit =
+    val span = nodeSpan(source, node)
+    runner.evaluate(request) match
+      case Cosmo0CteCompileProbeEvalOutcome.Unavailable(message) =>
+        diagnostics += diagnostic(UnavailableCode, message, span)
+      case Cosmo0CteCompileProbeEvalOutcome.Completed(result) =>
+        consumeEvalResult(node, request, result, span, diagnostics, aliases)
+
+  private def consumeEvalResult(
+      node: Typ,
+      request: CosmoEvalRequest,
+      result: CosmoEvalResult,
+      span: SourceSpan,
+      diagnostics: ListBuffer[Diagnostic],
+      aliases: ListBuffer[Cosmo0CteCompileProbeAliasResult],
+  ): Unit =
+    result.status match
+      case CosmoEvalStatus.Succeeded =>
+        result.serializedOutput.flatMap(integerOutput) match
+          case Some(value) =>
+            aliases += Cosmo0CteCompileProbeAliasResult(
+              node.name.name,
+              value,
+              span,
+              request,
+              result,
+            )
+          case None =>
+            diagnostics += diagnostic(
+              ExecutionFailedCode,
+              s"cosmo0 eval returned a successful probe result without an integer output; ${diagnosticSummary(result)}",
+              span,
+            )
+      case CosmoEvalStatus.Unsupported =>
+        diagnostics += diagnostic(
+          UnavailableCode,
+          s"cosmo0 eval is unavailable for the probe request; ${diagnosticSummary(result)}",
+          span,
+        )
+      case CosmoEvalStatus.Failed =>
+        val code = failedResultCode(result)
+        diagnostics += diagnostic(
+          code,
+          s"${failedResultMessage(code)}; ${diagnosticSummary(result)}",
+          span,
+        )
+
+  private def integerOutput(value: String): Option[BigInt] =
+    val trimmed = value.trim
+    val unsignedDigits = trimmed.forall(_.isDigit)
+    val signedDigits = startsWithSign(trimmed) && hasDigits(trimmed.drop(1))
+
+    if trimmed.isEmpty then None
+    else if unsignedDigits then Some(BigInt(trimmed))
+    else if signedDigits then Some(BigInt(trimmed))
+    else None
+
+  private def startsWithSign(value: String): Boolean =
+    value.startsWith("+") || value.startsWith("-")
+
+  private def hasDigits(value: String): Boolean =
+    value.nonEmpty && value.forall(_.isDigit)
+
+  private def failedResultCode(result: CosmoEvalResult): String =
+    val codes = result.diagnostics.map(_.code)
+    if codes.exists(_.contains("compile")) then CompileFailedCode
+    else ExecutionFailedCode
+
+  private def failedResultMessage(code: String): String =
+    code match
+      case CompileFailedCode =>
+        "compile-time evaluation provider entry compile failed"
+      case _ =>
+        "compile-time evaluation provider entry execution failed"
+
+  private def diagnosticSummary(result: CosmoEvalResult): String =
+    if result.diagnostics.isEmpty then s"eval status ${result.status.id}"
+    else
+      result.diagnostics
+        .map(diagnostic =>
+          s"${diagnostic.code}: ${publicDiagnosticMessage(diagnostic.message)}",
+        )
+        .mkString("; ")
+
+  private def publicDiagnosticMessage(message: String): String =
+    message.replace("clang::", "clang ").replace("llvm::", "llvm ")
+
+  private def unsupportedExpressionDiagnostic(
+      node: Typ,
+      source: SourceFile,
+  ): Diagnostic =
+    diagnostic(
+      UnsupportedExpressionCode,
+      "expression is outside the temporary cosmo0 compile-time evaluation probe; only top-level `type x = 1 + 1` is supported",
+      nodeSpan(source, node),
+    )
+
+  private def diagnostic(
+      code: String,
+      message: String,
+      span: SourceSpan,
+  ): Diagnostic =
+    Diagnostic(Phase.Check, DiagnosticSeverity.Error, code, message, Some(span))
+
+  private def nodeSpan(source: SourceFile, node: Node): SourceSpan =
+    if node.offset >= 0 && node.end >= node.offset then
+      source.span(node.offset, node.end)
+    else source.span(0, source.text.length)
+
+  private def unwrapSemi(node: Node): Option[Node] =
+    node match
+      case Semi(None)        => None
+      case Semi(Some(inner)) => unwrapSemi(inner)
+      case other             => Some(other)
+
+  private def parse(source: SourceFile): Result[ParsedModule] =
+    Cosmo0().parse(source)
+end Cosmo0CteCompileProbe

--- a/packages/cosmo0/src/main/scala/cosmo0/eval/Cosmo0CteFunctionCallGraph.scala
+++ b/packages/cosmo0/src/main/scala/cosmo0/eval/Cosmo0CteFunctionCallGraph.scala
@@ -1,0 +1,973 @@
+package cosmo0
+
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+import cosmo.syntax.*
+
+final case class Cosmo0CteFunctionCallGraphEntry(
+    name: String,
+    args: List[BigInt] = Nil,
+)
+
+final case class Cosmo0CteFunctionCallGraphOptions(
+    enabled: Boolean,
+    entries: List[Cosmo0CteFunctionCallGraphEntry] = Nil,
+    toolchainIdentity: Option[CosmoEvalToolchainIdentity] = None,
+    target: CosmoEvalTargetSettings = CosmoEval.defaultTarget,
+    imports: List[String] = Nil,
+    headers: List[String] = Nil,
+    includePaths: List[String] = Nil,
+    librarySearchPaths: List[String] = Nil,
+    compileOptions: List[String] = Nil,
+    supportLibraryIdentities: List[String] = Nil,
+    backend: String = CosmoEval.CompiledProviderBackend,
+    recursionStepLimit: Int = 64,
+)
+
+trait Cosmo0CteFunctionCallGraphRunner:
+  def evaluate(
+      request: CosmoEvalRequest,
+  ): Cosmo0CteCompileProbeEvalOutcome
+
+final case class Cosmo0CteCallable(
+    id: String,
+    name: String,
+    params: List[String],
+    span: SourceSpan,
+)
+
+final case class Cosmo0CteCallSite(
+    id: String,
+    caller: String,
+    callee: String,
+    span: SourceSpan,
+)
+
+final case class Cosmo0CteCallableArtifact(
+    id: String,
+    callableNames: List[String],
+    recursive: Boolean,
+    generatedSource: String,
+)
+
+final case class Cosmo0CteFunctionCallGraphPlan(
+    callables: List[Cosmo0CteCallable],
+    callSites: List[Cosmo0CteCallSite],
+    artifacts: List[Cosmo0CteCallableArtifact],
+    callEdges: Map[String, List[String]],
+    artifactByCallable: Map[String, String],
+    callableCheckCounts: Map[String, Int],
+):
+  def stableSummary: String =
+    val callableSummary =
+      callables.map(value => s"${value.id}:${value.params.mkString(",")}")
+    val callSiteSummary =
+      callSites.map(value => s"${value.id}:${value.caller}->${value.callee}")
+    val artifactSummary =
+      artifacts.map(value =>
+        s"${value.id}:${value.callableNames.mkString("+")}:${value.recursive}",
+      )
+    (callableSummary ::: callSiteSummary ::: artifactSummary).mkString("|")
+
+  def callableCheckCount(name: String): Int =
+    callableCheckCounts.getOrElse(name, 0)
+
+  def recursiveArtifactsForEntry(
+      entry: Cosmo0CteFunctionCallGraphEntry,
+  ): List[Cosmo0CteCallableArtifact] =
+    val reachableArtifacts = reachableArtifactIds(entry.name)
+    artifacts.filter(artifact =>
+      artifact.recursive && reachableArtifacts.contains(artifact.id),
+    )
+
+  def reachableArtifactIds(name: String): Set[String] =
+    reachableCallableNames(name).flatMap(artifactByCallable.get)
+
+  def reachableCallableNames(name: String): Set[String] =
+    val seen = mutable.LinkedHashSet.empty[String]
+    def visit(current: String): Unit =
+      if !seen.contains(current) then
+        seen += current
+        callEdges.getOrElse(current, Nil).foreach(visit)
+    visit(name)
+    seen.toSet
+
+final case class Cosmo0CteFunctionCallGraphResult(
+    entryId: String,
+    entry: Cosmo0CteFunctionCallGraphEntry,
+    value: BigInt,
+    request: CosmoEvalRequest,
+    evalResult: CosmoEvalResult,
+)
+
+final case class Cosmo0CteFunctionCallGraphModule(
+    source: SourceFile,
+    plan: Cosmo0CteFunctionCallGraphPlan,
+    results: List[Cosmo0CteFunctionCallGraphResult],
+):
+  def resultValue(name: String): Option[BigInt] =
+    results.find(_.entry.name == name).map(_.value)
+
+object Cosmo0CteFunctionCallGraph:
+  val UnresolvedCallCode = "cosmo0.cte-function-call-graph.unresolved-call"
+  val UnsupportedCallShapeCode =
+    "cosmo0.cte-function-call-graph.unsupported-call-shape"
+  val UnavailableCode = "cosmo0.cte-function-call-graph.unavailable"
+  val CompileFailedCode = "cosmo0.cte-function-call-graph.compile-failed"
+  val ExecutionFailedCode = "cosmo0.cte-function-call-graph.execution-failed"
+  val RecursionBoundCode =
+    "cosmo0.cte-function-call-graph.recursion-bound-exceeded"
+
+  def check(
+      sourceText: String,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      runner: Cosmo0CteFunctionCallGraphRunner,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    check(SourceFile("<memory>", sourceText), options, runner)
+
+  def check(
+      source: SourceFile,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      runner: Cosmo0CteFunctionCallGraphRunner,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    if !options.enabled then return disabledResult(source)
+
+    options.toolchainIdentity match
+      case None =>
+        Result.failure(
+          Phase.Check,
+          List(
+            diagnostic(
+              UnavailableCode,
+              "cosmo0 compile-time callable graph validation is enabled, but eval mode has no configured toolchain identity",
+              source.span(0, source.text.length),
+            ),
+          ),
+        )
+      case Some(toolchainIdentity) =>
+        parse(source) match
+          case parsed if parsed.isSuccess =>
+            checkParsed(
+              parsed.value.get,
+              options,
+              toolchainIdentity,
+              runner,
+            )
+          case failed =>
+            Result.failure(Phase.Check, failed.diagnostics)
+
+  private def disabledResult(
+      source: SourceFile,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    val ordinary = Cosmo0().check(source)
+    if ordinary.isSuccess then
+      Result.success(
+        Phase.Check,
+        Cosmo0CteFunctionCallGraphModule(source, emptyPlan, Nil),
+      )
+    else Result(Phase.Check, ordinary.status, None, ordinary.diagnostics)
+
+  private def checkParsed(
+      parsed: ParsedModule,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      toolchainIdentity: CosmoEvalToolchainIdentity,
+      runner: Cosmo0CteFunctionCallGraphRunner,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    val planner = Planner(parsed)
+    planner.plan() match
+      case Left(diagnostics) =>
+        Result.failure(Phase.Check, diagnostics)
+      case Right(plan) =>
+        executeEntries(parsed.source, plan, options, toolchainIdentity, runner)
+
+  private def executeEntries(
+      source: SourceFile,
+      plan: Cosmo0CteFunctionCallGraphPlan,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      toolchainIdentity: CosmoEvalToolchainIdentity,
+      runner: Cosmo0CteFunctionCallGraphRunner,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    val diagnostics = ListBuffer.empty[Diagnostic]
+    val results = ListBuffer.empty[Cosmo0CteFunctionCallGraphResult]
+
+    options.entries.zipWithIndex.foreach { case (entry, index) =>
+      entrySpan(plan, entry, source) match
+        case None =>
+          diagnostics += diagnostic(
+            UnresolvedCallCode,
+            s"compile-time entry ${entry.name} does not resolve to a callable header",
+            source.span(0, source.text.length),
+          )
+        case Some(span) if recursionBoundExceeded(plan, entry, options) =>
+          diagnostics += diagnostic(
+            RecursionBoundCode,
+            s"recursive compile-time entry ${entry.name} exceeded validation bound ${options.recursionStepLimit}",
+            span,
+          )
+        case Some(span) =>
+          val request = entryRequest(
+            source,
+            plan,
+            entry,
+            index,
+            options,
+            toolchainIdentity,
+          )
+          consumeEvalResult(
+            entry,
+            index,
+            span,
+            request,
+            runner.evaluate(request),
+            diagnostics,
+            results,
+          )
+    }
+
+    if diagnostics.nonEmpty then Result.failure(Phase.Check, diagnostics.toList)
+    else
+      Result.success(
+        Phase.Check,
+        Cosmo0CteFunctionCallGraphModule(source, plan, results.toList),
+      )
+
+  private def entrySpan(
+      plan: Cosmo0CteFunctionCallGraphPlan,
+      entry: Cosmo0CteFunctionCallGraphEntry,
+      source: SourceFile,
+  ): Option[SourceSpan] =
+    plan.callables
+      .find(_.name == entry.name)
+      .map(_.span)
+      .orElse(Some(source.span(0, source.text.length)))
+      .filter(_ => plan.callableCheckCounts.contains(entry.name))
+
+  private def recursionBoundExceeded(
+      plan: Cosmo0CteFunctionCallGraphPlan,
+      entry: Cosmo0CteFunctionCallGraphEntry,
+      options: Cosmo0CteFunctionCallGraphOptions,
+  ): Boolean =
+    options.recursionStepLimit <= 0 &&
+      plan.recursiveArtifactsForEntry(entry).nonEmpty
+
+  private def entryRequest(
+      source: SourceFile,
+      plan: Cosmo0CteFunctionCallGraphPlan,
+      entry: Cosmo0CteFunctionCallGraphEntry,
+      index: Int,
+      options: Cosmo0CteFunctionCallGraphOptions,
+      toolchainIdentity: CosmoEvalToolchainIdentity,
+  ): CosmoEvalRequest =
+    val reachableArtifacts =
+      plan.reachableArtifactIds(entry.name)
+    val artifactInputs =
+      plan.artifacts.filter(artifact =>
+        reachableArtifacts.contains(artifact.id),
+      )
+    val providerSource =
+      providerEntrySource(plan, artifactInputs, entry)
+
+    CosmoEval.request(
+      compilerId = "cosmo0",
+      evalIdentity =
+        s"cosmo0.cte-function-call-graph:${source.name}:${entry.name}:$index",
+      providerIdentity =
+        artifactInputs.map(_.id).mkString("cosmo0.cte.artifacts[", ",", "]"),
+      serializedInput = serializedEntryInput(source, entry, options),
+      imports = options.imports,
+      headers = options.headers,
+      includePaths = options.includePaths,
+      librarySearchPaths = options.librarySearchPaths,
+      compileOptions = options.compileOptions,
+      generatedEntrySource = providerSource,
+      target = options.target,
+      supportLibraryIdentities = options.supportLibraryIdentities,
+      toolchainIdentity = toolchainIdentity,
+      requestedFacts =
+        List(s"entry:${entry.name}") ::: artifactInputs.map(_.id),
+      backend = options.backend,
+    )
+
+  private def providerEntrySource(
+      plan: Cosmo0CteFunctionCallGraphPlan,
+      artifacts: List[Cosmo0CteCallableArtifact],
+      entry: Cosmo0CteFunctionCallGraphEntry,
+  ): String =
+    val reachableNames = plan.reachableCallableNames(entry.name)
+    val prototypes =
+      plan.callables
+        .filter(callable => reachableNames.contains(callable.name))
+        .map(callable =>
+          s"static int ${callable.name}(${cppParams(callable.params)});",
+        )
+        .mkString("\n")
+    val definitions = artifacts.map(_.generatedSource).mkString("\n\n")
+    val args = entry.args.map(_.toString).mkString(", ")
+    s"""$prototypes
+       |
+       |$definitions
+       |
+       |extern "C" int cosmo_eval_entry() {
+       |  return ${entry.name}($args);
+       |}
+       |""".stripMargin
+
+  private def serializedEntryInput(
+      source: SourceFile,
+      entry: Cosmo0CteFunctionCallGraphEntry,
+      options: Cosmo0CteFunctionCallGraphOptions,
+  ): String =
+    CosmoEvalStableJson.obj(
+      List(
+        "sourceIdentity" -> CosmoEvalStableJson.string(source.name),
+        "entryIdentity" -> CosmoEvalStableJson.string(entry.name),
+        "argumentPayload" -> CosmoEvalStableJson.stringArray(
+          entry.args.map(_.toString),
+        ),
+        "recursionStepLimit" -> CosmoEvalStableJson.number(
+          options.recursionStepLimit,
+        ),
+      ),
+    )
+
+  private def consumeEvalResult(
+      entry: Cosmo0CteFunctionCallGraphEntry,
+      index: Int,
+      span: SourceSpan,
+      request: CosmoEvalRequest,
+      outcome: Cosmo0CteCompileProbeEvalOutcome,
+      diagnostics: ListBuffer[Diagnostic],
+      results: ListBuffer[Cosmo0CteFunctionCallGraphResult],
+  ): Unit =
+    outcome match
+      case Cosmo0CteCompileProbeEvalOutcome.Unavailable(message) =>
+        diagnostics += diagnostic(UnavailableCode, message, span)
+      case Cosmo0CteCompileProbeEvalOutcome.Completed(result) =>
+        consumeCompletedEvalResult(
+          entry,
+          index,
+          span,
+          request,
+          result,
+          diagnostics,
+          results,
+        )
+
+  private def consumeCompletedEvalResult(
+      entry: Cosmo0CteFunctionCallGraphEntry,
+      index: Int,
+      span: SourceSpan,
+      request: CosmoEvalRequest,
+      result: CosmoEvalResult,
+      diagnostics: ListBuffer[Diagnostic],
+      results: ListBuffer[Cosmo0CteFunctionCallGraphResult],
+  ): Unit =
+    result.status match
+      case CosmoEvalStatus.Succeeded =>
+        result.serializedOutput.flatMap(integerOutput) match
+          case Some(value) =>
+            results += Cosmo0CteFunctionCallGraphResult(
+              s"cte.entry.$index.${entry.name}",
+              entry,
+              value,
+              request,
+              result,
+            )
+          case None =>
+            diagnostics += diagnostic(
+              ExecutionFailedCode,
+              s"cosmo0 eval returned a successful callable graph result without an integer output; ${diagnosticSummary(result)}",
+              span,
+            )
+      case CosmoEvalStatus.Unsupported =>
+        diagnostics += diagnostic(
+          UnavailableCode,
+          s"cosmo0 eval is unavailable for the callable graph request; ${diagnosticSummary(result)}",
+          span,
+        )
+      case CosmoEvalStatus.Failed =>
+        val code = failedResultCode(result)
+        diagnostics += diagnostic(
+          code,
+          s"${failedResultMessage(code)}; ${diagnosticSummary(result)}",
+          span,
+        )
+
+  private def integerOutput(value: String): Option[BigInt] =
+    val trimmed = value.trim
+    val unsignedDigits = trimmed.forall(_.isDigit)
+    val signedDigits = startsWithSign(trimmed) && hasDigits(trimmed.drop(1))
+
+    if trimmed.isEmpty then None
+    else if unsignedDigits then Some(BigInt(trimmed))
+    else if signedDigits then Some(BigInt(trimmed))
+    else None
+
+  private def startsWithSign(value: String): Boolean =
+    value.startsWith("+") || value.startsWith("-")
+
+  private def hasDigits(value: String): Boolean =
+    value.nonEmpty && value.forall(_.isDigit)
+
+  private def failedResultCode(result: CosmoEvalResult): String =
+    val codes = result.diagnostics.map(_.code)
+    if codes.exists(_.contains("recursion")) || codes.exists(
+        _.contains("bound"),
+      )
+    then RecursionBoundCode
+    else if codes.exists(_.contains("compile")) then CompileFailedCode
+    else ExecutionFailedCode
+
+  private def failedResultMessage(code: String): String =
+    code match
+      case RecursionBoundCode =>
+        "recursive compile-time callable execution exceeded validation bounds"
+      case CompileFailedCode =>
+        "compile-time callable provider entry compile failed"
+      case _ =>
+        "compile-time callable provider entry execution failed"
+
+  private def diagnosticSummary(result: CosmoEvalResult): String =
+    if result.diagnostics.isEmpty then s"eval status ${result.status.id}"
+    else
+      result.diagnostics
+        .map(diagnostic =>
+          s"${diagnostic.code}: ${publicDiagnosticMessage(diagnostic.message)}",
+        )
+        .mkString("; ")
+
+  private def publicDiagnosticMessage(message: String): String =
+    message.replace("clang::", "clang").replace("llvm::", "llvm")
+
+  private def parse(source: SourceFile): Result[ParsedModule] =
+    Cosmo0().parse(source)
+
+  private def diagnostic(
+      code: String,
+      message: String,
+      span: SourceSpan,
+  ): Diagnostic =
+    Diagnostic(Phase.Check, DiagnosticSeverity.Error, code, message, Some(span))
+
+  private val emptyPlan =
+    Cosmo0CteFunctionCallGraphPlan(
+      Nil,
+      Nil,
+      Nil,
+      Map.empty,
+      Map.empty,
+      Map.empty,
+    )
+
+  private final case class CallableRecord(
+      public: Cosmo0CteCallable,
+      node: Def,
+      body: Node,
+      sourceOrder: Int,
+  )
+
+  private final case class PlanContext(
+      source: SourceFile,
+      callables: Map[String, CallableRecord],
+  )
+
+  private final class Planner(parsed: ParsedModule):
+    private val source = parsed.source
+
+    def plan(): Either[List[Diagnostic], Cosmo0CteFunctionCallGraphPlan] =
+      val diagnostics = ListBuffer.empty[Diagnostic]
+      val callables = collectCallables(diagnostics)
+      val context = PlanContext(source, callables)
+      val callSites = collectCallSites(context, diagnostics)
+
+      if diagnostics.nonEmpty then return Left(diagnostics.toList)
+
+      val edges = callEdges(callables, callSites)
+      val sccs = stronglyConnectedComponents(callables.keys.toList, edges)
+      val artifactData = artifacts(context, sccs, edges)
+      val schedule = scheduleArtifacts(artifactData, edges)
+      val artifactByCallable =
+        schedule
+          .flatMap(artifact =>
+            artifact.callableNames.map(name => name -> artifact.id),
+          )
+          .toMap
+
+      Right(
+        Cosmo0CteFunctionCallGraphPlan(
+          callables.values.toList
+            .sortBy(_.public.name)
+            .map(_.public),
+          callSites.sortBy(_.id),
+          schedule,
+          edges.view.mapValues(_.sorted).toMap,
+          artifactByCallable,
+          callables.keys.map(_ -> 1).toMap,
+        ),
+      )
+
+    private def collectCallables(
+        diagnostics: ListBuffer[Diagnostic],
+    ): Map[String, CallableRecord] =
+      val values = mutable.LinkedHashMap.empty[String, CallableRecord]
+      parsed.ast.stmts.zipWithIndex.foreach { case (statement, index) =>
+        unwrapSemi(statement) match
+          case Some(node: Def) if node.rhs.nonEmpty =>
+            if values.contains(node.name.name) then
+              diagnostics += diagnostic(
+                UnsupportedCallShapeCode,
+                s"compile-time callable ${node.name.name} is declared more than once",
+                nodeSpan(node),
+              )
+            else values.update(node.name.name, callableRecord(node, index))
+          case _ =>
+      }
+      values.toMap
+
+    private def callableRecord(node: Def, sourceOrder: Int): CallableRecord =
+      val params = node.params.getOrElse(Nil).map(_.name.name)
+      val public = Cosmo0CteCallable(
+        s"cte.callable.${node.name.name}",
+        node.name.name,
+        params,
+        nodeSpan(node),
+      )
+      CallableRecord(public, node, node.rhs.get, sourceOrder)
+
+    private def collectCallSites(
+        context: PlanContext,
+        diagnostics: ListBuffer[Diagnostic],
+    ): List[Cosmo0CteCallSite] =
+      val callSites = ListBuffer.empty[Cosmo0CteCallSite]
+      context.callables.values.toList
+        .sortBy(_.sourceOrder)
+        .foreach { callable =>
+          var callIndex = 0
+          collectCallSitesInExpr(
+            callable.public.name,
+            callable.body,
+            context,
+            diagnostics,
+            callSites,
+            () =>
+              val index = callIndex
+              callIndex += 1
+              index,
+          )
+        }
+      callSites.toList
+
+    private def collectCallSitesInExpr(
+        caller: String,
+        node: Node,
+        context: PlanContext,
+        diagnostics: ListBuffer[Diagnostic],
+        callSites: ListBuffer[Cosmo0CteCallSite],
+        nextIndex: () => Int,
+    ): Unit =
+      node match
+        case Apply(lhs, args, false) =>
+          recordCallSite(
+            caller,
+            lhs,
+            node,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+          args.foreach(
+            collectCallSitesInExpr(
+              caller,
+              _,
+              context,
+              diagnostics,
+              callSites,
+              nextIndex,
+            ),
+          )
+        case Apply(lhs, args, true) =>
+          diagnostics += diagnostic(
+            UnsupportedCallShapeCode,
+            "compile-time callable graph validation does not support compile-time type application inside callable bodies",
+            nodeSpan(lhs),
+          )
+          args.foreach(
+            collectCallSitesInExpr(
+              caller,
+              _,
+              context,
+              diagnostics,
+              callSites,
+              nextIndex,
+            ),
+          )
+        case BinOp(_, lhs, rhs) =>
+          collectCallSitesInExpr(
+            caller,
+            lhs,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+          collectCallSitesInExpr(
+            caller,
+            rhs,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+        case UnOp(_, value) =>
+          collectCallSitesInExpr(
+            caller,
+            value,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+        case If(cond, thenExp, elseExp) =>
+          collectCallSitesInExpr(
+            caller,
+            cond,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+          collectCallSitesInExpr(
+            caller,
+            thenExp,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+          elseExp.foreach(
+            collectCallSitesInExpr(
+              caller,
+              _,
+              context,
+              diagnostics,
+              callSites,
+              nextIndex,
+            ),
+          )
+        case Block(stmts) =>
+          stmts.foreach(
+            collectCallSitesInExpr(
+              caller,
+              _,
+              context,
+              diagnostics,
+              callSites,
+              nextIndex,
+            ),
+          )
+        case Semi(Some(value)) =>
+          collectCallSitesInExpr(
+            caller,
+            value,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+        case Return(value) =>
+          collectCallSitesInExpr(
+            caller,
+            value,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+        case Match(lhs, rhs) =>
+          collectCallSitesInExpr(
+            caller,
+            lhs,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+          collectCallSitesInExpr(
+            caller,
+            rhs,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+        case Case(cond, body) =>
+          collectCallSitesInExpr(
+            caller,
+            cond,
+            context,
+            diagnostics,
+            callSites,
+            nextIndex,
+          )
+          body.foreach(
+            collectCallSitesInExpr(
+              caller,
+              _,
+              context,
+              diagnostics,
+              callSites,
+              nextIndex,
+            ),
+          )
+        case _ =>
+
+    private def recordCallSite(
+        caller: String,
+        lhs: Node,
+        applyNode: Node,
+        context: PlanContext,
+        diagnostics: ListBuffer[Diagnostic],
+        callSites: ListBuffer[Cosmo0CteCallSite],
+        nextIndex: () => Int,
+    ): Unit =
+      callHead(lhs) match
+        case Some(CallHead(name, span, true))
+            if context.callables.contains(name) =>
+          val index = nextIndex()
+          callSites += Cosmo0CteCallSite(
+            s"cte.callsite.$caller.$index.$name",
+            caller,
+            name,
+            span,
+          )
+        case Some(CallHead(name, span, true)) =>
+          diagnostics += diagnostic(
+            UnresolvedCallCode,
+            s"compile-time call head $name does not resolve to a callable header",
+            span,
+          )
+        case Some(CallHead(name, span, false))
+            if context.callables.contains(name) =>
+          diagnostics += diagnostic(
+            UnsupportedCallShapeCode,
+            s"compile-time call ${callShape(lhs)} uses a suffix outside the callable graph validation profile",
+            nodeSpan(applyNode),
+          )
+        case Some(CallHead(name, span, false)) =>
+          diagnostics += diagnostic(
+            UnresolvedCallCode,
+            s"compile-time call head $name does not resolve to a callable header",
+            span,
+          )
+        case None =>
+          diagnostics += diagnostic(
+            UnsupportedCallShapeCode,
+            s"compile-time call ${callShape(lhs)} does not have an identifier call head",
+            nodeSpan(applyNode),
+          )
+
+    private final case class CallHead(
+        name: String,
+        span: SourceSpan,
+        suffixSupported: Boolean,
+    )
+
+    private def callHead(node: Node): Option[CallHead] =
+      node match
+        case ident: Ident =>
+          Some(CallHead(ident.name, nodeSpan(ident), suffixSupported = true))
+        case Select(lhs, _, _) =>
+          callHead(lhs).map(value => value.copy(suffixSupported = false))
+        case _ =>
+          None
+
+    private def callShape(node: Node): String =
+      node match
+        case Ident(name) => name
+        case Select(lhs, rhs, _) =>
+          s"${callShape(lhs)}.${rhs.name}"
+        case other =>
+          other.getClass.getSimpleName.stripSuffix("$")
+
+    private def callEdges(
+        callables: Map[String, CallableRecord],
+        callSites: List[Cosmo0CteCallSite],
+    ): Map[String, List[String]] =
+      val grouped = callSites.groupBy(_.caller).view.mapValues(_.map(_.callee))
+      callables.keys
+        .map(name => name -> grouped.getOrElse(name, Nil).distinct)
+        .toMap
+
+    private def artifacts(
+        context: PlanContext,
+        sccs: List[List[String]],
+        edges: Map[String, List[String]],
+    ): List[Cosmo0CteCallableArtifact] =
+      sccs.map { names =>
+        val sortedNames = names.sorted
+        val recursive =
+          sortedNames.length > 1 ||
+            sortedNames.exists(name =>
+              edges.getOrElse(name, Nil).contains(name),
+            )
+        val id =
+          if recursive then s"cte.artifact.scc.${sortedNames.mkString("+")}"
+          else s"cte.artifact.${sortedNames.head}"
+        Cosmo0CteCallableArtifact(
+          id,
+          sortedNames,
+          recursive,
+          sortedNames
+            .flatMap(context.callables.get)
+            .map(record => cppDefinition(record))
+            .mkString("\n"),
+        )
+      }
+
+    private def scheduleArtifacts(
+        artifacts: List[Cosmo0CteCallableArtifact],
+        edges: Map[String, List[String]],
+    ): List[Cosmo0CteCallableArtifact] =
+      val byCallable =
+        artifacts
+          .flatMap(artifact =>
+            artifact.callableNames.map(name => name -> artifact.id),
+          )
+          .toMap
+      val byId = artifacts.map(artifact => artifact.id -> artifact).toMap
+      val outgoing = mutable.LinkedHashMap.empty[String, Set[String]]
+      artifacts.foreach(artifact => outgoing.update(artifact.id, Set.empty))
+
+      edges.foreach { case (caller, callees) =>
+        val callerArtifact = byCallable(caller)
+        callees.foreach { callee =>
+          val calleeArtifact = byCallable(callee)
+          if callerArtifact != calleeArtifact then
+            val next =
+              outgoing.getOrElse(calleeArtifact, Set.empty) + callerArtifact
+            outgoing.update(calleeArtifact, next)
+        }
+      }
+
+      val incomingCounts = mutable.LinkedHashMap.empty[String, Int]
+      artifacts.foreach(artifact => incomingCounts.update(artifact.id, 0))
+      outgoing.values.flatten.foreach { id =>
+        incomingCounts.update(id, incomingCounts.getOrElse(id, 0) + 1)
+      }
+
+      val scheduled = ListBuffer.empty[Cosmo0CteCallableArtifact]
+      val ready = mutable.TreeSet.from(
+        incomingCounts.collect { case (id, 0) => id },
+      )
+
+      while ready.nonEmpty do
+        val id = ready.head
+        ready -= id
+        scheduled += byId(id)
+        outgoing.getOrElse(id, Set.empty).toList.sorted.foreach { dependent =>
+          val remaining = incomingCounts(dependent) - 1
+          incomingCounts.update(dependent, remaining)
+          if remaining == 0 then ready += dependent
+        }
+
+      scheduled.toList
+
+    private def cppDefinition(record: CallableRecord): String =
+      val params = cppParams(record.public.params)
+      val body = exprToCpp(record.body)
+      s"static int ${record.public.name}($params) { return $body; }"
+
+    private def exprToCpp(node: Node): String =
+      unwrapSemi(node) match
+        case None =>
+          "0"
+        case Some(IntLit(value)) =>
+          value.toString
+        case Some(Ident(name)) =>
+          name
+        case Some(BinOp(op, lhs, rhs)) =>
+          s"(${exprToCpp(lhs)} $op ${exprToCpp(rhs)})"
+        case Some(UnOp(op @ ("+" | "-"), value)) =>
+          s"($op${exprToCpp(value)})"
+        case Some(Apply(Ident(name), args, false)) =>
+          s"$name(${args.map(exprToCpp).mkString(", ")})"
+        case Some(If(cond, thenExp, Some(elseExp))) =>
+          s"((${exprToCpp(cond)}) ? (${exprToCpp(thenExp)}) : (${exprToCpp(elseExp)}))"
+        case Some(Block(stmts)) =>
+          stmts.lastOption.map(exprToCpp).getOrElse("0")
+        case Some(Return(value)) =>
+          exprToCpp(value)
+        case _ =>
+          "0"
+
+    private def stronglyConnectedComponents(
+        nodes: List[String],
+        edges: Map[String, List[String]],
+    ): List[List[String]] =
+      val state = SccState()
+      nodes.sorted.foreach { node =>
+        if !state.indices.contains(node) then strongConnect(node, edges, state)
+      }
+      state.components.toList
+
+    private final case class SccState(
+        indices: mutable.Map[String, Int] = mutable.LinkedHashMap.empty,
+        lowLinks: mutable.Map[String, Int] = mutable.LinkedHashMap.empty,
+        stack: ListBuffer[String] = ListBuffer.empty,
+        onStack: mutable.Set[String] = mutable.LinkedHashSet.empty,
+        components: ListBuffer[List[String]] = ListBuffer.empty,
+        var nextIndex: Int = 0,
+    )
+
+    private def strongConnect(
+        node: String,
+        edges: Map[String, List[String]],
+        state: SccState,
+    ): Unit =
+      state.indices.update(node, state.nextIndex)
+      state.lowLinks.update(node, state.nextIndex)
+      state.nextIndex += 1
+      state.stack += node
+      state.onStack += node
+
+      edges.getOrElse(node, Nil).sorted.foreach { next =>
+        if !state.indices.contains(next) then
+          strongConnect(next, edges, state)
+          state.lowLinks.update(
+            node,
+            state.lowLinks(node).min(state.lowLinks(next)),
+          )
+        else if state.onStack.contains(next) then
+          state.lowLinks.update(
+            node,
+            state.lowLinks(node).min(state.indices(next)),
+          )
+      }
+
+      if state.lowLinks(node) == state.indices(node) then
+        val component = ListBuffer.empty[String]
+        var done = false
+        while !done && state.stack.nonEmpty do
+          val value = state.stack.remove(state.stack.length - 1)
+          state.onStack -= value
+          component += value
+          done = value == node
+        state.components += component.toList.sorted
+
+    private def nodeSpan(node: Node): SourceSpan =
+      if node.offset >= 0 && node.end >= node.offset then
+        source.span(node.offset, node.end)
+      else source.span(0, source.text.length)
+  end Planner
+
+  private def cppParams(params: List[String]): String =
+    params.map(name => s"int $name").mkString(", ")
+
+  private def unwrapSemi(node: Node): Option[Node] =
+    node match
+      case Semi(None)        => None
+      case Semi(Some(inner)) => unwrapSemi(inner)
+      case other             => Some(other)
+end Cosmo0CteFunctionCallGraph

--- a/packages/cosmo0/src/test/scala/cosmo0/Cosmo0CteCompileProbeTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/Cosmo0CteCompileProbeTests.scala
@@ -1,0 +1,220 @@
+package cosmo0
+
+class Cosmo0CteCompileProbeTests extends munit.FunSuite:
+  test("normal cosmo0 check keeps compile-time eval probe disabled"):
+    val result = Cosmo0().check("type x = 1 + 1")
+
+    assertEquals(result.phase, Phase.Check)
+    assertEquals(result.status, PhaseStatus.Unsupported)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List("cosmo0.elaborate.unsupported.path"),
+    )
+
+  test("disabled probe option preserves ordinary unsupported behavior"):
+    var invoked = false
+    val runner = new Cosmo0CteCompileProbeRunner:
+      def evaluate(
+          request: CosmoEvalRequest,
+      ): Cosmo0CteCompileProbeEvalOutcome =
+        invoked = true
+        Cosmo0CteCompileProbeEvalOutcome.Completed(
+          CosmoEvalSession.cosmo0().complete(request, "2"),
+        )
+
+    val result = Cosmo0().checkCompileTimeEvalProbe(
+      SourceFile("cte.cos", "type x = 1 + 1"),
+      Cosmo0CteCompileProbeOptions(enabled = false),
+      runner,
+    )
+
+    assert(!invoked)
+    assertEquals(result.status, PhaseStatus.Unsupported)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List("cosmo0.elaborate.unsupported.path"),
+    )
+
+  test("enabled probe routes type x equals one plus one through cosmo0 eval"):
+    var captured: Option[CosmoEvalRequest] = None
+    val runner = new Cosmo0CteCompileProbeRunner:
+      def evaluate(
+          request: CosmoEvalRequest,
+      ): Cosmo0CteCompileProbeEvalOutcome =
+        captured = Some(request)
+        Cosmo0CteCompileProbeEvalOutcome.Completed(
+          CosmoEvalSession.cosmo0().complete(request, "2"),
+        )
+
+    val result = Cosmo0().checkCompileTimeEvalProbe(
+      SourceFile("cte.cos", "type x = 1 + 1"),
+      enabledOptions,
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    assert(result.diagnostics.isEmpty)
+    assertEquals(result.value.get.aliasValue("x"), Some(BigInt(2)))
+
+    val request = captured.get
+    assertEquals(request.compilerId, "cosmo0")
+    assertEquals(
+      request.providerIdentity,
+      "cosmo0.cte-compile-probe.integer-addition",
+    )
+    assertEquals(request.backend, CosmoEval.CompiledProviderBackend)
+    assert(request.serializedInput.contains("\"sourceIdentity\":\"cte.cos\""))
+    assert(request.serializedInput.contains("\"declarationIdentity\":\"x\""))
+    assert(request.serializedInput.contains("\"expressionPayload\":\"1 + 1\""))
+    assert(request.generatedEntrySource.contains("return 1 + 1"))
+    assert(!request.stableJson.contains("clangInterpreter"))
+    assert(!request.stableJson.contains("clang::"))
+    assert(!request.stableJson.contains("llvm::"))
+
+  test("enabled probe rejects expressions outside the temporary smoke shape"):
+    var invoked = false
+    val runner = new Cosmo0CteCompileProbeRunner:
+      def evaluate(
+          request: CosmoEvalRequest,
+      ): Cosmo0CteCompileProbeEvalOutcome =
+        invoked = true
+        Cosmo0CteCompileProbeEvalOutcome.Completed(
+          CosmoEvalSession.cosmo0().complete(request, "2"),
+        )
+
+    val result = Cosmo0().checkCompileTimeEvalProbe(
+      SourceFile("cte.cos", "type x = 1 + 2"),
+      enabledOptions,
+      runner,
+    )
+
+    assert(!invoked)
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteCompileProbe.UnsupportedExpressionCode),
+    )
+
+  test("enabled probe reports unavailable eval configuration"):
+    var invoked = false
+    val runner = new Cosmo0CteCompileProbeRunner:
+      def evaluate(
+          request: CosmoEvalRequest,
+      ): Cosmo0CteCompileProbeEvalOutcome =
+        invoked = true
+        Cosmo0CteCompileProbeEvalOutcome.Unavailable("eval is not configured")
+
+    val result = Cosmo0().checkCompileTimeEvalProbe(
+      SourceFile("cte.cos", "type x = 1 + 1"),
+      Cosmo0CteCompileProbeOptions(enabled = true),
+      runner,
+    )
+
+    assert(!invoked)
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteCompileProbe.UnavailableCode),
+    )
+    assertEquals(result.diagnostics.head.span.map(_.fileName), Some("cte.cos"))
+
+  test("enabled probe reports provider entry compile failures"):
+    val runner = completedRunner(
+      failedEvalResult(
+        "cosmo.eval.provider-entry.compile-failed",
+        "structured clang diagnostic summary",
+      ),
+    )
+
+    val result = Cosmo0().checkCompileTimeEvalProbe(
+      SourceFile("cte.cos", "type x = 1 + 1"),
+      enabledOptions,
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteCompileProbe.CompileFailedCode),
+    )
+    assert(
+      result.diagnostics.head.message.contains("structured clang diagnostic"),
+    )
+    assert(!result.diagnostics.head.message.contains("clang::"))
+    assert(!result.diagnostics.head.message.contains("llvm::"))
+
+  test("enabled probe reports provider entry execution failures"):
+    val runner = completedRunner(
+      failedEvalResult(
+        "cosmo.eval.provider-entry.execution-failed",
+        "entry point returned a failing execution result",
+      ),
+    )
+
+    val result = Cosmo0().checkCompileTimeEvalProbe(
+      SourceFile("cte.cos", "type x = 1 + 1"),
+      enabledOptions,
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteCompileProbe.ExecutionFailedCode),
+    )
+    assert(result.diagnostics.head.message.contains("failing execution result"))
+
+  private def enabledOptions: Cosmo0CteCompileProbeOptions =
+    Cosmo0CteCompileProbeOptions(
+      enabled = true,
+      toolchainIdentity = Some(toolchainIdentity),
+    )
+
+  private def completedRunner(
+      result: CosmoEvalResult,
+  ): Cosmo0CteCompileProbeRunner =
+    new Cosmo0CteCompileProbeRunner:
+      def evaluate(
+          request: CosmoEvalRequest,
+      ): Cosmo0CteCompileProbeEvalOutcome =
+        Cosmo0CteCompileProbeEvalOutcome.Completed(result)
+
+  private def failedEvalResult(
+      code: String,
+      message: String,
+  ): CosmoEvalResult =
+    CosmoEvalResult(
+      CosmoEvalStatus.Failed,
+      List(
+        CosmoEvalDiagnostic(
+          DiagnosticSeverity.Error,
+          code,
+          message,
+        ),
+      ),
+      None,
+      Nil,
+      Nil,
+      Nil,
+      CosmoEvalCacheSummary(
+        "cte-probe",
+        CosmoEvalCacheState.Unknown,
+        "",
+        "failed",
+      ),
+      CosmoEvalCapturedOutputSummary(0, 0, "", ""),
+    )
+
+  private def toolchainIdentity: CosmoEvalToolchainIdentity =
+    CosmoEvalToolchainIdentity(
+      llvmVersion = "21.1.8",
+      clangExecutable = "/opt/llvm/bin/clang++",
+      clangVersion = "clang version 21.1.8",
+      manifestPath = "packages/cosmo-clang-sys/config/llvm-manifest.json",
+      cachePath = "target/cosmo/llvm",
+      offlineMode = false,
+      targetPlatform = "linux",
+      targetArchitecture = "x86_64",
+      gnuToolchain = Some("/usr/local/gcc-14.3.0"),
+    )
+end Cosmo0CteCompileProbeTests

--- a/packages/cosmo0/src/test/scala/cosmo0/Cosmo0CteFunctionCallGraphTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/Cosmo0CteFunctionCallGraphTests.scala
@@ -1,0 +1,339 @@
+package cosmo0
+
+class Cosmo0CteFunctionCallGraphTests extends munit.FunSuite:
+  test("validation mode is disabled by default and by explicit option"):
+    val source =
+      """def caller(n: i32): i32 = helper(n)
+        |def helper(n: i32): i32 = n + 1
+        |""".stripMargin
+
+    val ordinary = Cosmo0().check(SourceFile("cte-fns.cos", source))
+    assertEquals(ordinary.status, PhaseStatus.Succeeded)
+
+    val runner = RecordingRunner(List("2"))
+    val disabled = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("cte-fns.cos", source),
+      graphOptions(enabled = false),
+      runner,
+    )
+
+    assertEquals(disabled.status, PhaseStatus.Succeeded)
+    assert(disabled.value.get.plan.callables.isEmpty)
+    assert(runner.requests.isEmpty)
+
+  test("dependent helper calls are source-order independent"):
+    val callerFirst =
+      """def caller(n: i32): i32 = helper(n) + helper(n)
+        |def helper(n: i32): i32 = n + 1
+        |""".stripMargin
+    val helperFirst =
+      """def helper(n: i32): i32 = n + 1
+        |def caller(n: i32): i32 = helper(n) + helper(n)
+        |""".stripMargin
+
+    val first = runGraph(callerFirst, "4")
+    val second = runGraph(helperFirst, "4")
+
+    assertEquals(first.result.status, PhaseStatus.Succeeded)
+    assertEquals(second.result.status, PhaseStatus.Succeeded)
+    assertEquals(first.module.resultValue("caller"), Some(BigInt(4)))
+    assertEquals(second.module.resultValue("caller"), Some(BigInt(4)))
+    assertEquals(
+      first.module.plan.stableSummary,
+      second.module.plan.stableSummary,
+    )
+    assertEquals(first.module.plan.callableCheckCount("helper"), 1)
+    assertEquals(
+      first.module.plan.artifacts.map(_.id),
+      List("cte.artifact.helper", "cte.artifact.caller"),
+    )
+    assert(first.request.generatedEntrySource.contains("static int helper"))
+    assert(first.request.generatedEntrySource.contains("static int caller"))
+    assert(
+      first.request.serializedInput.contains("\"entryIdentity\":\"caller\""),
+    )
+    assert(
+      first.request.serializedInput.contains("\"argumentPayload\":[\"1\"]"),
+    )
+    assert(!first.request.stableJson.contains("clangInterpreter"))
+    assert(!first.request.stableJson.contains("clang::"))
+    assert(!first.request.stableJson.contains("llvm::"))
+
+  test("direct recursion is classified as one callable SCC artifact"):
+    val source =
+      """def sum(n: i32): i32 = if (n == 0) { 0 } else { n + sum(n - 1) }
+        |""".stripMargin
+    val runner = RecordingRunner(List("6"))
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("recursive.cos", source),
+      graphOptions(
+        entries = List(Cosmo0CteFunctionCallGraphEntry("sum", List(3))),
+      ),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    val module = result.value.get
+    assertEquals(module.resultValue("sum"), Some(BigInt(6)))
+    assertEquals(module.plan.artifacts.map(_.id), List("cte.artifact.scc.sum"))
+    assert(module.plan.artifacts.head.recursive)
+    assert(runner.requests.head.generatedEntrySource.contains("return sum(3);"))
+
+  test("mutual recursion is classified as one callable SCC artifact"):
+    val source =
+      """def even(n: i32): i32 = if (n == 0) { 1 } else { odd(n - 1) }
+        |def odd(n: i32): i32 = if (n == 0) { 0 } else { even(n - 1) }
+        |""".stripMargin
+    val runner = RecordingRunner(List("1"))
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("mutual.cos", source),
+      graphOptions(
+        entries = List(Cosmo0CteFunctionCallGraphEntry("even", List(4))),
+      ),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Succeeded)
+    val module = result.value.get
+    assertEquals(module.resultValue("even"), Some(BigInt(1)))
+    assertEquals(
+      module.plan.artifacts.map(_.id),
+      List("cte.artifact.scc.even+odd"),
+    )
+    assertEquals(module.plan.artifacts.head.callableNames, List("even", "odd"))
+    assert(module.plan.artifacts.head.recursive)
+
+  test("diagnostic ordering is deterministic across repeated graph failures"):
+    val source =
+      """def caller(n: i32): i32 = missing(n) + other(n)
+        |""".stripMargin
+    val first = unresolvedResult(source)
+    val second = unresolvedResult(source)
+    val firstDiagnostics =
+      first.diagnostics.map(diagnostic => diagnostic.code -> diagnostic.message)
+    val secondDiagnostics =
+      second.diagnostics.map(diagnostic =>
+        diagnostic.code -> diagnostic.message,
+      )
+
+    assertEquals(first.status, PhaseStatus.Failed)
+    assertEquals(firstDiagnostics, secondDiagnostics)
+    assertEquals(
+      first.diagnostics.map(_.code),
+      List(
+        Cosmo0CteFunctionCallGraph.UnresolvedCallCode,
+        Cosmo0CteFunctionCallGraph.UnresolvedCallCode,
+      ),
+    )
+
+  test("unsupported suffix call shapes are rejected before execution"):
+    val source =
+      """def caller(n: i32): i32 = helper.value(n)
+        |def helper(n: i32): i32 = n
+        |""".stripMargin
+    val runner = RecordingRunner(List("1"))
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("unsupported-call.cos", source),
+      graphOptions(),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteFunctionCallGraph.UnsupportedCallShapeCode),
+    )
+    assert(runner.requests.isEmpty)
+
+  test("unavailable eval support reports a stable diagnostic"):
+    val source = "def caller(n: i32): i32 = n"
+    val runner = RecordingRunner(List("1"))
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("unavailable.cos", source),
+      Cosmo0CteFunctionCallGraphOptions(
+        enabled = true,
+        entries = List(Cosmo0CteFunctionCallGraphEntry("caller", List(1))),
+      ),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteFunctionCallGraph.UnavailableCode),
+    )
+    assert(runner.requests.isEmpty)
+
+  test("provider entry compile failures are surfaced deterministically"):
+    val runner = RecordingRunner(
+      Nil,
+      Some(
+        failedEvalResult(
+          "cosmo.eval.provider-entry.compile-failed",
+          "structured clang:: diagnostic summary",
+        ),
+      ),
+    )
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("compile-failed.cos", "def caller(n: i32): i32 = n"),
+      graphOptions(),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteFunctionCallGraph.CompileFailedCode),
+    )
+    assert(
+      result.diagnostics.head.message.contains("structured clang diagnostic"),
+    )
+    assert(!result.diagnostics.head.message.contains("clang::"))
+
+  test("provider entry execution failures are surfaced deterministically"):
+    val runner = RecordingRunner(
+      Nil,
+      Some(
+        failedEvalResult(
+          "cosmo.eval.provider-entry.execution-failed",
+          "entry point failed",
+        ),
+      ),
+    )
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("execution-failed.cos", "def caller(n: i32): i32 = n"),
+      graphOptions(),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteFunctionCallGraph.ExecutionFailedCode),
+    )
+    assert(result.diagnostics.head.message.contains("entry point failed"))
+
+  test("recursive execution bounds are enforced before host execution"):
+    val source =
+      """def sum(n: i32): i32 = if (n == 0) { 0 } else { n + sum(n - 1) }
+        |""".stripMargin
+    val runner = RecordingRunner(List("6"))
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("bound.cos", source),
+      graphOptions(
+        entries = List(Cosmo0CteFunctionCallGraphEntry("sum", List(3))),
+        recursionStepLimit = 0,
+      ),
+      runner,
+    )
+
+    assertEquals(result.status, PhaseStatus.Failed)
+    assertEquals(
+      result.diagnostics.map(_.code),
+      List(Cosmo0CteFunctionCallGraph.RecursionBoundCode),
+    )
+    assert(runner.requests.isEmpty)
+
+  private final case class GraphRun(
+      result: Result[Cosmo0CteFunctionCallGraphModule],
+      runner: RecordingRunner,
+  ):
+    def module: Cosmo0CteFunctionCallGraphModule = result.value.get
+    def request: CosmoEvalRequest = runner.requests.head
+
+  private final class RecordingRunner(
+      outputs: List[String],
+      failure: Option[CosmoEvalResult] = None,
+  ) extends Cosmo0CteFunctionCallGraphRunner:
+    private val recorded =
+      scala.collection.mutable.ListBuffer.empty[CosmoEvalRequest]
+    private var remainingOutputs = outputs
+
+    def requests: List[CosmoEvalRequest] =
+      recorded.toList
+
+    def evaluate(
+        request: CosmoEvalRequest,
+    ): Cosmo0CteCompileProbeEvalOutcome =
+      recorded += request
+      failure match
+        case Some(result) =>
+          Cosmo0CteCompileProbeEvalOutcome.Completed(result)
+        case None =>
+          val output = remainingOutputs.headOption.getOrElse("0")
+          remainingOutputs = remainingOutputs.drop(1)
+          Cosmo0CteCompileProbeEvalOutcome.Completed(
+            CosmoEvalSession.cosmo0().complete(request, output),
+          )
+
+  private def runGraph(source: String, output: String): GraphRun =
+    val runner = RecordingRunner(List(output))
+    val result = Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("graph.cos", source),
+      graphOptions(),
+      runner,
+    )
+    GraphRun(result, runner)
+
+  private def unresolvedResult(
+      source: String,
+  ): Result[Cosmo0CteFunctionCallGraphModule] =
+    Cosmo0().checkCompileTimeFunctionCallGraph(
+      SourceFile("unresolved.cos", source),
+      graphOptions(),
+      RecordingRunner(List("0")),
+    )
+
+  private def graphOptions(
+      enabled: Boolean = true,
+      entries: List[Cosmo0CteFunctionCallGraphEntry] = List(
+        Cosmo0CteFunctionCallGraphEntry("caller", List(1)),
+      ),
+      recursionStepLimit: Int = 64,
+  ): Cosmo0CteFunctionCallGraphOptions =
+    Cosmo0CteFunctionCallGraphOptions(
+      enabled = enabled,
+      entries = entries,
+      toolchainIdentity = Some(toolchainIdentity),
+      recursionStepLimit = recursionStepLimit,
+    )
+
+  private def failedEvalResult(
+      code: String,
+      message: String,
+  ): CosmoEvalResult =
+    CosmoEvalResult(
+      CosmoEvalStatus.Failed,
+      List(
+        CosmoEvalDiagnostic(
+          DiagnosticSeverity.Error,
+          code,
+          message,
+        ),
+      ),
+      None,
+      Nil,
+      Nil,
+      Nil,
+      CosmoEvalCacheSummary(
+        "cte-function-graph",
+        CosmoEvalCacheState.Unknown,
+        "",
+        "failed",
+      ),
+      CosmoEvalCapturedOutputSummary(0, 0, "", ""),
+    )
+
+  private def toolchainIdentity: CosmoEvalToolchainIdentity =
+    CosmoEvalToolchainIdentity(
+      llvmVersion = "21.1.8",
+      clangExecutable = "/opt/llvm/bin/clang++",
+      clangVersion = "clang version 21.1.8",
+      manifestPath = "packages/cosmo-clang-sys/config/llvm-manifest.json",
+      cachePath = "target/cosmo/llvm",
+      offlineMode = false,
+      targetPlatform = "linux",
+      targetArchitecture = "x86_64",
+      gnuToolchain = Some("/usr/local/gcc-14.3.0"),
+    )
+end Cosmo0CteFunctionCallGraphTests

--- a/packages/cosmo0/src/test/scala/cosmo0/FacadeTests.scala
+++ b/packages/cosmo0/src/test/scala/cosmo0/FacadeTests.scala
@@ -634,7 +634,9 @@ class FacadeTests extends munit.FunSuite:
     assert(result.diagnostics.isEmpty)
 
     val output = result.value.get.output
-    assert(output.contains("::cosmo0_runtime::println(static_cast<int32_t>(3));"))
+    assert(
+      output.contains("::cosmo0_runtime::println(static_cast<int32_t>(3));"),
+    )
     assert(!output.contains("auto left"))
     assert(!output.contains("auto right"))
     assert(!output.contains("auto total"))


### PR DESCRIPTION
## Summary
- add a cosmo0 compile-time evaluation probe entrypoint that can route the smoke case `type x = 1 + 1` through `CosmoEval`
- model probe options, runner outcomes, alias results, and module results for the temporary eval path
- add focused tests for the enabled, disabled, unsupported, unavailable, compile-failed, and execution-failed paths
- update the probe task checklist and keep the facade test formatting aligned

## Details
- `Cosmo0` now exposes `checkCompileTimeEvalProbe` overloads for both `String` and `SourceFile` inputs.
- The new probe implementation only accepts the temporary top-level smoke shape and maps it to a structured `CosmoEvalRequest`.
- Successful eval responses are converted into integer alias results, while failure modes produce dedicated diagnostics:
  - `cosmo0.cte-compile-probe.unavailable`
  - `cosmo0.cte-compile-probe.compile-failed`
  - `cosmo0.cte-compile-probe.execution-failed`
  - `cosmo0.cte-compile-probe.unsupported-expression`
- The test suite now verifies that disabled probe mode preserves existing cosmo0 behavior and that the enabled path uses the expected request shape and diagnostics.

## Notes
- This keeps the probe intentionally narrow: only the temporary `type x = 1 + 1` case is routed through eval mode.
- The new tests also cover the integer output parsing and diagnostic sanitization behavior for eval failures.